### PR TITLE
Add a decorator to mark views deprecated

### DIFF
--- a/dmutils/deprecation.py
+++ b/dmutils/deprecation.py
@@ -1,0 +1,28 @@
+from functools import wraps
+from datetime import datetime, timedelta
+
+from flask import current_app
+
+
+def deprecated(dies_at):
+    """Mark a flask view as deprecated
+
+    Usage:
+    @deprecated(dies_at=datetime(2015, 8, 1))
+    """
+    def decorator(view):
+        @wraps(view)
+        def func(*args, **kwargs):
+            message = "Calling deprecated view '%s'. Dies in %s."
+            time_left = dies_at - datetime.now()
+            if time_left < timedelta(days=7):
+                current_app.logger.error(message, view.__name__, time_left)
+            else:
+                current_app.logger.warning(message, view.__name__, time_left)
+            response = view(*args, **kwargs)
+            response.headers['DM-Deprecated'] = "Dies in {}".format(time_left)
+            return response
+
+        return func
+
+    return decorator


### PR DESCRIPTION
We have discussed writing our APIs quickly to meet a deadline with the
understanding that they will almost certainly change. Move fast and
break things. In response to that this decorator allows us to easily
mark and track the use of views as we evolve the system.

TODO:
- [ ] Add tests