### PR TITLE
Import ConnectionError into apiclient namespace

### DIFF
--- a/dmutils/apiclient.py
+++ b/dmutils/apiclient.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
-import requests
 import logging
+
+import requests
+from requests import ConnectionError  # noqa
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
This allows clients to import the exception from dmutils.apiclient and
not rely on the assumption that apiclient is using requests package.