### PR TITLE
Supplier a to z

### DIFF
--- a/dmutils/apiclient.py
+++ b/dmutils/apiclient.py
@@ -139,6 +139,28 @@ class DataAPIClient(BaseAPIClient):
         self.base_url = app.config['DM_DATA_API_URL']
         self.auth_token = app.config['DM_DATA_API_AUTH_TOKEN']
 
+    def get_suppliers(self, prefix=None):
+        params = None
+        if prefix:
+            params = {
+                "prefix": prefix
+            }
+        return self._get(
+            "{}/suppliers".format(self.base_url),
+            params
+        )
+
+    def get_supplier_by_id(self, supplier_id):
+        return self._get(
+            "{}/suppliers/{}".format(self.base_url, supplier_id)
+        )
+
+    def get_services_by_supplier_id(self, supplier_id):
+        return self._get(
+            "{}/services".format(self.base_url),
+            {"supplier_id": supplier_id}
+        )
+
     def get_service(self, service_id):
         return self._get(
             "{}/services/{}".format(self.base_url, service_id))['services']

--- a/dmutils/apiclient.py
+++ b/dmutils/apiclient.py
@@ -161,6 +161,21 @@ class DataAPIClient(BaseAPIClient):
                 "services": service,
             })
 
+    def get_user(self, user_id=None, email_address=None):
+        if user_id is not None and email_address is not None:
+            raise ValueError(
+                "Cannot get user by both user_id and email_address")
+        elif user_id is not None:
+            url = "{}/users/{}".format(self.base_url, user_id)
+            params = {}
+        elif email_address is not None:
+            url = "{}/users".format(self.base_url)
+            params = {"email": email_address}
+        else:
+            raise ValueError("Either user_id or email_address must be set")
+
+        return self._get(url, params=params)['users']
+
     def authenticate_user(self, email_address, password, supplier=True):
         try:
             response = self._post(
@@ -177,3 +192,17 @@ class DataAPIClient(BaseAPIClient):
             if e.response.status_code not in [400, 403, 404]:
                 raise
         return None
+
+    def update_user_password(self, user_id, new_password):
+        try:
+            self._post(
+                '{}/users/{}'.format(self.base_url, user_id),
+                data={"users": {"password": new_password}}
+            )
+
+            logger.info("Updated password for user %s", user_id)
+            return True
+        except APIError as e:
+            logger.info("Password update failed for user %s: %s",
+                        user_id, e.response.status_code)
+            return False

--- a/dmutils/apiclient.py
+++ b/dmutils/apiclient.py
@@ -20,7 +20,7 @@ class APIError(requests.HTTPError):
     def response_message(self):
         try:
             return self.response.json()['error']
-        except TypeError:
+        except (TypeError, KeyError):
             return str(self.response.content)
 
 
@@ -55,7 +55,11 @@ class BaseAPIClient(object):
 
             return response.json()
         except requests.HTTPError as e:
-            raise APIError(e)
+            e = APIError(e)
+            logger.warning(
+                "API %s request on %s failed with %s '%s'",
+                method, url, e.response.status_code, e.response_message)
+            raise e
         except requests.RequestException as e:
             logger.exception(e.message)
             raise

--- a/dmutils/apiclient.py
+++ b/dmutils/apiclient.py
@@ -160,3 +160,20 @@ class DataAPIClient(BaseAPIClient):
                 },
                 "services": service,
             })
+
+    def authenticate_user(self, email_address, password, supplier=True):
+        try:
+            response = self._post(
+                '{}/users/auth'.format(self.base_url),
+                data={
+                    "auth_users": {
+                        "email_address": email_address,
+                        "password": password,
+                    }
+                })
+            if not supplier or "supplier" in response['users']:
+                return response['users']
+        except APIError as e:
+            if e.response.status_code not in [400, 403, 404]:
+                raise
+        return None

--- a/dmutils/apiclient.py
+++ b/dmutils/apiclient.py
@@ -139,7 +139,7 @@ class DataAPIClient(BaseAPIClient):
         self.base_url = app.config['DM_DATA_API_URL']
         self.auth_token = app.config['DM_DATA_API_AUTH_TOKEN']
 
-    def get_suppliers(self, prefix=None):
+    def find_suppliers(self, prefix=None):
         params = None
         if prefix:
             params = {
@@ -150,15 +150,9 @@ class DataAPIClient(BaseAPIClient):
             params
         )
 
-    def get_supplier_by_id(self, supplier_id):
+    def get_supplier(self, supplier_id):
         return self._get(
             "{}/suppliers/{}".format(self.base_url, supplier_id)
-        )
-
-    def get_services_by_supplier_id(self, supplier_id):
-        return self._get(
-            "{}/services".format(self.base_url),
-            {"supplier_id": supplier_id}
         )
 
     def get_service(self, service_id):
@@ -174,7 +168,7 @@ class DataAPIClient(BaseAPIClient):
 
         return self._get(
             self.base_url + "/services",
-            params=params)['services']
+            params=params)
 
     def update_service(self, service_id, service, user, reason):
         return self._post(

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -268,7 +268,7 @@ class TestDataApiClient(object):
 
         result = data_client.find_service()
 
-        assert result == "result"
+        assert result == {"services": "result"}
         assert rmock.called
 
     def test_find_service_adds_page_parameter(self, data_client, rmock):
@@ -279,7 +279,7 @@ class TestDataApiClient(object):
 
         result = data_client.find_service(page=2)
 
-        assert result == "result"
+        assert result == {"services": "result"}
         assert rmock.called
 
     def test_find_service_adds_supplier_id_parameter(self, data_client, rmock):
@@ -290,7 +290,7 @@ class TestDataApiClient(object):
 
         result = data_client.find_service(supplier_id=1)
 
-        assert result == "result"
+        assert result == {"services": "result"}
         assert rmock.called
 
     def test_update_service(self, data_client, rmock):
@@ -454,18 +454,18 @@ class TestDataApiClient(object):
             json={"services": "result"},
             status_code=200)
 
-        result = data_client.get_suppliers()
+        result = data_client.find_suppliers()
 
         assert result == {"services": "result"}
         assert rmock.called
 
-    def test_get_suppliers_with_prefix(self, data_client, rmock):
+    def test_find_suppliers_with_prefix(self, data_client, rmock):
         rmock.get(
             "http://baseurl/suppliers?prefix=a",
             json={"services": "result"},
             status_code=200)
 
-        result = data_client.get_suppliers(prefix='a')
+        result = data_client.find_suppliers(prefix='a')
 
         assert result == {"services": "result"}
         assert rmock.called
@@ -476,7 +476,7 @@ class TestDataApiClient(object):
             json={"services": "result"},
             status_code=200)
 
-        result = data_client.get_supplier_by_id(123)
+        result = data_client.get_supplier(123)
 
         assert result == {"services": "result"}
         assert rmock.called
@@ -487,7 +487,7 @@ class TestDataApiClient(object):
             json={"services": "result"},
             status_code=200)
 
-        result = data_client.get_services_by_supplier_id(123)
+        result = data_client.find_service(supplier_id=123)
 
         assert result == {"services": "result"}
         assert rmock.called

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
-from flask import json
-from datetime import datetime
 
+from flask import json
 import requests_mock
 import pytest
 import mock
@@ -341,7 +340,7 @@ class TestDataApiClient(object):
             self, data_client, rmock):
         rmock.post(
             "http://baseurl/users/auth",
-            text=json.dumps(self.user()),
+            json=self.user(),
             status_code=200)
 
         user = data_client.authenticate_user(

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -447,3 +447,47 @@ class TestDataApiClient(object):
                 'name': 'name'
             }
         }}
+
+    def test_get_suppliers_with_no_prefix(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/suppliers",
+            json={"services": "result"},
+            status_code=200)
+
+        result = data_client.get_suppliers()
+
+        assert result == "result"
+        assert rmock.called
+
+    def test_get_suppliers_with_prefix(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/suppliers?prefix=a",
+            json={"services": "result"},
+            status_code=200)
+
+        result = data_client.get_suppliers(prefix='a')
+
+        assert result == "result"
+        assert rmock.called
+
+    def test_get_supplier_by_id(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/suppliers/123",
+            json={"services": "result"},
+            status_code=200)
+
+        result = data_client.get_supplier_by_id(123)
+
+        assert result == "result"
+        assert rmock.called
+
+    def test_get_services_by_supplier(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/services?supplier_id=123",
+            json={"services": "result"},
+            status_code=200)
+
+        result = data_client.get_services_by_supplier_id(123)
+
+        assert result == "result"
+        assert rmock.called

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -456,7 +456,7 @@ class TestDataApiClient(object):
 
         result = data_client.get_suppliers()
 
-        assert result == "result"
+        assert result == {"services": "result"}
         assert rmock.called
 
     def test_get_suppliers_with_prefix(self, data_client, rmock):
@@ -467,7 +467,7 @@ class TestDataApiClient(object):
 
         result = data_client.get_suppliers(prefix='a')
 
-        assert result == "result"
+        assert result == {"services": "result"}
         assert rmock.called
 
     def test_get_supplier_by_id(self, data_client, rmock):
@@ -478,7 +478,7 @@ class TestDataApiClient(object):
 
         result = data_client.get_supplier_by_id(123)
 
-        assert result == "result"
+        assert result == {"services": "result"}
         assert rmock.called
 
     def test_get_services_by_supplier(self, data_client, rmock):
@@ -489,5 +489,5 @@ class TestDataApiClient(object):
 
         result = data_client.get_services_by_supplier_id(123)
 
-        assert result == "result"
+        assert result == {"services": "result"}
         assert rmock.called


### PR DESCRIPTION
This adds methods to allow querying by supplier in the same style as for services. The response signature is slightly different to other methods in that it returns the whole response. This is the correct approach otherwise pagination isn't available. I'll change the other methods in a separate pull request.

This has been rebased on https://github.com/alphagov/digitalmarketplace-utils/pull/17