### PR TITLE
Better error handling in `get_status` method

### DIFF
--- a/dmutils/apiclient.py
+++ b/dmutils/apiclient.py
@@ -3,7 +3,6 @@ import logging
 
 import six
 import requests
-from requests import ConnectionError  # noqa
 
 
 logger = logging.getLogger(__name__)
@@ -64,13 +63,14 @@ class BaseAPIClient(object):
         try:
             return self._get(
                 "{}/_status".format(self.base_url))
-        except APIError as e:
-            return e.response.json()
         except requests.RequestException as e:
-            return {
-                "status": "error",
-                "message": "{}".format(e.message),
-            }
+            try:
+                return e.response.json()
+            except ValueError:
+                return {
+                    "status": "error",
+                    "message": "{}".format(e.message),
+                }
 
 
 class SearchAPIClient(BaseAPIClient):

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,6 @@ setup(
     install_requires=[
         'Flask>=0.10',
         'six==1.9.0',
+        'requests==2.7.0',
     ],
 )


### PR DESCRIPTION
Apache generates an 'Internal Server Error' page if any of our upstream APIs return 500-level responses.
So we'll just have the API Client return its own error if that happens.
Also required requests package.