### PR TITLE
Supplier a to z 2

### DIFF
--- a/dmutils/apiclient.py
+++ b/dmutils/apiclient.py
@@ -147,6 +147,28 @@ class DataAPIClient(BaseAPIClient):
         self.base_url = app.config['DM_DATA_API_URL']
         self.auth_token = app.config['DM_DATA_API_AUTH_TOKEN']
 
+    def get_suppliers(self, prefix=None):
+        params = None
+        if prefix:
+            params = {
+                "prefix": prefix
+            }
+        return self._get(
+            "{}/suppliers".format(self.base_url),
+            params
+        )
+
+    def get_supplier_by_id(self, supplier_id):
+        return self._get(
+            "{}/suppliers/{}".format(self.base_url, supplier_id)
+        )
+
+    def get_services_by_supplier_id(self, supplier_id):
+        return self._get(
+            "{}/services".format(self.base_url),
+            {"supplier_id": supplier_id}
+        )
+
     def get_service(self, service_id):
         try:
             return self._get(

--- a/dmutils/apiclient.py
+++ b/dmutils/apiclient.py
@@ -147,7 +147,7 @@ class DataAPIClient(BaseAPIClient):
         self.base_url = app.config['DM_DATA_API_URL']
         self.auth_token = app.config['DM_DATA_API_AUTH_TOKEN']
 
-    def get_suppliers(self, prefix=None):
+    def find_suppliers(self, prefix=None):
         params = None
         if prefix:
             params = {
@@ -158,15 +158,9 @@ class DataAPIClient(BaseAPIClient):
             params
         )
 
-    def get_supplier_by_id(self, supplier_id):
+    def get_supplier(self, supplier_id):
         return self._get(
             "{}/suppliers/{}".format(self.base_url, supplier_id)
-        )
-
-    def get_services_by_supplier_id(self, supplier_id):
-        return self._get(
-            "{}/services".format(self.base_url),
-            {"supplier_id": supplier_id}
         )
 
     def get_service(self, service_id):

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -483,18 +483,18 @@ class TestDataApiClient(object):
             json={"services": "result"},
             status_code=200)
 
-        result = data_client.get_suppliers()
+        result = data_client.find_suppliers()
 
         assert result == {"services": "result"}
         assert rmock.called
 
-    def test_get_suppliers_with_prefix(self, data_client, rmock):
+    def test_find_suppliers_with_prefix(self, data_client, rmock):
         rmock.get(
             "http://baseurl/suppliers?prefix=a",
             json={"services": "result"},
             status_code=200)
 
-        result = data_client.get_suppliers(prefix='a')
+        result = data_client.find_suppliers(prefix='a')
 
         assert result == {"services": "result"}
         assert rmock.called
@@ -505,7 +505,7 @@ class TestDataApiClient(object):
             json={"services": "result"},
             status_code=200)
 
-        result = data_client.get_supplier_by_id(123)
+        result = data_client.get_supplier(123)
 
         assert result == {"services": "result"}
         assert rmock.called
@@ -516,7 +516,7 @@ class TestDataApiClient(object):
             json={"services": "result"},
             status_code=200)
 
-        result = data_client.get_services_by_supplier_id(123)
+        result = data_client.find_service(supplier_id=123)
 
         assert result == {"services": "result"}
         assert rmock.called

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -510,13 +510,13 @@ class TestDataApiClient(object):
         assert result == {"services": "result"}
         assert rmock.called
 
-    def test_get_services_by_supplier(self, data_client, rmock):
+    def test_find_services_by_supplier(self, data_client, rmock):
         rmock.get(
             "http://baseurl/services?supplier_id=123",
             json={"services": "result"},
             status_code=200)
 
-        result = data_client.find_service(supplier_id=123)
+        result = data_client.find_services(supplier_id=123)
 
         assert result == {"services": "result"}
         assert rmock.called

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -485,7 +485,7 @@ class TestDataApiClient(object):
 
         result = data_client.get_suppliers()
 
-        assert result == "result"
+        assert result == {"services": "result"}
         assert rmock.called
 
     def test_get_suppliers_with_prefix(self, data_client, rmock):
@@ -496,7 +496,7 @@ class TestDataApiClient(object):
 
         result = data_client.get_suppliers(prefix='a')
 
-        assert result == "result"
+        assert result == {"services": "result"}
         assert rmock.called
 
     def test_get_supplier_by_id(self, data_client, rmock):
@@ -507,7 +507,7 @@ class TestDataApiClient(object):
 
         result = data_client.get_supplier_by_id(123)
 
-        assert result == "result"
+        assert result == {"services": "result"}
         assert rmock.called
 
     def test_get_services_by_supplier(self, data_client, rmock):
@@ -518,5 +518,5 @@ class TestDataApiClient(object):
 
         result = data_client.get_services_by_supplier_id(123)
 
-        assert result == "result"
+        assert result == {"services": "result"}
         assert rmock.called

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -476,3 +476,47 @@ class TestDataApiClient(object):
                 'name': 'name'
             }
         }}
+
+    def test_get_suppliers_with_no_prefix(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/suppliers",
+            json={"services": "result"},
+            status_code=200)
+
+        result = data_client.get_suppliers()
+
+        assert result == "result"
+        assert rmock.called
+
+    def test_get_suppliers_with_prefix(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/suppliers?prefix=a",
+            json={"services": "result"},
+            status_code=200)
+
+        result = data_client.get_suppliers(prefix='a')
+
+        assert result == "result"
+        assert rmock.called
+
+    def test_get_supplier_by_id(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/suppliers/123",
+            json={"services": "result"},
+            status_code=200)
+
+        result = data_client.get_supplier_by_id(123)
+
+        assert result == "result"
+        assert rmock.called
+
+    def test_get_services_by_supplier(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/services?supplier_id=123",
+            json={"services": "result"},
+            status_code=200)
+
+        result = data_client.get_services_by_supplier_id(123)
+
+        assert result == "result"
+        assert rmock.called

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -477,7 +477,7 @@ class TestDataApiClient(object):
             }
         }}
 
-    def test_get_suppliers_with_no_prefix(self, data_client, rmock):
+    def test_find_suppliers_with_no_prefix(self, data_client, rmock):
         rmock.get(
             "http://baseurl/suppliers",
             json={"services": "result"},
@@ -499,17 +499,6 @@ class TestDataApiClient(object):
         assert result == {"services": "result"}
         assert rmock.called
 
-    def test_get_supplier_by_id(self, data_client, rmock):
-        rmock.get(
-            "http://baseurl/suppliers/123",
-            json={"services": "result"},
-            status_code=200)
-
-        result = data_client.get_supplier(123)
-
-        assert result == {"services": "result"}
-        assert rmock.called
-
     def test_find_services_by_supplier(self, data_client, rmock):
         rmock.get(
             "http://baseurl/services?supplier_id=123",
@@ -517,6 +506,17 @@ class TestDataApiClient(object):
             status_code=200)
 
         result = data_client.find_services(supplier_id=123)
+
+        assert result == {"services": "result"}
+        assert rmock.called
+
+    def test_get_supplier_by_id(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/suppliers/123",
+            json={"services": "result"},
+            status_code=200)
+
+        result = data_client.get_supplier(123)
 
         assert result == {"services": "result"}
         assert rmock.called


### PR DESCRIPTION
This adds methods to allow querying by supplier in the same style as for services. The response signature is slightly different to other methods in that it returns the whole response. This is the correct approach otherwise pagination isn't available. I'll change the other methods in a separate pull request.

This has been rebased on #17