### PR TITLE
Add the request ID to API client requests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import tempfile
+
+import pytest
+from flask import Flask
+
+from dmutils.logging import init_app
+
+
+@pytest.fixture
+def app():
+    return Flask(__name__)
+
+
+@pytest.yield_fixture
+def app_with_logging(app):
+    with tempfile.NamedTemporaryFile() as f:
+        app.config['DM_LOG_PATH'] = f.name
+        init_app(app)
+        yield app

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -227,6 +227,32 @@ class TestSearchApiClient(object):
 
 
 class TestDataApiClient(object):
+    def test_request_id_is_added_if_available(
+            self, data_client, rmock, app_with_logging):
+        headers = {'DM-Request-Id': 'generated'}
+        with app_with_logging.test_request_context('/', headers=headers):
+            rmock.get(
+                "http://baseurl/_status",
+                json={"status": "ok"},
+                status_code=200)
+
+            data_client.get_status()
+
+            assert rmock.last_request.headers["DM-Request-Id"] == "generated"
+
+    def test_request_id_is_not_added_if_logging_is_not_loaded(
+            self, data_client, rmock, app):
+        headers = {'DM-Request-Id': 'generated'}
+        with app.test_request_context('/', headers=headers):
+            rmock.get(
+                "http://baseurl/_status",
+                json={"status": "ok"},
+                status_code=200)
+
+            data_client.get_status()
+
+            assert "DM-Request-Id" not in rmock.last_request.headers
+
     def test_init_app_sets_attributes(self, data_client):
         app = mock.Mock()
         app.config = {


### PR DESCRIPTION
The logging module will pick up the request ID from the header so that
we can correlate requests across different apps. This needs to be passed
down by the API client if it's available.