### PR TITLE
Put log message in quotes

### DIFF
--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -8,7 +8,7 @@ from flask.wrappers import Request
 from flask.ctx import has_request_context
 
 LOG_FORMAT = '%(asctime)s %(app_name)s %(name)s %(levelname)s %(request_id)s ' \
-             '%(message)s [in %(pathname)s:%(lineno)d]'
+             '"%(message)s" [in %(pathname)s:%(lineno)d]'
 TIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
 
 


### PR DESCRIPTION
CloudWatch Logs metric filters split log lines on spaces unless they're
quoted or between square brackets. This allows us to write metric
filters on things like levelname.