### PR TITLE
Add `delete` method to SearchApiClient.

### DIFF
--- a/dmutils/apiclient.py
+++ b/dmutils/apiclient.py
@@ -40,6 +40,9 @@ class BaseAPIClient(object):
     def _post(self, url, data):
         return self._request("POST", url, data=data)
 
+    def _delete(self, url):
+        return self._request("DELETE", url)
+
     def _request(self, method, url, data=None, params=None):
         if not self.enabled:
             return None
@@ -128,6 +131,16 @@ class SearchAPIClient(BaseAPIClient):
         data = self._convert_service(service_id, service, supplier_name)
 
         return self._put(url, data=data)
+
+    def delete(self, service_id):
+        url = self._url("/{}".format(service_id))
+
+        try:
+            return self._delete(url)
+        except APIError as e:
+            if e.response.status_code != 404:
+                raise
+        return None
 
     def search_services(self, q="", **filters):
         if isinstance(q, list):

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -85,7 +85,7 @@ def service():
         "datacentreTier": "TIA-942 Tier 3",
         "datacentresSpecifyLocation": True,
         "datacentresEUCode": False,
-    }
+        }
 
 
 class TestSearchApiClient(object):
@@ -95,7 +95,7 @@ class TestSearchApiClient(object):
             "DM_SEARCH_API_URL": "http://example",
             "DM_SEARCH_API_AUTH_TOKEN": "example-token",
             "ES_ENABLED": False,
-        }
+            }
         search_client.init_app(app)
 
         assert search_client.base_url == "http://example"
@@ -186,6 +186,21 @@ class TestSearchApiClient(object):
         result = search_client.index("12345", service, "Supplier name")
         assert result == {'message': 'acknowledged'}
 
+    def test_delete_to_delete_method_service_id(
+            self, search_client, rmock):
+        rmock.delete(
+            'http://baseurl/g-cloud/services/12345',
+            json={"services": {
+                "_id": "12345",
+                "_index": "g-cloud",
+                "_type": "services",
+                "_version": 1,
+                "found": True
+            }},
+            status_code=200)
+        result = search_client.delete("12345")
+        assert result['services']['found'] is True
+
     def test_should_not_call_search_api_is_es_disabled(
             self, search_client, rmock, service):
         search_client.enabled = False
@@ -258,7 +273,7 @@ class TestDataApiClient(object):
         app.config = {
             "DM_DATA_API_URL": "http://example",
             "DM_DATA_API_AUTH_TOKEN": "example-token",
-        }
+            }
         data_client.init_app(app)
 
         assert data_client.base_url == "http://example"


### PR DESCRIPTION
Also meant adding a `_delete` method to the BaseApiClient and some tests.
If we try to delete a service that doesn't exist, no (harm|foul).  We'll return `None` but won't raise an error.