### PR TITLE
Indexing the framework name.

### DIFF
--- a/dmutils/apiclient.py
+++ b/dmutils/apiclient.py
@@ -115,7 +115,7 @@ class SearchAPIClient(BaseAPIClient):
         "openSource",
         "persistentStorage",
         "guaranteedResources",
-        "elasticCloud",
+        "elasticCloud"
     ]
 
     def init_app(self, app):
@@ -126,9 +126,13 @@ class SearchAPIClient(BaseAPIClient):
     def _url(self, path):
         return "{}/g-cloud/services{}".format(self.base_url, path)
 
-    def index(self, service_id, service, supplier_name):
+    def index(self, service_id, service, supplier_name, framework_name):
         url = self._url("/{}".format(service_id))
-        data = self._convert_service(service_id, service, supplier_name)
+        data = self._convert_service(
+            service_id,
+            service,
+            supplier_name,
+            framework_name)
 
         return self._put(url, data=data)
 
@@ -157,8 +161,14 @@ class SearchAPIClient(BaseAPIClient):
 
         return response['search']
 
-    def _convert_service(self, service_id, service, supplier_name):
+    def _convert_service(
+            self,
+            service_id,
+            service,
+            supplier_name,
+            framework_name):
         data = {k: service[k] for k in self.FIELDS if k in service}
+        data['frameworkName'] = framework_name
         data['supplierName'] = supplier_name
         data['id'] = service_id
 

--- a/dmutils/apiclient.py
+++ b/dmutils/apiclient.py
@@ -115,7 +115,7 @@ class SearchAPIClient(BaseAPIClient):
         "openSource",
         "persistentStorage",
         "guaranteedResources",
-        "elasticCloud"
+        "elasticCloud",
     ]
 
     def init_app(self, app):

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -116,12 +116,13 @@ class TestSearchApiClient(object):
 
     def test_convert_service(self, search_client, service):
         converted = search_client._convert_service(
-            service['id'], service, "Supplier Name")
+            service['id'], service, "Supplier Name", "Framework Name")
 
         assert "service" in converted
         assert "service" in converted
         assert converted["service"]["id"] == "1234567890123456"
         assert converted["service"]["lot"] == "IaaS"
+        assert converted["service"]["frameworkName"] == "Framework Name"
         assert converted["service"]["serviceName"] == "My Iaas Service"
         assert \
             converted["service"]["serviceSummary"] == "IaaS Service Summary"
@@ -164,11 +165,12 @@ class TestSearchApiClient(object):
         del service["serviceFeatures"]
 
         converted = search_client._convert_service(
-            service['id'], service, "Supplier Name")
+            service['id'], service, "Supplier Name", "Framework Name")
 
         assert "service" in converted
         assert converted["service"]["id"] == "1234567890123456"
         assert converted["service"]["lot"] == "IaaS"
+        assert converted["service"]["frameworkName"] == "Framework Name"
         assert converted["service"]["serviceName"] == "My Iaas Service"
         assert \
             converted["service"]["serviceSummary"] == "IaaS Service Summary"
@@ -183,7 +185,11 @@ class TestSearchApiClient(object):
             'http://baseurl/g-cloud/services/12345',
             json={'message': 'acknowledged'},
             status_code=200)
-        result = search_client.index("12345", service, "Supplier name")
+        result = search_client.index(
+            "12345",
+            service,
+            "Supplier name",
+            "Framework Name")
         assert result == {'message': 'acknowledged'}
 
     def test_delete_to_delete_method_service_id(
@@ -208,7 +214,11 @@ class TestSearchApiClient(object):
             'http://baseurl/g-cloud/services/12345',
             json={'message': 'acknowledged'},
             status_code=200)
-        result = search_client.index("12345", service, "Supplier name")
+        result = search_client.index(
+            "12345",
+            service,
+            "Supplier name",
+            "Framework Name")
         assert result is None
         assert not rmock.called
 
@@ -219,7 +229,11 @@ class TestSearchApiClient(object):
                 'http://baseurl/g-cloud/services/12345',
                 json={'error': 'some error'},
                 status_code=400)
-            search_client.index("12345", service, "Supplier name")
+            search_client.index(
+                "12345",
+                service,
+                "Supplier name",
+                "Framework Name")
 
     def test_search_services(self, search_client, rmock):
         rmock.get(


### PR DESCRIPTION
- Updates the client to require the framework name to be indexed alongside service details and supplier name

- This is part of https://www.pivotaltracker.com/story/show/94070088

Required by:
https://github.com/alphagov/digitalmarketplace-api/pull/116
https://github.com/alphagov/digitalmarketplace-search-api/pull/31


