### PR TITLE
Add metrics

### DIFF
--- a/dmutils/config.py
+++ b/dmutils/config.py
@@ -7,6 +7,8 @@ def init_app(app):
     for key, value in app.config.items():
         if key in os.environ:
             app.config[key] = convert_to_boolean(os.environ[key])
+    app.config['DM_ENVIRONMENT'] = os.environ.get('DM_ENVIRONMENT',
+                                                  'development')
 
 
 def convert_to_boolean(value):

--- a/dmutils/metrics.py
+++ b/dmutils/metrics.py
@@ -1,0 +1,43 @@
+import copy
+from datetime import datetime
+
+from boto.ec2.cloudwatch import connect_to_region
+
+
+def client(region, namespace, default_dimensions=None):
+    return CloudWatchClient(region, namespace, default_dimensions)
+
+
+class CloudWatchClient(object):
+    def __init__(self, region, namespace, default_dimensions=None):
+        self._conn = connect_to_region(region)
+        self.namespace = namespace
+        if default_dimensions is None:
+            default_dimensions = dict()
+        self.default_dimensions = default_dimensions
+
+    def dimensions(self, dimensions):
+        _dimensions = copy.copy(self.default_dimensions)
+        if dimensions is not None:
+            _dimensions.update(dimensions)
+        return _dimensions
+
+    def _put_metric(self, name, value=None, timestamp=None, unit=None,
+                    dimensions=None, statistics=None):
+        if timestamp is None:
+            timestamp = datetime.now()
+        self._conn.put_metric_data(
+            namespace=self.namespace,
+            name=name,
+            value=value,
+            timestamp=timestamp,
+            unit=unit,
+            dimensions=self.dimensions(dimensions),
+            statistics=statistics)
+
+    def inc(self, name, value=1, timestamp=None, dimensions=None):
+        self._put_metric(name,
+                         value=value,
+                         timestamp=timestamp,
+                         unit="Count",
+                         dimensions=dimensions)

--- a/dmutils/metrics.py
+++ b/dmutils/metrics.py
@@ -63,9 +63,3 @@ class CloudWatchClient(object):
             dimensions=self.dimensions(dimensions),
             statistics=statistics)
 
-    def inc(self, name, value=1, timestamp=None, dimensions=None):
-        self._put_metric(name,
-                         value=value,
-                         timestamp=timestamp,
-                         unit="Count",
-                         dimensions=dimensions)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 boto==2.38.0
+contextlib2==0.4.0
 Flask>=0.10
 six==1.9.0
 requests==2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+boto==2.38.0
 Flask>=0.10
 six==1.9.0
 requests==2.7.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import tempfile
 
 import pytest
 from flask import Flask
+import mock
+from boto.ec2.cloudwatch import CloudWatchConnection
 
 from dmutils.logging import init_app
 
@@ -17,3 +19,19 @@ def app_with_logging(app):
         app.config['DM_LOG_PATH'] = f.name
         init_app(app)
         yield app
+
+
+@pytest.yield_fixture
+def cloudwatch():
+    with mock.patch('dmutils.metrics.connect_to_region') as connect_to_region:
+        conn = mock.Mock(spec=CloudWatchConnection)
+        connect_to_region.return_value = conn
+        yield conn
+
+
+@pytest.fixture
+def os_environ(request):
+    env_patch = mock.patch('os.environ', {})
+    request.addfinalizer(env_patch.stop)
+
+    return env_patch.start()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,6 @@
+from datetime import datetime
+
+
+class IsDatetime(object):
+    def __eq__(self, other):
+        return isinstance(other, datetime)

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -109,7 +109,6 @@ class TestSearchApiClient(object):
             status_code=200)
 
         result = data_client.get_status()
-        print("result = {}".format(result))
 
         assert result['status'] == "ok"
         assert rmock.called

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,21 +1,4 @@
-from flask import Flask
-import pytest
-import mock
-
 from dmutils.config import init_app
-
-
-@pytest.fixture
-def app():
-    return Flask(__name__)
-
-
-@pytest.fixture
-def os_environ(request):
-    env_patch = mock.patch('os.environ', {})
-    request.addfinalizer(env_patch.stop)
-
-    return env_patch.start()
 
 
 def test_init_app_updates_known_config_options(app, os_environ):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -30,3 +30,44 @@ def test_inc_produces_a_counter(cloudwatch):
         unit="Count",
         dimensions=dict(),
         statistics=None)
+
+
+def test_flask_client_returns_none_before_init():
+    client = metrics.flask_client()
+
+    assert client.client is None
+
+
+def test_flask_client_returns_none_when_not_in_app_context(app):
+    client = metrics.flask_client()
+    client.init_app(app)
+
+    assert client.client is None
+
+
+def test_flask_client_returns_client_when_in_app_context(app):
+    client = metrics.flask_client()
+    client.init_app(app)
+
+    with app.app_context():
+        assert isinstance(client.client, metrics.CloudWatchClient)
+
+
+def test_flask_client_adds_application_name_dimension(app):
+    client = metrics.flask_client()
+    client.init_app(app)
+
+    assert app.config['DM_METRICS_DIMENSIONS'] == {'applicationName': 'none'}
+
+
+def test_flask_client_merges_configured_dimensions(app):
+    client = metrics.flask_client()
+    app.config['DM_METRICS_DIMENSIONS'] = {
+        "customDimension": "value",
+    }
+    client.init_app(app)
+
+    assert app.config['DM_METRICS_DIMENSIONS'] == {
+        "applicationName": "none",
+        "customDimension": "value",
+    }

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,23 +1,7 @@
-from datetime import datetime
-
 import mock
-import pytest
-from boto.ec2.cloudwatch import CloudWatchConnection
 
 from dmutils import metrics
-
-
-@pytest.yield_fixture
-def cloudwatch():
-    with mock.patch('dmutils.metrics.connect_to_region') as connect_to_region:
-        conn = mock.Mock(spec=CloudWatchConnection)
-        connect_to_region.return_value = conn
-        yield conn
-
-
-class IsDatetime(object):
-    def __eq__(self, other):
-        return isinstance(other, datetime)
+from .helpers import IsDatetime
 
 
 @mock.patch('dmutils.metrics.connect_to_region')

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -18,9 +18,9 @@ def test_client_default_dimensions_defaults_to_dict(cloudwatch):
     assert client.default_dimensions == dict()
 
 
-def test_inc_produces_a_counter(cloudwatch):
+def test_put_metric(cloudwatch):
     client = metrics.client("myregion", "mynamespace")
-    client.inc("foo")
+    client._put_metric("foo", 1, unit="Count")
 
     cloudwatch.put_metric_data.assert_called_with(
         namespace="mynamespace",

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+
+import mock
+import pytest
+from boto.ec2.cloudwatch import CloudWatchConnection
+
+from dmutils import metrics
+
+
+@pytest.yield_fixture
+def cloudwatch():
+    with mock.patch('dmutils.metrics.connect_to_region') as connect_to_region:
+        conn = mock.Mock(spec=CloudWatchConnection)
+        connect_to_region.return_value = conn
+        yield conn
+
+
+class IsDatetime(object):
+    def __eq__(self, other):
+        return isinstance(other, datetime)
+
+
+@mock.patch('dmutils.metrics.connect_to_region')
+def test_client_connects_to_region(connect_to_region):
+    connect_to_region.return_value = "myconn"
+    metrics.client("myregion", "mynamespace")
+
+    connect_to_region.assert_called_with("myregion")
+
+
+def test_client_default_dimensions_defaults_to_dict(cloudwatch):
+    client = metrics.client("myregion", "mynamespace")
+
+    assert client.default_dimensions == dict()
+
+
+def test_inc_produces_a_counter(cloudwatch):
+    client = metrics.client("myregion", "mynamespace")
+    client.inc("foo")
+
+    cloudwatch.put_metric_data.assert_called_with(
+        namespace="mynamespace",
+        name="foo",
+        value=1,
+        timestamp=IsDatetime(),
+        unit="Count",
+        dimensions=dict(),
+        statistics=None)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,3 +1,5 @@
+import time
+
 import mock
 
 from dmutils import metrics
@@ -30,6 +32,18 @@ def test_put_metric(cloudwatch):
         unit="Count",
         dimensions=dict(),
         statistics=None)
+
+
+def test_timer(cloudwatch):
+    client = metrics.client("myregion", "mynamespace")
+    with client.timer("mytimer"):
+        time.sleep(0.1)
+
+    cloudwatch.put_metric_data.assert_called()
+    args, kwargs = cloudwatch.put_metric_data.call_args
+
+    assert 0 < kwargs['value'] < 150
+    assert kwargs['unit'] == "Milliseconds"
 
 
 def test_flask_client_returns_none_before_init():

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -52,14 +52,14 @@ def test_flask_client_returns_none_before_init():
     assert client.client is None
 
 
-def test_flask_client_returns_none_when_not_in_app_context(app):
+def test_flask_client_returns_none_when_not_in_app_context(app, cloudwatch):
     client = metrics.flask_client()
     client.init_app(app)
 
     assert client.client is None
 
 
-def test_flask_client_returns_client_when_in_app_context(app):
+def test_flask_client_returns_client_when_in_app_context(app, cloudwatch):
     client = metrics.flask_client()
     client.init_app(app)
 
@@ -67,14 +67,14 @@ def test_flask_client_returns_client_when_in_app_context(app):
         assert isinstance(client.client, metrics.CloudWatchClient)
 
 
-def test_flask_client_adds_application_name_dimension(app):
+def test_flask_client_adds_application_name_dimension(app, cloudwatch):
     client = metrics.flask_client()
     client.init_app(app)
 
     assert app.config['DM_METRICS_DIMENSIONS'] == {'applicationName': 'none'}
 
 
-def test_flask_client_merges_configured_dimensions(app):
+def test_flask_client_merges_configured_dimensions(app, cloudwatch):
     client = metrics.flask_client()
     app.config['DM_METRICS_DIMENSIONS'] = {
         "customDimension": "value",


### PR DESCRIPTION
Add a very basic client for sending metrics to CloudWatch. It tries to
follow the pystatsd interface but so far only implements the `inc`
method.

The timestamp is explicitly set rather than allowing CloudWatch to set
it so that events line up better with our logs.