### PR TITLE
Fix exception on connection error for get_status

### DIFF
--- a/dmutils/apiclient.py
+++ b/dmutils/apiclient.py
@@ -85,7 +85,7 @@ class BaseAPIClient(object):
         except requests.RequestException as e:
             try:
                 return e.response.json()
-            except ValueError:
+            except (ValueError, AttributeError):
                 return {
                     "status": "error",
                     "message": "{}".format(e.message),


### PR DESCRIPTION
When connection fails, e.response is None, which means trying to
access .json raises an AttributeError.