### PR TITLE
Support blank query

### DIFF
--- a/dmutils/apiclient.py
+++ b/dmutils/apiclient.py
@@ -149,7 +149,9 @@ class SearchAPIClient(BaseAPIClient):
     def search_services(self, q="", **filters):
         if isinstance(q, list):
             q = q[0]
-        params = {"q": q}
+        params = dict()
+        if q != "":
+            params['q'] = q
 
         for filter_name, filter_values in six.iteritems(filters):
             if filter_name == "minimumContractPeriod":

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -247,6 +247,15 @@ class TestSearchApiClient(object):
             something=['a', 'b'])
         assert result == "myresponse"
 
+    def test_search_services_with_blank_query(self, search_client, rmock):
+        rmock.get(
+            'http://baseurl/g-cloud/services/search?',
+            json={'search': "myresponse"},
+            status_code=200)
+        result = search_client.search_services(q='')
+        assert result == "myresponse"
+        assert rmock.last_request.query == ''
+
     @staticmethod
     def load_example_listing(name):
         file_path = os.path.join("example_listings", "{}.json".format(name))


### PR DESCRIPTION
Specifically, support the sending of a blank 'q' parameter.