### PR TITLE
WIP: Make search_services respond with JSON API style

### DIFF
--- a/dmutils/apiclient.py
+++ b/dmutils/apiclient.py
@@ -161,7 +161,24 @@ class SearchAPIClient(BaseAPIClient):
 
         response = self._get(self._url("/search"), params=params)
 
-        return response['search']
+        if 'search' in response:
+            return self._build_search_result_from_legacy_response(response)
+        else:
+            return response
+
+    def _build_search_result_from_legacy_response(self, response):
+        result = dict()
+        if 'links' in response:
+            result['links'] = response['links']
+        result.update({
+            'meta': {
+                'query': response['search']['query'],
+                'took': response['search']['took'],
+                'total': response['search']['total'],
+            },
+            'services': response['search']['services'],
+        })
+        return result
 
     def _convert_service(
             self,


### PR DESCRIPTION
**This pull request is for discussion, please do not merge**

Make the search_services method on the search API client return responses that look like JSON API responses even if they are not coming back from the search API like that.

JSON API style response would look like:
```
{
  "links": {
    "next": <next link>
  },
  "meta": {
    "query": { <query args sent to the search API> },
    "total": <total number of results>,
    "took": <milliseconds took>
  },
  "services": [
    <matching services>
  ]
}
```

The current response fromat from the search API follows. This change will
convert this to the JSON API style.
```
{
  "links": {
    "next": <next link>
  },
  "search": {
    "query": { <query args sent to the search API> },
    "services": [
      <matching services>
    ],
    "total": <total number of results>,
    "took": <milliseconds took>
  }
}
```