### PR TITLE
[#94292928] Allow HTTP proto to be configured

### DIFF
--- a/dmutils/proxy_fix.py
+++ b/dmutils/proxy_fix.py
@@ -1,0 +1,18 @@
+from werkzeug.contrib.fixers import ProxyFix
+
+
+class CustomProxyFix(object):
+    def __init__(self, app, forwarded_proto):
+        self.app = ProxyFix(app)
+        self.forwarded_proto = forwarded_proto
+
+    def __call__(self, environ, start_response):
+        environ.update({
+            "HTTP_X_FORWARDED_PROTO": self.forwarded_proto
+        })
+        return self.app(environ, start_response)
+
+
+def init_app(app):
+    app.wsgi_app = CustomProxyFix(app.wsgi_app,
+                                  app.config.get('DM_HTTP_PROTO', 'http'))

--- a/tests/test_proxy_fix.py
+++ b/tests/test_proxy_fix.py
@@ -1,0 +1,17 @@
+from flask import request
+
+from dmutils import proxy_fix
+
+
+def test_proxy_fix(app):
+    app.config['DM_HTTP_PROTO'] = 'foo'
+    proxy_fix.init_app(app)
+
+    @app.route("/")
+    def foo():
+        return request.environ['HTTP_X_FORWARDED_PROTO']
+
+    with app.app_context():
+        client = app.test_client()
+        response = client.get('/')
+        assert response.data.decode('utf-8') == 'foo'


### PR DESCRIPTION
Provide a custom ProxyFix class that will override X-Forwarded-Proto
with a value from the Flask config. AWS ELBs set the X-Forwarded-Proto
to HTTP if they're configured port 80 -> 80. Because the apps are now
internal and served over HTTP we lose the X-Forwarded-Proto that is sent
by Nginx.