### PR TITLE
Log URL including the query string

### DIFF
--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -28,7 +28,7 @@ def init_app(app):
 
         current_app.logger.info('%s %s %s',
                                 request.method,
-                                request.path,
+                                request.url,
                                 response.status_code)
         return response
 


### PR DESCRIPTION
Changed logger to log whole URL not the path.

- This means we see http://host/path?querystring in the logs