### PR TITLE
[#94576802] Update Json api format

### DIFF
--- a/dmutils/apiclient.py
+++ b/dmutils/apiclient.py
@@ -184,8 +184,7 @@ class SearchAPIClient(BaseAPIClient):
             params['filter_{}'.format(filter_name)] = filter_values
 
         response = self._get(self._url("/search"), params=params)
-
-        return response['search']
+        return response
 
     def _convert_service(
             self,

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -304,21 +304,21 @@ class TestSearchApiClient(object):
             'http://baseurl/g-cloud/services/search?q=foo&'
             'filter_minimumContractPeriod=a,b&'
             'filter_something=a&filter_something=b',
-            json={'search': "myresponse"},
+            json={'services': "myresponse"},
             status_code=200)
         result = search_client.search_services(
             q='foo',
             minimumContractPeriod=['a', 'b'],
             something=['a', 'b'])
-        assert result == "myresponse"
+        assert result == {'services': "myresponse"}
 
     def test_search_services_with_blank_query(self, search_client, rmock):
         rmock.get(
             'http://baseurl/g-cloud/services/search?',
-            json={'search': "myresponse"},
+            json={'services': "myresponse"},
             status_code=200)
         result = search_client.search_services(q='')
-        assert result == "myresponse"
+        assert result == {'services': "myresponse"}
         assert rmock.last_request.query == ''
 
     @staticmethod


### PR DESCRIPTION
See this story in Pivotal: https://www.pivotaltracker.com/story/show/94576802 - the main aim is to make API response formats consistent across the Data and Search APIs.

There are FOUR related pull-requests to complete this story.  The other three are:
https://github.com/alphagov/digitalmarketplace-api/pull/132
https://github.com/alphagov/digitalmarketplace-search-api/pull/42
https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/60

Changes in the search API client here are to return the whole response now as metadata is under a separate key from the services found.

See these gists for examples of the new API responses:
[Example services data API response](https://gist.github.com/TheDoubleK/0d7cd9363440e700a50d)
[Example suppliers data API response](https://gist.github.com/TheDoubleK/4fde0400e052f20ed2c0)
[Example services search API response](https://gist.github.com/TheDoubleK/8e82782502e611faabcc)