### PR TITLE
Log the API error message

### DIFF
--- a/dmutils/apiclient.py
+++ b/dmutils/apiclient.py
@@ -86,7 +86,7 @@ class BaseAPIClient(object):
             api_error = HTTPError(e.response)
             logger.warning(
                 "API %s request on %s failed with %s '%s'",
-                method, url, api_error.status_code, e)
+                method, url, api_error.status_code, api_error.message)
             raise api_error
         try:
             return response.json()


### PR DESCRIPTION
Try to get the error message out of the API response and log that so
that we can get a better idea of why a request failed from the logs.