### PR TITLE
Add Feature Flags, pull out some shared app config, pull out /status/utils.py

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -9,6 +9,7 @@ def init_app(
         config_object,
         bootstrap=None,
         data_api_client=None,
+        db=None,
         feature_flags=None,
         login_manager=None,
         search_api_client=None,
@@ -26,7 +27,10 @@ def init_app(
         bootstrap.init_app(application)
     if data_api_client:
         data_api_client.init_app(application)
+    if db:
+        db.init_app(application)
     if feature_flags:
+        # Standardize FeatureFlags, only accept inline config variables
         feature_flags.init_app(application)
         feature_flags.clear_handlers()
         feature_flags.add_handler(InlineFeatureFlag())

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -16,7 +16,8 @@ def init_app(
 ):
 
     application.config.from_object(config_object)
-    config_object.init_app(application)
+    if hasattr(config_object, 'init_app'):
+        config_object.init_app(application)
 
     # all belong to dmutils
     config.init_app(application)
@@ -38,6 +39,3 @@ def init_app(
         login_manager.init_app(application)
     if search_api_client:
         search_api_client.init_app(application)
-
-    logging.init_app(application)
-    proxy_fix.init_app(application)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -1,4 +1,5 @@
 from . import logging, config, proxy_fix
+from flask_featureflags import FeatureFlag
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
 __version__ = '0.17.0'

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -1,1 +1,38 @@
-__version__ = '0.16.0'
+from . import logging, config, proxy_fix
+from flask_featureflags.contrib.inline import InlineFeatureFlag
+
+__version__ = '0.17.0'
+
+def init_app(
+        application,
+        config_object,
+        bootstrap=None,
+        data_api_client=None,
+        feature_flags=None,
+        login_manager=None,
+        search_api_client=None,
+):
+
+    application.config.from_object(config_object)
+    config_object.init_app(application)
+
+    # all belong to dmutils
+    config.init_app(application)
+    logging.init_app(application)
+    proxy_fix.init_app(application)
+
+    if bootstrap:
+        bootstrap.init_app(application)
+    if data_api_client:
+        data_api_client.init_app(application)
+    if feature_flags:
+        feature_flags.init_app(application)
+        feature_flags.clear_handlers()
+        feature_flags.add_handler(InlineFeatureFlag())
+    if login_manager:
+        login_manager.init_app(application)
+    if search_api_client:
+        search_api_client.init_app(application)
+
+    logging.init_app(application)
+    proxy_fix.init_app(application)

--- a/dmutils/status.py
+++ b/dmutils/status.py
@@ -1,0 +1,11 @@
+import os
+
+
+def get_version_label():
+    try:
+        path = os.path.join(os.path.dirname(__file__),
+                            '..', '..', 'version_label')
+        with open(path) as f:
+            return f.read().strip()
+    except IOError:
+        return None

--- a/dmutils/status.py
+++ b/dmutils/status.py
@@ -1,5 +1,5 @@
 import os
-
+from flask_featureflags import FEATURE_FLAGS_CONFIG
 
 def get_version_label():
     try:
@@ -9,3 +9,15 @@ def get_version_label():
             return f.read().strip()
     except IOError:
         return None
+
+def get_flags(current_app):
+    """ Loop through config variables and return a dictionary of flags.  """
+    flags = {}
+
+    for config_var in current_app.config.keys():
+        # Check that the (inline) key starts with our config variable
+        if config_var.startswith("{}_".format(FEATURE_FLAGS_CONFIG)):
+
+                flags[config_var] = current_app.config[config_var]
+
+    return flags

--- a/dmutils/status.py
+++ b/dmutils/status.py
@@ -1,4 +1,5 @@
 import os
+import datetime
 from flask_featureflags import FEATURE_FLAGS_CONFIG
 
 def get_version_label():
@@ -21,3 +22,11 @@ def get_flags(current_app):
                 flags[config_var] = current_app.config[config_var]
 
     return flags
+
+def enabled_since(date_string):
+    if date_string:
+        # Check format like YYYY-MM-DD
+        datetime.datetime.strptime(date_string, '%Y-%m-%d')
+        return date_string
+
+    return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ six==1.9.0
 requests==2.7.0
 pyyaml==3.11
 inflection==0.2.1
+# Flask-FeatureFlags==0.5.1
+git+https://github.com/pcraig3/Flask-FeatureFlags.git@master#egg=Flask-FeatureFlags-0.6dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ requests==2.7.0
 pyyaml==3.11
 inflection==0.2.1
 # Flask-FeatureFlags==0.5.1
-git+https://github.com/pcraig3/Flask-FeatureFlags.git@master#egg=Flask-FeatureFlags-0.6dev
+git+https://github.com/pcraig3/Flask-FeatureFlags.git@master#egg=Flask-FeatureFlags==0.6-dev

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ Common utils for Digital Marketplace apps.
 """
 import re
 import ast
+import pip.download
+from pip.req import parse_requirements
 from setuptools import setup
 
 
@@ -12,8 +14,9 @@ with open('dmutils/__init__.py', 'rb') as f:
     version = str(ast.literal_eval(_version_re.search(
         f.read().decode('utf-8')).group(1)))
 
-with open('requirements.txt', 'rb') as f:
-    install_requires = f.read().decode('utf-8').splitlines()
+requirements = parse_requirements('requirements.txt', session=pip.download.PipSession())
+install_requires = [str(r.req) for r in requirements]
+dependency_links = [str(r.url) for r in requirements]
 
 setup(
     name='digitalmarketplace-utils',
@@ -26,4 +29,5 @@ setup(
     packages=['dmutils'],
     include_package_data=True,
     install_requires=install_requires,
+    dependency_links=dependency_links
 )

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ Common utils for Digital Marketplace apps.
 import re
 import ast
 import pip.download
+import itertools
 from pip.req import parse_requirements
 from setuptools import setup
 
@@ -14,9 +15,13 @@ with open('dmutils/__init__.py', 'rb') as f:
     version = str(ast.literal_eval(_version_re.search(
         f.read().decode('utf-8')).group(1)))
 
-requirements = parse_requirements('requirements.txt', session=pip.download.PipSession())
+requirements = list(parse_requirements('requirements.txt', session=pip.download.PipSession()))
+
 install_requires = [str(r.req) for r in requirements]
-dependency_links = [str(r.url) for r in requirements]
+dependency_links = filter(
+    lambda x: x != 'None',
+    [str(r.link if hasattr(r, 'link') else r.url) for r in requirements]
+)
 
 setup(
     name='digitalmarketplace-utils',

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,6 @@ with open('dmutils/__init__.py', 'rb') as f:
 requirements = list(parse_requirements('requirements.txt', session=pip.download.PipSession()))
 
 install_requires = [str(r.req) for r in requirements]
-dependency_links = filter(
-    lambda x: x != 'None',
-    [str(r.link if hasattr(r, 'link') else r.url) for r in requirements]
-)
 
 setup(
     name='digitalmarketplace-utils',
@@ -33,6 +29,5 @@ setup(
     long_description=__doc__,
     packages=['dmutils'],
     include_package_data=True,
-    install_requires=install_requires,
-    dependency_links=dependency_links
+    install_requires=install_requires
 )


### PR DESCRIPTION
Pull request is meant to do four things:

* Adds in [Flask-FeatureFlags](https://github.com/pcraig3/Flask-FeatureFlags), and sets them up so that feature flags in all other apps are configured in the same way (more below). 
  * Also adds a couple of flag-centric utility methods we want all apps to have
* Pull out some of the shared app configurations.  Basically, anything with an `init_app(application)` method was targeted.
* Pulls out the `get_version_label()` function that all the _status endpoints rely on.
* Version++

I've tested this with all the other apps.  The [Supplier app](https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/45) is the only one with an open pull request, but all the others have a `pc_feature_flags_utils_upgrade` branch that you can test out if you're curious.  

It's also a backwards-compatible set of changes, so nothing breaks in dependent apps if this pull request gets merged.

[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/94571574)

***

### Flask-FeatureFlags

So there's a few things going on here, and we should probably talk about them.
[@trustrachel](https://github.com/trustrachel)'s [Flask-FeatureFlags](https://github.com/trustrachel/Flask-FeatureFlags) is the FeatureFlag extension that I went with, and on first blush, it seemed like it did everything that we wanted it to do straight out of the box. :smile: 

Then I showed it to @minglis, and it then didn't. :disappointed: 

Specifically, we wanted (**a**) inline configuration variables instead of dictionaries, (**b**) to list all flags in the app in the status endpoint, and (**c**) to know when they were enabled.

##### (a) inline config variables
It's [meant to be able to do inline configuration variables](https://flask-featureflags.readthedocs.org/en/latest/contrib.html), but, due to a couple lines missing from `setup.py`, it doesn't.   Looks like an oversight, and there's a [pull request sitting there](https://github.com/trustrachel/Flask-FeatureFlags/pull/13) (just over a week now), which addresses this very issue.  But since we need it now, [I forked it](https://github.com/pcraig3/Flask-FeatureFlags/commit/e6454ff0cbc584d25af8c6c8f9413ce84d9fd8aa) and updated the one file in question (thanks @robyoung!).

Since my fork isn't on :snake: :cake:, it means we have to do some [not super-cool stuff](https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/pc_fit_in_feature_flags/requirements.txt#L5) to get it into our separate apps.  

In an ideal world, the pending pull request is merged and then the pypie package is updated and then we delete my fork forever.  Could happen tomorrow.

##### (b) list flags in status endpoints

I figured the extension would build up a dictionary of flags and then iterate through them, but it doesn't.  It waits until either someone uses its [`@is_active_feature`](https://github.com/trustrachel/Flask-FeatureFlags/blob/master/flask_featureflags/__init__.py#L165) decorator or the [`active_feature`](https://github.com/trustrachel/Flask-FeatureFlags/blob/master/flask_featureflags/__init__.py#L150) jinja2 method and then loops through all the config variables trying to match the passed-in `'name_of_feature'` string.  It has a default way of matching strings to config variables, and lets you attach handlers with more matching logic. 

We *only* want inline config variables, so we mandate this in [`init_app`](https://github.com/alphagov/digitalmarketplace-utils/blob/pc_figure_out_feature_flags/dmutils/__init__.py#L34), and then our [`get_flags`](https://github.com/alphagov/digitalmarketplace-utils/blob/pc_figure_out_feature_flags/dmutils/status.py#L14) method can find them all because we control the logic for matching flags.

##### (c) when were they enabled

This is the hardest to do without persistence, so I just did something @allait suggested: write a small method with a reasonably descriptive name that takes advantage of a side-effect.
Flask-FeatureFlags decides if something is enabled by checking your config variable is set to [any truthy value](https://github.com/trustrachel/Flask-FeatureFlags/blob/master/flask_featureflags/__init__.py#L130), so it can be any string just as easily as it can be `True`.
[`enabled_since()`](https://github.com/alphagov/digitalmarketplace-utils/blob/pc_figure_out_feature_flags/dmutils/status.py#L26) takes a date string, throws an error if the format is wrong, and then returns the string (or `False`).

So we can do config variables like this:

```python
    FEATURE_FLAGS_EDIT_SERVICE_PAGE = enabled_since('2015-06-04')
    FEATURE_FLAGS_SOMETHING_ELSE = False
```

And then our _status endpoint looks like:
```json
{
  "api_status": {
    "db_version": "10_adding_supplier_to_user_table", 
    "flags": {}, 
    "status": "ok", 
    "version": null
  }, 
  "flags": {
    "FEATURE_FLAGS_EDIT_SERVICE_PAGE": "2015-06-04", 
    "FEATURE_FLAGS_SOMETHING_ELSE": false
  }, 
  "status": "ok", 
  "version": null
}
```

It's obviously a manual process, but @minglis felt we could police that people are doing the right thing during pull requests.  I think the complexity is sufficient for the problem, so I'm happy. 

<sub>Oh, and @allait suggested a better way of doing pull requests, so in the future more of this information will be in my commit messages.</sub> 