### PR TITLE
Apiclient update supplier

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,7 +2,7 @@ from . import logging, config, proxy_fix
 from flask_featureflags import FeatureFlag
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '0.17.0'
+__version__ = '0.18.0'
 
 def init_app(
         application,

--- a/dmutils/apiclient.py
+++ b/dmutils/apiclient.py
@@ -233,6 +233,26 @@ class DataAPIClient(BaseAPIClient):
             data={"suppliers": supplier},
         )
 
+    def update_supplier(self, supplier_id, supplier, user):
+        return self._post(
+            "/suppliers/{}".format(supplier_id),
+            data={
+                "suppliers": supplier,
+                "updated_by": user,
+            },
+        )
+
+    def update_contact_information(self, supplier_id, contact_id,
+                                   contact, user):
+        return self._post(
+            "/suppliers/{}/contact-information/{}".format(
+                supplier_id, contact_id),
+            data={
+                "contactInformation": contact,
+                "updated_by": user,
+            },
+        )
+
     def get_service(self, service_id):
         try:
             return self._get(

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -718,3 +718,35 @@ class TestDataApiClient(object):
 
         assert result == {"suppliers": "result"}
         assert rmock.called
+
+    def test_update_supplier(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/suppliers/123",
+            json={"suppliers": "result"},
+            status_code=201,
+        )
+
+        result = data_client.update_supplier(123, {"foo": "bar"}, 'supplier')
+
+        assert result == {"suppliers": "result"}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'suppliers': {'foo': 'bar'}, 'updated_by': 'supplier'
+        }
+
+    def test_update_contact_information(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/suppliers/123/contact-information/2",
+            json={"suppliers": "result"},
+            status_code=201,
+        )
+
+        result = data_client.update_contact_information(
+            123, 2, {"foo": "bar"}, 'supplier'
+        )
+
+        assert result == {"suppliers": "result"}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'contactInformation': {'foo': 'bar'}, 'updated_by': 'supplier'
+        }


### PR DESCRIPTION
apiclient methods for https://github.com/alphagov/digitalmarketplace-api/pull/136

### Add update_supplier and update_contact_information methods
Used to send requests to the new Data API supplier edit endpoints.
Since the API doesn't expect update_reason only `user` argument is
required.