### PR TITLE
Import feature flags module instead of class.

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -1,5 +1,5 @@
 from . import logging, config, proxy_fix
-from flask_featureflags import FeatureFlag
+import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
 __version__ = '0.17.0'


### PR DESCRIPTION
Importing the FeatureFlag class from the flask_featureflags module works in the sense that we can set config variables and see them all at our /_status endpoint, but it doesn't actually let us permit/disallow
features in our apps, which, one could make the argument, is the very reason for having feature flags in the first place.