### PR TITLE
Use PEP8 in tests and fix existing PEP8 errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ install:
   - pip install -r requirements_for_test.txt
   - pip install -e .
 script:
-  - py.test
+  - ./scripts/run_tests.sh
 notifications:
   email: false

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,6 +4,7 @@ from flask_featureflags.contrib.inline import InlineFeatureFlag
 
 __version__ = '0.18.0'
 
+
 def init_app(
         application,
         config_object,

--- a/dmutils/status.py
+++ b/dmutils/status.py
@@ -2,6 +2,7 @@ import os
 import datetime
 from flask_featureflags import FEATURE_FLAGS_CONFIG
 
+
 def get_version_label():
     try:
         path = os.path.join(os.path.dirname(__file__),
@@ -10,6 +11,7 @@ def get_version_label():
             return f.read().strip()
     except IOError:
         return None
+
 
 def get_flags(current_app):
     """ Loop through config variables and return a dictionary of flags.  """
@@ -22,6 +24,7 @@ def get_flags(current_app):
                 flags[config_var] = current_app.config[config_var]
 
     return flags
+
 
 def enabled_since(date_string):
     if date_string:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ with open('dmutils/__init__.py', 'rb') as f:
     version = str(ast.literal_eval(_version_re.search(
         f.read().decode('utf-8')).group(1)))
 
-requirements = list(parse_requirements('requirements.txt', session=pip.download.PipSession()))
+requirements = list(parse_requirements('requirements.txt',
+                                       session=pip.download.PipSession()))
 
 install_requires = [str(r.req) for r in requirements]
 


### PR DESCRIPTION
All our other projects enforce PEP8; we should do the same here for consistency.