### PR TITLE
Pass in path for `get_version_label` function

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,7 +2,7 @@ from . import logging, config, proxy_fix
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '0.18.0'
+__version__ = '0.19.0'
 
 
 def init_app(

--- a/dmutils/status.py
+++ b/dmutils/status.py
@@ -1,12 +1,9 @@
-import os
 import datetime
 from flask_featureflags import FEATURE_FLAGS_CONFIG
 
 
-def get_version_label():
+def get_version_label(path):
     try:
-        path = os.path.join(os.path.dirname(__file__),
-                            '..', '..', 'version_label')
         with open(path) as f:
             return f.read().strip()
     except IOError:

--- a/dmutils/status.py
+++ b/dmutils/status.py
@@ -1,9 +1,11 @@
+import os
 import datetime
 from flask_featureflags import FEATURE_FLAGS_CONFIG
 
 
-def get_version_label(path):
+def get_version_label():
     try:
+        path = os.getcwd()
         with open(path) as f:
             return f.read().strip()
     except IOError:


### PR DESCRIPTION
Versions files are added to the root of each app when packaged for deploy.
Moving `get_version_label` to dmutils means it was looking for a relative path in the wrong place.  

Solution is for each app to pass its respective path.