### PR TITLE
`get_verison_label` accepts a path and returns a version

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,7 +2,7 @@ from . import logging, config, proxy_fix
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '0.19.0'
+__version__ = '0.20.0'
 
 
 def init_app(

--- a/dmutils/status.py
+++ b/dmutils/status.py
@@ -3,9 +3,9 @@ import datetime
 from flask_featureflags import FEATURE_FLAGS_CONFIG
 
 
-def get_version_label():
+def get_version_label(path):
     try:
-        path = os.getcwd()
+        path = os.path.join(path, 'version_label')
         with open(path) as f:
             return f.read().strip()
     except IOError:


### PR DESCRIPTION
`os.os.getcwd()` wasn't finding the right path to the version_label file, so each app can pass in its root directory and everything is going to work.

Was suggested by @allait after running into problems.