### PR TITLE
Require FeatureFlags extension from pypi

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,7 +2,7 @@ from . import logging, config, proxy_fix
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '0.20.0'
+__version__ = '0.21.0'
 
 
 def init_app(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ six==1.9.0
 requests==2.7.0
 pyyaml==3.11
 inflection==0.2.1
-# Flask-FeatureFlags==0.5.1
-git+https://github.com/pcraig3/Flask-FeatureFlags.git@master#egg=Flask-FeatureFlags==0.6-dev
+Flask-FeatureFlags==0.6


### PR DESCRIPTION
Pull request was merged with the fix we asked for, so we can require the extension as normal instead of relying on my custom forked version.

