### PR TITLE
Deny third-party sites embedding ours in an iframe

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,7 +2,7 @@ from . import logging, config, proxy_fix
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '0.22.0'
+__version__ = '0.23.0'
 
 
 def init_app(
@@ -40,3 +40,8 @@ def init_app(
         login_manager.init_app(application)
     if search_api_client:
         search_api_client.init_app(application)
+
+    @application.after_request
+    def add_header(response):
+        response.headers['X-Frame-Options'] = 'DENY'
+        return response


### PR DESCRIPTION
Added an `X-Frame-Options` to all headers which prevents any of our sites being embedded in an iframe by other sites.

Things to consider:
- We *could* set this at the server level if we wanted to make
this change more uniform. (Might be harder to test though)
- [The alphagov/whitehall team have set their public-facing headers
for their content to `ALLOWALL`](https://github.com/alphagov/whitehall/commit/9f8c7ccd1fdf7695e66b1340cb6b89ca0e134f9a), but @minglis says we're not going
to allow this at present for any of our sites.
