### PR TITLE
Add present_all method to presenters

### DIFF
--- a/dmutils/presenters.py
+++ b/dmutils/presenters.py
@@ -17,6 +17,12 @@ class Presenters(object):
         else:
             return value
 
+    def present_all(self, service_data, content):
+        return {
+            key: self.present(value, content.get_question(key))
+            for key, value in service_data.items()
+        }
+
     def _service_id(self, value):
         if re.findall("[a-zA-Z]", str(value)):
             return [value]

--- a/tests/test_presenters.py
+++ b/tests/test_presenters.py
@@ -1,12 +1,37 @@
 # coding=utf-8
 
 import unittest
+import mock
 
 from dmutils.presenters import Presenters
+from dmutils.content_loader import ContentLoader
 presenters = Presenters()
 
 
 class TestPresenters(unittest.TestCase):
+
+    def test_present_all(self):
+        content = mock.Mock()
+        content.get_question.return_value = {
+            "id": "id",
+            "type": "service_id"
+        }
+        self.assertEqual(
+            presenters.present_all(
+                {
+                    "id": "1234567891023456",
+                    "field_1": True,
+                    "field_2": "Cloud infrastructure"
+                },
+                content
+            ),
+            {
+                "id": ["1234", "5678", "9102", "3456"],
+                "field_1": [True],
+                "field_2": ["Cloud infrastructure"]
+            }
+        )
+
     def test_service_id(self):
         G5 = presenters.present(
             "5.G5.12345",


### PR DESCRIPTION
This commit adds a method to preseters which accepts:
- The entire data for a service
- A content object

It returns the data for the service, with each field transformed by the presenters.

This means that each app using the presenters doesn't have to loop through each item in the service data itself.