### PR TITLE
Make content loader handle dependencies

### DIFF
--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -8,14 +8,13 @@ class ContentLoader(object):
 
     def __init__(self, manifest, content_directory):
 
-        with open(manifest, "r") as file:
-            section_order = yaml.load(file)
+        section_order = self._read_yaml_file(manifest)
 
         self._directory = content_directory
         self._question_cache = {}
         self.sections = [
             self.__populate_section__(s) for s in section_order
-            ]
+        ]
 
     def get_section(self, requested_section):
 
@@ -29,12 +28,11 @@ class ContentLoader(object):
 
             question_file = self._directory + question + ".yml"
 
-            if not os.path.isfile(question_file):
+            if not self._yaml_file_exists(question_file):
                 self._question_cache[question] = {}
                 return {}
 
-            with open(question_file, "r") as file:
-                question_content = yaml.load(file)
+            question_content = self._read_yaml_file(question_file)
 
             question_content["id"] = question
 
@@ -49,16 +47,24 @@ class ContentLoader(object):
 
         return self._question_cache[question]
 
+    def _yaml_file_exists(self, yaml_file):
+        return os.path.isfile(yaml_file)
+
+    def _read_yaml_file(self, yaml_file):
+        with open(yaml_file, "r") as file:
+            question_content = yaml.load(file)
+            return question_content
+
     def __populate_section__(self, section):
         section["questions"] = [
             self.get_question(q) for q in section["questions"]
-            ]
+        ]
         all_dependencies = [
             q["depends_on_lots"] for q in section["questions"]
-            ]
+        ]
         section["depends_on_lots"] = [
             y for x in all_dependencies for y in x  # flatten array
-            ]
+        ]
         section["id"] = self.__make_id__(section["name"])
         return section
 

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -13,7 +13,7 @@ class ContentLoader(object):
         self._directory = content_directory
         self._question_cache = {}
         self._all_sections = [
-            self.__populate_section__(s) for s in section_order
+            self._populate_section(s) for s in section_order
         ]
         self.sections = self._all_sections
 
@@ -67,14 +67,14 @@ class ContentLoader(object):
             question_content = yaml.load(file)
             return question_content
 
-    def __populate_section__(self, section):
+    def _populate_section(self, section):
         section["questions"] = [
             self.get_question(q) for q in section["questions"]
         ]
-        section["id"] = self.__make_id__(section["name"])
+        section["id"] = self._make_id(section["name"])
         return section
 
-    def __make_id__(self, name):
+    def _make_id(self, name):
         return inflection.underscore(
             re.sub("\s", "_", name)
         )

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1,0 +1,49 @@
+# coding=utf-8
+
+import unittest
+import mock
+
+import os
+import tempfile
+import yaml
+
+from dmutils.content_loader import ContentLoader
+
+
+class MonkeyPatch:
+    def __init__(self, mocked_content=""):
+        self.mocked_content = mocked_content
+
+    def read_yaml_file(self, yaml_file):
+        return yaml.load(self.mocked_content[yaml_file])
+
+    def yaml_file_exists(self, file):
+        return True
+
+
+class TestContentLoader(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        ContentLoader._yaml_file_exists = MonkeyPatch().yaml_file_exists
+
+    def test_a_simple_question(self):
+        ContentLoader._read_yaml_file = MonkeyPatch({
+            "manifest.yml": """
+                -
+                  name: First section
+                  questions:
+                    - firstQuestion
+            """,
+            "folder/firstQuestion.yml": """
+                question: 'First question'
+                dependsOnLots: 'SaaS'
+            """
+        }).read_yaml_file
+        content = ContentLoader(
+            "manifest.yml",
+            "folder/"
+        )
+        self.assertEqual(
+            content.get_question("firstQuestion").get("question"),
+            "First question"
+        )

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -36,7 +36,6 @@ class TestContentLoader(unittest.TestCase):
             """,
             "folder/firstQuestion.yml": """
                 question: 'First question'
-                dependsOnLots: 'SaaS'
             """
         }).read_yaml_file
         content = ContentLoader(
@@ -46,4 +45,226 @@ class TestContentLoader(unittest.TestCase):
         self.assertEqual(
             content.get_question("firstQuestion").get("question"),
             "First question"
+        )
+
+    def test_a_question_with_a_dependency(self):
+        ContentLoader._read_yaml_file = MonkeyPatch({
+          "manifest.yml": """
+              -
+                name: First section
+                questions:
+                  - firstQuestion
+          """,
+          "folder/firstQuestion.yml": """
+                question: 'First question'
+                depends:
+                    -
+                      "on": lot
+                      being: SCS
+
+          """
+        }).read_yaml_file
+        content = ContentLoader(
+            "manifest.yml",
+            "folder/"
+        )
+        content.filter({
+            "lot": "SCS"
+        })
+        self.assertEqual(
+            len(content.sections),
+            1
+        )
+
+    def test_a_question_with_a_dependency_that_doesnt_match(self):
+        ContentLoader._read_yaml_file = MonkeyPatch({
+          "manifest.yml": """
+              -
+                name: First section
+                questions:
+                  - firstQuestion
+          """,
+          "folder/firstQuestion.yml": """
+            question: 'First question'
+            depends:
+                -
+                  "on": lot
+                  being: SCS
+          """
+        }).read_yaml_file
+        content = ContentLoader(
+            "manifest.yml",
+            "folder/"
+        )
+        content.filter({
+            "lot": "SaaS"
+        })
+        self.assertEqual(
+            len(content.sections),
+            0
+        )
+
+    def test_a_question_which_depends_on_one_of_several_answers(self):
+        ContentLoader._read_yaml_file = MonkeyPatch({
+          "manifest.yml": """
+              -
+                name: First section
+                questions:
+                  - firstQuestion
+          """,
+          "firstQuestion.yml": """
+                question: 'First question'
+                depends:
+                    -
+                      "on": lot
+                      being:
+                       - SCS
+                       - SaaS
+                       - PaaS
+
+          """
+        }).read_yaml_file
+        content = ContentLoader(
+            "manifest.yml",
+            "folder/"
+        )
+        content.filter({
+            "lot": "SaaS"
+        })
+        self.assertEqual(
+            len(content.sections),
+            1
+        )
+
+    def test_a_question_which_depends_on_one_of_several_answers(self):
+        ContentLoader._read_yaml_file = MonkeyPatch({
+          "manifest.yml": """
+              -
+                name: First section
+                questions:
+                  - firstQuestion
+          """,
+          "folder/firstQuestion.yml": """
+                question: 'First question'
+                depends:
+                    -
+                      "on": lot
+                      being:
+                       - SCS
+                       - SaaS
+                       - PaaS
+
+          """
+        }).read_yaml_file
+        content = ContentLoader(
+            "manifest.yml",
+            "folder/"
+        )
+        content.filter({
+            "lot": "IaaS"
+        })
+        self.assertEqual(
+            len(content.sections),
+            0
+        )
+
+    def test_a_section_which_has_a_mixture_of_dependencies(self):
+        ContentLoader._read_yaml_file = MonkeyPatch({
+          "manifest.yml": """
+              -
+                name: First section
+                questions:
+                  - firstQuestion
+                  - secondQuestion
+              -
+                name: Second section
+                questions:
+                  - firstQuestion
+          """,
+          "folder/firstQuestion.yml": """
+                question: 'First question'
+                depends:
+                    -
+                      "on": lot
+                      being:
+                       - SCS
+                       - SaaS
+                       - PaaS
+          """,
+          "folder/secondQuestion.yml": """
+                question: 'Second question'
+                depends:
+                    -
+                      "on": lot
+                      being: IaaS
+
+          """
+        }).read_yaml_file
+        content = ContentLoader(
+            "manifest.yml",
+            "folder/"
+        )
+        content.filter({
+            "lot": "IaaS"
+        })
+        self.assertEqual(
+            len(content.sections),
+            1
+        )
+
+    def test_that_filtering_isnt_cumulative(self):
+        ContentLoader._read_yaml_file = MonkeyPatch({
+          "manifest.yml": """
+              -
+                name: First section
+                questions:
+                  - firstQuestion
+              -
+                name: Second section
+                questions:
+                  - secondQuestion
+          """,
+          "folder/firstQuestion.yml": """
+                question: 'First question'
+                depends:
+                    -
+                      "on": lot
+                      being: IaaS
+          """,
+          "folder/secondQuestion.yml": """
+                question: 'Second question'
+                depends:
+                    -
+                      "on": lot
+                      being: PaaS
+
+          """
+        }).read_yaml_file
+        content = ContentLoader(
+            "manifest.yml",
+            "folder/"
+        )
+
+        content.filter({
+            "lot": "IaaS"
+        })
+        self.assertEqual(
+            len(content.sections),
+            1
+        )
+
+        content.filter({
+            "lot": "PaaS"
+        })
+        self.assertEqual(
+            len(content.sections),
+            1
+        )
+
+        content.filter({
+            "lot": "SCS"
+        })
+        self.assertEqual(
+            len(content.sections),
+            0
         )

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -10,25 +10,18 @@ import yaml
 from dmutils.content_loader import ContentLoader
 
 
-class MockedYamlFiles:
-    def __init__(self, mocked_content=""):
-        self.mocked_content = mocked_content
-
-    def read(self, yaml_file):
-        return yaml.load(self.mocked_content[yaml_file])
+def get_mocked_yaml_reader(mocked_content={}):
+    def read(yaml_file):
+        return yaml.load(mocked_content[yaml_file])
+    return read
 
 
 class TestContentLoader(unittest.TestCase):
 
-    def setUp(self):
-        ContentLoader._yaml_file_exists = mock.patch(
-            "ContentLoader._yaml_file_exists",
-            return_value=True
-        )
-
-    @mock.patch("dmutils.content_loader.ContentLoader._read_yaml_file")
-    def test_a_simple_question(self, mocked_read_yaml_file):
-        mocked_read_yaml_file.side_effect = MockedYamlFiles({
+    @mock.patch("dmutils.content_loader.ContentLoader._yaml_file_exists")
+    @mock.patch(
+        "dmutils.content_loader.ContentLoader._read_yaml_file",
+        side_effect=get_mocked_yaml_reader({
             "manifest.yml": """
                 -
                   name: First section
@@ -38,8 +31,11 @@ class TestContentLoader(unittest.TestCase):
             "folder/firstQuestion.yml": """
                 question: 'First question'
             """
-        }).read
-
+        })
+    )
+    def test_a_simple_question(
+        self, mocked_read_yaml_file, mocked_yaml_file_exists
+    ):
         content = ContentLoader(
             "manifest.yml",
             "folder/"
@@ -49,9 +45,10 @@ class TestContentLoader(unittest.TestCase):
             "First question"
         )
 
-    @mock.patch("dmutils.content_loader.ContentLoader._read_yaml_file")
-    def test_a_question_with_a_dependency(self, mocked_read_yaml_file):
-        mocked_read_yaml_file.side_effect = MockedYamlFiles({
+    @mock.patch("dmutils.content_loader.ContentLoader._yaml_file_exists")
+    @mock.patch(
+        "dmutils.content_loader.ContentLoader._read_yaml_file",
+        side_effect=get_mocked_yaml_reader({
           "manifest.yml": """
               -
                 name: First section
@@ -66,7 +63,11 @@ class TestContentLoader(unittest.TestCase):
                       being: SCS
 
           """
-        }).read
+        })
+    )
+    def test_a_question_with_a_dependency(
+        self, mocked_read_yaml_file, mocked_yaml_file_exists
+    ):
         content = ContentLoader(
             "manifest.yml",
             "folder/"
@@ -79,11 +80,10 @@ class TestContentLoader(unittest.TestCase):
             1
         )
 
-    @mock.patch("dmutils.content_loader.ContentLoader._read_yaml_file")
-    def test_a_question_with_a_dependency_that_doesnt_match(
-        self, mocked_read_yaml_file
-    ):
-        mocked_read_yaml_file.side_effect = MockedYamlFiles({
+    @mock.patch("dmutils.content_loader.ContentLoader._yaml_file_exists")
+    @mock.patch(
+        "dmutils.content_loader.ContentLoader._read_yaml_file",
+        side_effect=get_mocked_yaml_reader({
           "manifest.yml": """
               -
                 name: First section
@@ -97,7 +97,11 @@ class TestContentLoader(unittest.TestCase):
                   "on": lot
                   being: SCS
           """
-        }).read
+        })
+    )
+    def test_a_question_with_a_dependency_that_doesnt_match(
+        self, mocked_read_yaml_file, mocked_yaml_file_exists
+    ):
         content = ContentLoader(
             "manifest.yml",
             "folder/"
@@ -110,11 +114,10 @@ class TestContentLoader(unittest.TestCase):
             0
         )
 
-    @mock.patch("dmutils.content_loader.ContentLoader._read_yaml_file")
-    def ftest_a_question_which_depends_on_one_of_several_answers(
-        self, mocked_read_yaml_file
-    ):
-        mocked_read_yaml_file.side_effect = MockedYamlFiles({
+    @mock.patch("dmutils.content_loader.ContentLoader._yaml_file_exists")
+    @mock.patch(
+        "dmutils.content_loader.ContentLoader._read_yaml_file",
+        side_effect=get_mocked_yaml_reader({
           "manifest.yml": """
               -
                 name: First section
@@ -132,7 +135,11 @@ class TestContentLoader(unittest.TestCase):
                        - PaaS
 
           """
-        }).read
+        })
+    )
+    def test_a_question_which_depends_on_one_of_several_answers(
+        self, mocked_read_yaml_file, mocked_yaml_file_exists
+    ):
         content = ContentLoader(
             "manifest.yml",
             "folder/"
@@ -145,11 +152,10 @@ class TestContentLoader(unittest.TestCase):
             1
         )
 
-    @mock.patch("dmutils.content_loader.ContentLoader._read_yaml_file")
-    def test_a_question_which_depends_on_one_of_several_answers(
-        self, mocked_read_yaml_file
-    ):
-        mocked_read_yaml_file.side_effect = MockedYamlFiles({
+    @mock.patch("dmutils.content_loader.ContentLoader._yaml_file_exists")
+    @mock.patch(
+        "dmutils.content_loader.ContentLoader._read_yaml_file",
+        side_effect=get_mocked_yaml_reader({
           "manifest.yml": """
               -
                 name: First section
@@ -167,7 +173,11 @@ class TestContentLoader(unittest.TestCase):
                        - PaaS
 
           """
-        }).read
+        })
+    )
+    def test_a_question_which_depends_on_one_of_several_answers(
+        self, mocked_read_yaml_file, mocked_yaml_file_exists
+    ):
         content = ContentLoader(
             "manifest.yml",
             "folder/"
@@ -180,11 +190,10 @@ class TestContentLoader(unittest.TestCase):
             0
         )
 
-    @mock.patch("dmutils.content_loader.ContentLoader._read_yaml_file")
-    def test_a_section_which_has_a_mixture_of_dependencies(
-        self, mocked_read_yaml_file
-    ):
-        mocked_read_yaml_file.side_effect = MockedYamlFiles({
+    @mock.patch("dmutils.content_loader.ContentLoader._yaml_file_exists")
+    @mock.patch(
+        "dmutils.content_loader.ContentLoader._read_yaml_file",
+        side_effect=get_mocked_yaml_reader({
           "manifest.yml": """
               -
                 name: First section
@@ -214,7 +223,11 @@ class TestContentLoader(unittest.TestCase):
                       being: IaaS
 
           """
-        }).read
+        })
+    )
+    def test_a_section_which_has_a_mixture_of_dependencies(
+        self, mocked_read_yaml_file, mocked_yaml_file_exists
+    ):
         content = ContentLoader(
             "manifest.yml",
             "folder/"
@@ -227,11 +240,10 @@ class TestContentLoader(unittest.TestCase):
             1
         )
 
-    @mock.patch("dmutils.content_loader.ContentLoader._read_yaml_file")
-    def test_that_filtering_isnt_cumulative(
-        self, mocked_read_yaml_file
-    ):
-        mocked_read_yaml_file.side_effect = MockedYamlFiles({
+    @mock.patch("dmutils.content_loader.ContentLoader._yaml_file_exists")
+    @mock.patch(
+        "dmutils.content_loader.ContentLoader._read_yaml_file",
+        side_effect=get_mocked_yaml_reader({
           "manifest.yml": """
               -
                 name: First section
@@ -257,7 +269,11 @@ class TestContentLoader(unittest.TestCase):
                       being: PaaS
 
           """
-        }).read
+        })
+    )
+    def test_that_filtering_isnt_cumulative(
+        self, mocked_read_yaml_file, mocked_yaml_file_exists
+    ):
         content = ContentLoader(
             "manifest.yml",
             "folder/"

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -10,24 +10,25 @@ import yaml
 from dmutils.content_loader import ContentLoader
 
 
-class MonkeyPatch:
+class MockedYamlFiles:
     def __init__(self, mocked_content=""):
         self.mocked_content = mocked_content
 
-    def read_yaml_file(self, yaml_file):
+    def read(self, yaml_file):
         return yaml.load(self.mocked_content[yaml_file])
-
-    def yaml_file_exists(self, file):
-        return True
 
 
 class TestContentLoader(unittest.TestCase):
-    @classmethod
-    def setUpClass(self):
-        ContentLoader._yaml_file_exists = MonkeyPatch().yaml_file_exists
 
-    def test_a_simple_question(self):
-        ContentLoader._read_yaml_file = MonkeyPatch({
+    def setUp(self):
+        ContentLoader._yaml_file_exists = mock.patch(
+            "ContentLoader._yaml_file_exists",
+            return_value=True
+        )
+
+    @mock.patch("dmutils.content_loader.ContentLoader._read_yaml_file")
+    def test_a_simple_question(self, mocked_read_yaml_file):
+        mocked_read_yaml_file.side_effect = MockedYamlFiles({
             "manifest.yml": """
                 -
                   name: First section
@@ -37,7 +38,8 @@ class TestContentLoader(unittest.TestCase):
             "folder/firstQuestion.yml": """
                 question: 'First question'
             """
-        }).read_yaml_file
+        }).read
+
         content = ContentLoader(
             "manifest.yml",
             "folder/"
@@ -47,8 +49,9 @@ class TestContentLoader(unittest.TestCase):
             "First question"
         )
 
-    def test_a_question_with_a_dependency(self):
-        ContentLoader._read_yaml_file = MonkeyPatch({
+    @mock.patch("dmutils.content_loader.ContentLoader._read_yaml_file")
+    def test_a_question_with_a_dependency(self, mocked_read_yaml_file):
+        mocked_read_yaml_file.side_effect = MockedYamlFiles({
           "manifest.yml": """
               -
                 name: First section
@@ -63,7 +66,7 @@ class TestContentLoader(unittest.TestCase):
                       being: SCS
 
           """
-        }).read_yaml_file
+        }).read
         content = ContentLoader(
             "manifest.yml",
             "folder/"
@@ -76,8 +79,11 @@ class TestContentLoader(unittest.TestCase):
             1
         )
 
-    def test_a_question_with_a_dependency_that_doesnt_match(self):
-        ContentLoader._read_yaml_file = MonkeyPatch({
+    @mock.patch("dmutils.content_loader.ContentLoader._read_yaml_file")
+    def test_a_question_with_a_dependency_that_doesnt_match(
+        self, mocked_read_yaml_file
+    ):
+        mocked_read_yaml_file.side_effect = MockedYamlFiles({
           "manifest.yml": """
               -
                 name: First section
@@ -91,7 +97,7 @@ class TestContentLoader(unittest.TestCase):
                   "on": lot
                   being: SCS
           """
-        }).read_yaml_file
+        }).read
         content = ContentLoader(
             "manifest.yml",
             "folder/"
@@ -104,8 +110,11 @@ class TestContentLoader(unittest.TestCase):
             0
         )
 
-    def test_a_question_which_depends_on_one_of_several_answers(self):
-        ContentLoader._read_yaml_file = MonkeyPatch({
+    @mock.patch("dmutils.content_loader.ContentLoader._read_yaml_file")
+    def ftest_a_question_which_depends_on_one_of_several_answers(
+        self, mocked_read_yaml_file
+    ):
+        mocked_read_yaml_file.side_effect = MockedYamlFiles({
           "manifest.yml": """
               -
                 name: First section
@@ -123,7 +132,7 @@ class TestContentLoader(unittest.TestCase):
                        - PaaS
 
           """
-        }).read_yaml_file
+        }).read
         content = ContentLoader(
             "manifest.yml",
             "folder/"
@@ -136,8 +145,11 @@ class TestContentLoader(unittest.TestCase):
             1
         )
 
-    def test_a_question_which_depends_on_one_of_several_answers(self):
-        ContentLoader._read_yaml_file = MonkeyPatch({
+    @mock.patch("dmutils.content_loader.ContentLoader._read_yaml_file")
+    def test_a_question_which_depends_on_one_of_several_answers(
+        self, mocked_read_yaml_file
+    ):
+        mocked_read_yaml_file.side_effect = MockedYamlFiles({
           "manifest.yml": """
               -
                 name: First section
@@ -155,7 +167,7 @@ class TestContentLoader(unittest.TestCase):
                        - PaaS
 
           """
-        }).read_yaml_file
+        }).read
         content = ContentLoader(
             "manifest.yml",
             "folder/"
@@ -168,8 +180,11 @@ class TestContentLoader(unittest.TestCase):
             0
         )
 
-    def test_a_section_which_has_a_mixture_of_dependencies(self):
-        ContentLoader._read_yaml_file = MonkeyPatch({
+    @mock.patch("dmutils.content_loader.ContentLoader._read_yaml_file")
+    def test_a_section_which_has_a_mixture_of_dependencies(
+        self, mocked_read_yaml_file
+    ):
+        mocked_read_yaml_file.side_effect = MockedYamlFiles({
           "manifest.yml": """
               -
                 name: First section
@@ -199,7 +214,7 @@ class TestContentLoader(unittest.TestCase):
                       being: IaaS
 
           """
-        }).read_yaml_file
+        }).read
         content = ContentLoader(
             "manifest.yml",
             "folder/"
@@ -212,8 +227,11 @@ class TestContentLoader(unittest.TestCase):
             1
         )
 
-    def test_that_filtering_isnt_cumulative(self):
-        ContentLoader._read_yaml_file = MonkeyPatch({
+    @mock.patch("dmutils.content_loader.ContentLoader._read_yaml_file")
+    def test_that_filtering_isnt_cumulative(
+        self, mocked_read_yaml_file
+    ):
+        mocked_read_yaml_file.side_effect = MockedYamlFiles({
           "manifest.yml": """
               -
                 name: First section
@@ -239,7 +257,7 @@ class TestContentLoader(unittest.TestCase):
                       being: PaaS
 
           """
-        }).read_yaml_file
+        }).read
         content = ContentLoader(
             "manifest.yml",
             "folder/"

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -16,12 +16,14 @@ def get_mocked_yaml_reader(mocked_content={}):
     return read
 
 
+@mock.patch("dmutils.content_loader.ContentLoader._yaml_file_exists")
+@mock.patch("dmutils.content_loader.ContentLoader._read_yaml_file")
 class TestContentLoader(unittest.TestCase):
 
-    @mock.patch("dmutils.content_loader.ContentLoader._yaml_file_exists")
-    @mock.patch(
-        "dmutils.content_loader.ContentLoader._read_yaml_file",
-        side_effect=get_mocked_yaml_reader({
+    def test_a_simple_question(
+        self, mocked_read_yaml_file, mocked_yaml_file_exists
+    ):
+        mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({
             "manifest.yml": """
                 -
                   name: First section
@@ -32,10 +34,6 @@ class TestContentLoader(unittest.TestCase):
                 question: 'First question'
             """
         })
-    )
-    def test_a_simple_question(
-        self, mocked_read_yaml_file, mocked_yaml_file_exists
-    ):
         content = ContentLoader(
             "manifest.yml",
             "folder/"
@@ -45,10 +43,10 @@ class TestContentLoader(unittest.TestCase):
             "First question"
         )
 
-    @mock.patch("dmutils.content_loader.ContentLoader._yaml_file_exists")
-    @mock.patch(
-        "dmutils.content_loader.ContentLoader._read_yaml_file",
-        side_effect=get_mocked_yaml_reader({
+    def test_a_question_with_a_dependency(
+        self, mocked_read_yaml_file, mocked_yaml_file_exists
+    ):
+        mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({
           "manifest.yml": """
               -
                 name: First section
@@ -64,10 +62,6 @@ class TestContentLoader(unittest.TestCase):
 
           """
         })
-    )
-    def test_a_question_with_a_dependency(
-        self, mocked_read_yaml_file, mocked_yaml_file_exists
-    ):
         content = ContentLoader(
             "manifest.yml",
             "folder/"
@@ -80,10 +74,10 @@ class TestContentLoader(unittest.TestCase):
             1
         )
 
-    @mock.patch("dmutils.content_loader.ContentLoader._yaml_file_exists")
-    @mock.patch(
-        "dmutils.content_loader.ContentLoader._read_yaml_file",
-        side_effect=get_mocked_yaml_reader({
+    def test_a_question_with_a_dependency_that_doesnt_match(
+        self, mocked_read_yaml_file, mocked_yaml_file_exists
+    ):
+        mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({
           "manifest.yml": """
               -
                 name: First section
@@ -98,10 +92,6 @@ class TestContentLoader(unittest.TestCase):
                   being: SCS
           """
         })
-    )
-    def test_a_question_with_a_dependency_that_doesnt_match(
-        self, mocked_read_yaml_file, mocked_yaml_file_exists
-    ):
         content = ContentLoader(
             "manifest.yml",
             "folder/"
@@ -114,10 +104,10 @@ class TestContentLoader(unittest.TestCase):
             0
         )
 
-    @mock.patch("dmutils.content_loader.ContentLoader._yaml_file_exists")
-    @mock.patch(
-        "dmutils.content_loader.ContentLoader._read_yaml_file",
-        side_effect=get_mocked_yaml_reader({
+    def test_a_question_which_depends_on_one_of_several_answers(
+        self, mocked_read_yaml_file, mocked_yaml_file_exists
+    ):
+        mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({
           "manifest.yml": """
               -
                 name: First section
@@ -136,10 +126,6 @@ class TestContentLoader(unittest.TestCase):
 
           """
         })
-    )
-    def test_a_question_which_depends_on_one_of_several_answers(
-        self, mocked_read_yaml_file, mocked_yaml_file_exists
-    ):
         content = ContentLoader(
             "manifest.yml",
             "folder/"
@@ -152,10 +138,10 @@ class TestContentLoader(unittest.TestCase):
             1
         )
 
-    @mock.patch("dmutils.content_loader.ContentLoader._yaml_file_exists")
-    @mock.patch(
-        "dmutils.content_loader.ContentLoader._read_yaml_file",
-        side_effect=get_mocked_yaml_reader({
+    def test_a_question_which_depends_on_one_of_several_answers(
+        self, mocked_read_yaml_file, mocked_yaml_file_exists
+    ):
+        mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({
           "manifest.yml": """
               -
                 name: First section
@@ -174,10 +160,6 @@ class TestContentLoader(unittest.TestCase):
 
           """
         })
-    )
-    def test_a_question_which_depends_on_one_of_several_answers(
-        self, mocked_read_yaml_file, mocked_yaml_file_exists
-    ):
         content = ContentLoader(
             "manifest.yml",
             "folder/"
@@ -190,10 +172,10 @@ class TestContentLoader(unittest.TestCase):
             0
         )
 
-    @mock.patch("dmutils.content_loader.ContentLoader._yaml_file_exists")
-    @mock.patch(
-        "dmutils.content_loader.ContentLoader._read_yaml_file",
-        side_effect=get_mocked_yaml_reader({
+    def test_a_section_which_has_a_mixture_of_dependencies(
+        self, mocked_read_yaml_file, mocked_yaml_file_exists
+    ):
+        mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({
           "manifest.yml": """
               -
                 name: First section
@@ -224,10 +206,6 @@ class TestContentLoader(unittest.TestCase):
 
           """
         })
-    )
-    def test_a_section_which_has_a_mixture_of_dependencies(
-        self, mocked_read_yaml_file, mocked_yaml_file_exists
-    ):
         content = ContentLoader(
             "manifest.yml",
             "folder/"
@@ -240,10 +218,10 @@ class TestContentLoader(unittest.TestCase):
             1
         )
 
-    @mock.patch("dmutils.content_loader.ContentLoader._yaml_file_exists")
-    @mock.patch(
-        "dmutils.content_loader.ContentLoader._read_yaml_file",
-        side_effect=get_mocked_yaml_reader({
+    def test_that_filtering_isnt_cumulative(
+        self, mocked_read_yaml_file, mocked_yaml_file_exists
+    ):
+        mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({
           "manifest.yml": """
               -
                 name: First section
@@ -270,10 +248,6 @@ class TestContentLoader(unittest.TestCase):
 
           """
         })
-    )
-    def test_that_filtering_isnt_cumulative(
-        self, mocked_read_yaml_file, mocked_yaml_file_exists
-    ):
         content = ContentLoader(
             "manifest.yml",
             "folder/"


### PR DESCRIPTION
The format of the question content has changed from this:
``` yaml
question: "What is your service name?"
dependsOnLots: "SaaS, PaaS"
```

to this:

``` yaml
question: "What is your service name?"
depends:
  -
    "on": "lot"
    "being":
      - SaaS
      - PaaS
```

(alphagov/digital-marketplace-ssp-content#42)

This pull request adds a `filter` method to the content loader, which works like this:
``` python
  content.filter({
    "lot": "SaaS",
    "serviceName": "My first service",
    …
  })
```

Getting `content.sections` will then have only the questions relevant to the
current service, which means that the views don't have to do this kind of thing:
``` jinja
{% if service_data['lot']|lower in question['depends_on_lots'] %}
```

This pull request also adds tests, which the content loader did not previously have.

_This represents a breaking change and so releasing it will have to be reflected in the version number of utils_