### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,7 +2,7 @@ from . import logging, config, proxy_fix
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '0.23.0'
+__version__ = '1.0.0'
 
 
 def init_app(


### PR DESCRIPTION
Includes:
-  #62 test-for-content-loader-handling
-  #61 add-present-all-to-presenters

There are breaking changes to `dmutils.content_loader`. Any apps that use this class will need to update their version of the SSP content to https://github.com/alphagov/digital-marketplace-ssp-content/commit/39b766e5660a5af6d95dd24d02b36cd49bda9700 in order to still work.