### PR TITLE
Standardize our datetime format.

### DIFF
--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -1,0 +1,1 @@
+DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S%Z"


### PR DESCRIPTION
Add a datetime format to utils so that we don't end up coming up with different formats across different apps.

<sub>Which definitely hasn't already happened.</sub>