### PR TITLE
Gracefully handle questions without dependencies

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,7 +2,7 @@ from . import logging, config, proxy_fix
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 
 def init_app(

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -80,6 +80,8 @@ class ContentLoader(object):
         )
 
     def _question_should_be_shown(self, dependencies, service_data):
+        if dependencies is None:
+            return True
         for depends in dependencies:
             if not service_data[depends["on"]] in depends["being"]:
                 return False


### PR DESCRIPTION
Some attributes of a service (`lot`, `service_id`) don't have dependencies. Dependencies shouldn't be mandatory, so this commit handles the case where they are not specified.