### PR TITLE
Content loader shouldn't require service attributes

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,7 +2,7 @@ from . import logging, config, proxy_fix
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 
 def init_app(

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -83,6 +83,8 @@ class ContentLoader(object):
         if dependencies is None:
             return True
         for depends in dependencies:
+            if not depends["on"] in service_data:
+                return False
             if not service_data[depends["on"]] in depends["being"]:
                 return False
         return True


### PR DESCRIPTION
Currently, if the display of a question is dependent on, for example, the `lot` of a service then `service_data.lot` must be defined.

This isn't a problem in real-world scenarios, because services always have lots.

It is, however, a problem when mocking a `get_service` call for testing.

This pull request adds a line to catch any 'services' that don't have set the parameter that a question depends on.