### PR TITLE
Make content loader thread safe

### DIFF
--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -12,10 +12,9 @@ class ContentLoader(object):
 
         self._directory = content_directory
         self._question_cache = {}
-        self._all_sections = [
+        self.sections = [
             self._populate_section(s) for s in section_order
         ]
-        self.sections = self._all_sections
 
     def get_section(self, requested_section):
 
@@ -34,30 +33,35 @@ class ContentLoader(object):
                 return {}
 
             question_content = self._read_yaml_file(question_file)
-
             question_content["id"] = question
-
             self._question_cache[question] = question_content
 
         return self._question_cache[question]
 
-    def filter(self, service_data):
+    def get_sections_filtered_by(self, service_data):
+        return [
+            section for section in [
+                self.get_section_filtered_by(section["id"], service_data)
+                for section in self.sections
+            ] if section is not None
+        ]
 
-        self.sections = self._all_sections
-        filtered_sections = []
+    def get_section_filtered_by(self, section_id, service_data):
 
-        for section in self.sections:
-            filtered_questions = []
-            for question in section["questions"]:
-                if self._question_should_be_shown(
-                    question.get("depends"), service_data
-                ):
-                    filtered_questions.append(question)
-            if len(filtered_questions):
-                section["questions"] = filtered_questions
-                filtered_sections.append(section)
+        section = self.get_section(section_id)
 
-        self.sections = filtered_sections
+        filtered_questions = [
+            question for question in section["questions"]
+            if self._question_should_be_shown(
+                question.get("depends"), service_data
+            )
+        ]
+
+        if len(filtered_questions):
+            section["questions"] = filtered_questions
+            return section
+        else:
+            return None
 
     def _yaml_file_exists(self, yaml_file):
         return os.path.isfile(yaml_file)

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -66,11 +66,11 @@ class TestContentLoader(unittest.TestCase):
             "manifest.yml",
             "folder/"
         )
-        content.filter({
+        sections = content.get_sections_filtered_by({
             "lot": "SCS"
         })
         self.assertEqual(
-            len(content.sections),
+            len(sections),
             1
         )
 
@@ -96,11 +96,11 @@ class TestContentLoader(unittest.TestCase):
             "manifest.yml",
             "folder/"
         )
-        content.filter({
+        sections = content.get_sections_filtered_by({
             "lot": "SaaS"
         })
         self.assertEqual(
-            len(content.sections),
+            len(sections),
             0
         )
 
@@ -130,11 +130,11 @@ class TestContentLoader(unittest.TestCase):
             "manifest.yml",
             "folder/"
         )
-        content.filter({
+        sections = content.get_sections_filtered_by({
             "lot": "SaaS"
         })
         self.assertEqual(
-            len(content.sections),
+            len(sections),
             1
         )
 
@@ -164,11 +164,11 @@ class TestContentLoader(unittest.TestCase):
             "manifest.yml",
             "folder/"
         )
-        content.filter({
+        sections = content.get_sections_filtered_by({
             "lot": "IaaS"
         })
         self.assertEqual(
-            len(content.sections),
+            len(sections),
             0
         )
 
@@ -210,11 +210,11 @@ class TestContentLoader(unittest.TestCase):
             "manifest.yml",
             "folder/"
         )
-        content.filter({
+        sections = content.get_sections_filtered_by({
             "lot": "IaaS"
         })
         self.assertEqual(
-            len(content.sections),
+            len(sections),
             1
         )
 
@@ -253,26 +253,26 @@ class TestContentLoader(unittest.TestCase):
             "folder/"
         )
 
-        content.filter({
+        sections = content.get_sections_filtered_by({
             "lot": "IaaS"
         })
         self.assertEqual(
-            len(content.sections),
+            len(sections),
             1
         )
 
-        content.filter({
+        sections = content.get_sections_filtered_by({
             "lot": "PaaS"
         })
         self.assertEqual(
-            len(content.sections),
+            len(sections),
             1
         )
 
-        content.filter({
+        sections = content.get_sections_filtered_by({
             "lot": "SCS"
         })
         self.assertEqual(
-            len(content.sections),
+            len(sections),
             0
         )


### PR DESCRIPTION
## Currently, `content_loader` is used like this:
``` python
content = ContentLoader("manifest.yml", "question_folder/")
content.filter({"lot": "SaaS"})
print(content.sections)
```
…which is potentially not thread safe, because the state of `content.sections` could be changed by another, simultaneous, request. It also means that every user of content_loader would have to remember to run `.filter()` before accessing the content, just in case some previous request had filtered it by a different lot.

## This pull request
- removes .filter() method
- adds new methods (`get_sections_filtered_by()`, `get_section_filtered_by()`)
which return the content to the request using it, meaning that it cant be
changed by anything outside the scope of that request.

## New usage
``` python
content = ContentLoader("manifest.yml", "question_folder/")
print(content.get_sections_filtered_by({"lot": "SaaS"}))
```