### PR TITLE
Bump version to 1.0.3

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,7 +2,7 @@ from . import logging, config, proxy_fix
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 
 
 def init_app(


### PR DESCRIPTION
Includes:
- #71 make-content-loader-thread-safe

I think this is a patch, not major change because it's a bugfix in something that no apps were yet using.