### PR TITLE
Add .get_next_section_id() method to content loader

### DIFF
--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -4,14 +4,14 @@ import re
 import os
 
 
-class ContentLoader(object):
+class ContentBuilder(object):
 
-    def __init__(self, manifest, content_directory):
+    def __init__(self, manifest, content_directory, yaml_loader):
 
-        section_order = self._read_yaml_file(manifest)
-
+        self.yaml_loader = yaml_loader
+        section_order = yaml_loader.read(manifest)
         self._directory = content_directory
-        self._question_cache = {}
+
         self.sections = [
             self._populate_section(s) for s in section_order
         ]
@@ -23,20 +23,7 @@ class ContentLoader(object):
                 return section
 
     def get_question(self, question):
-
-        if question not in self._question_cache:
-
-            question_file = self._directory + question + ".yml"
-
-            if not self._yaml_file_exists(question_file):
-                self._question_cache[question] = {}
-                return {}
-
-            question_content = self._read_yaml_file(question_file)
-            question_content["id"] = question
-            self._question_cache[question] = question_content
-
-        return self._question_cache[question]
+        return self.yaml_loader.read(self._directory + question + ".yml")
 
     def get_sections_filtered_by(self, service_data):
         return [
@@ -75,14 +62,6 @@ class ContentLoader(object):
 
         return None
 
-    def _yaml_file_exists(self, yaml_file):
-        return os.path.isfile(yaml_file)
-
-    def _read_yaml_file(self, yaml_file):
-        with open(yaml_file, "r") as file:
-            question_content = yaml.load(file)
-            return question_content
-
     def _populate_section(self, section):
         section["questions"] = [
             self.get_question(q) for q in section["questions"]
@@ -104,3 +83,17 @@ class ContentLoader(object):
             if not service_data[depends["on"]] in depends["being"]:
                 return False
         return True
+
+
+class YAMLLoader(object):
+
+    def __init__(self):
+        self._cache = []
+
+    def read(self, yaml_file):
+        if yaml_file not in self._cache:
+            if not os.path.isfile(yaml_file):
+                return None
+            with open(yaml_file, "r") as file:
+                self._cache[yaml_file] = yaml.load(file)
+        return self._cache[yaml_file]

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -63,6 +63,18 @@ class ContentLoader(object):
         else:
             return None
 
+    def get_next_section_id(self, section_id, sections):
+
+        previous_section_is_current = False
+
+        for section in sections:
+            if previous_section_is_current:
+                return section["id"]
+            if section["id"] == section_id:
+                previous_section_is_current = True
+
+        return None
+
     def _yaml_file_exists(self, yaml_file):
         return os.path.isfile(yaml_file)
 

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -58,12 +58,14 @@ class ContentBuilder(object):
         ]
 
         if len(filtered_questions):
-            section["questions"] = filtered_questions
-            return section
+            filtered_section = section.copy()
+            filtered_section["questions"] = filtered_questions
+            return filtered_section
         else:
             return None
 
     def _populate_section(self, section):
+        section = section.copy()
         section["questions"] = [
             self.get_question(q) for q in section["questions"]
         ]
@@ -93,8 +95,6 @@ class YAMLLoader(object):
 
     def read(self, yaml_file):
         if yaml_file not in self._cache:
-            if not os.path.isfile(yaml_file):
-                return None
             with open(yaml_file, "r") as file:
                 self._cache[yaml_file] = yaml.load(file)
         return self._cache[yaml_file]

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -89,7 +89,7 @@ class ContentBuilder(object):
 class YAMLLoader(object):
 
     def __init__(self):
-        self._cache = []
+        self._cache = {}
 
     def read(self, yaml_file):
         if yaml_file not in self._cache:

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -276,3 +276,46 @@ class TestContentLoader(unittest.TestCase):
             len(sections),
             0
         )
+
+    def test_get_next_section(
+        self, mocked_read_yaml_file, mocked_yaml_file_exists
+    ):
+        mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({
+            "manifest.yml": """
+              -
+                name: First section
+                questions:
+                  - firstQuestion
+              -
+                name: Second section
+                questions:
+                  - firstQuestion
+              -
+                name: Third section
+                questions:
+                  - firstQuestion
+            """,
+            "folder/firstQuestion.yml": "question: 'First question'"
+        })
+
+        content = ContentLoader(
+            "manifest.yml",
+            "folder/"
+        )
+
+        sections = content.sections
+
+        self.assertEqual(
+            content.get_next_section_id("first_section", sections),
+            "second_section"
+        )
+
+        self.assertEqual(
+            content.get_next_section_id("second_section", sections),
+            "third_section"
+        )
+
+        self.assertEqual(
+            content.get_next_section_id("third_section", sections),
+            None
+        )

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -63,11 +63,11 @@ class TestContentLoader(unittest.TestCase):
             "folder/",
             YAMLLoader()
         )
-        sections = content.get_sections_filtered_by({
+        content.filter({
             "lot": "SCS"
         })
         self.assertEqual(
-            len(sections),
+            len(content.sections),
             1
         )
 
@@ -94,11 +94,11 @@ class TestContentLoader(unittest.TestCase):
             "folder/",
             YAMLLoader()
         )
-        sections = content.get_sections_filtered_by({
+        content.filter({
             "lot": "SaaS"
         })
         self.assertEqual(
-            len(sections),
+            len(content.sections),
             0
         )
 
@@ -129,11 +129,11 @@ class TestContentLoader(unittest.TestCase):
             "folder/",
             YAMLLoader()
         )
-        sections = content.get_sections_filtered_by({
+        content.filter({
             "lot": "SaaS"
         })
         self.assertEqual(
-            len(sections),
+            len(content.sections),
             1
         )
 
@@ -164,11 +164,11 @@ class TestContentLoader(unittest.TestCase):
             "folder/",
             YAMLLoader()
         )
-        sections = content.get_sections_filtered_by({
+        content.filter({
             "lot": "IaaS"
         })
         self.assertEqual(
-            len(sections),
+            len(content.sections),
             0
         )
 
@@ -211,11 +211,11 @@ class TestContentLoader(unittest.TestCase):
             "folder/",
             YAMLLoader()
         )
-        sections = content.get_sections_filtered_by({
+        content.filter({
             "lot": "IaaS"
         })
         self.assertEqual(
-            len(sections),
+            len(content.sections),
             1
         )
 
@@ -253,27 +253,27 @@ class TestContentLoader(unittest.TestCase):
             YAMLLoader()
         )
 
-        sections = content.get_sections_filtered_by({
+        content.filter({
             "lot": "IaaS"
         })
         self.assertEqual(
-            len(sections),
+            len(content.sections),
             1
         )
 
-        sections = content.get_sections_filtered_by({
+        content.filter({
             "lot": "PaaS"
         })
         self.assertEqual(
-            len(sections),
+            len(content.sections),
             1
         )
 
-        sections = content.get_sections_filtered_by({
+        content.filter({
             "lot": "SCS"
         })
         self.assertEqual(
-            len(sections),
+            len(content.sections),
             0
         )
 
@@ -305,16 +305,16 @@ class TestContentLoader(unittest.TestCase):
         sections = content.sections
 
         self.assertEqual(
-            content.get_next_section_id("first_section", sections),
+            content.get_next_section_id("first_section"),
             "second_section"
         )
 
         self.assertEqual(
-            content.get_next_section_id("second_section", sections),
+            content.get_next_section_id("second_section"),
             "third_section"
         )
 
         self.assertEqual(
-            content.get_next_section_id("third_section", sections),
+            content.get_next_section_id("third_section"),
             None
         )

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -7,7 +7,7 @@ import os
 import tempfile
 import yaml
 
-from dmutils.content_loader import ContentLoader
+from dmutils.content_loader import YAMLLoader, ContentBuilder
 
 
 def get_mocked_yaml_reader(mocked_content={}):
@@ -16,13 +16,10 @@ def get_mocked_yaml_reader(mocked_content={}):
     return read
 
 
-@mock.patch("dmutils.content_loader.ContentLoader._yaml_file_exists")
-@mock.patch("dmutils.content_loader.ContentLoader._read_yaml_file")
+@mock.patch("dmutils.content_loader.YAMLLoader.read")
 class TestContentLoader(unittest.TestCase):
 
-    def test_a_simple_question(
-        self, mocked_read_yaml_file, mocked_yaml_file_exists
-    ):
+    def test_a_simple_question(self, mocked_read_yaml_file):
         mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({
             "manifest.yml": """
                 -
@@ -34,18 +31,17 @@ class TestContentLoader(unittest.TestCase):
                 question: 'First question'
             """
         })
-        content = ContentLoader(
+        content = ContentBuilder(
             "manifest.yml",
-            "folder/"
+            "folder/",
+            YAMLLoader()
         )
         self.assertEqual(
             content.get_question("firstQuestion").get("question"),
             "First question"
         )
 
-    def test_a_question_with_a_dependency(
-        self, mocked_read_yaml_file, mocked_yaml_file_exists
-    ):
+    def test_a_question_with_a_dependency(self, mocked_read_yaml_file):
         mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({
           "manifest.yml": """
               -
@@ -62,9 +58,10 @@ class TestContentLoader(unittest.TestCase):
 
           """
         })
-        content = ContentLoader(
+        content = ContentBuilder(
             "manifest.yml",
-            "folder/"
+            "folder/",
+            YAMLLoader()
         )
         sections = content.get_sections_filtered_by({
             "lot": "SCS"
@@ -75,7 +72,7 @@ class TestContentLoader(unittest.TestCase):
         )
 
     def test_a_question_with_a_dependency_that_doesnt_match(
-        self, mocked_read_yaml_file, mocked_yaml_file_exists
+        self, mocked_read_yaml_file
     ):
         mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({
           "manifest.yml": """
@@ -92,9 +89,10 @@ class TestContentLoader(unittest.TestCase):
                   being: SCS
           """
         })
-        content = ContentLoader(
+        content = ContentBuilder(
             "manifest.yml",
-            "folder/"
+            "folder/",
+            YAMLLoader()
         )
         sections = content.get_sections_filtered_by({
             "lot": "SaaS"
@@ -105,7 +103,7 @@ class TestContentLoader(unittest.TestCase):
         )
 
     def test_a_question_which_depends_on_one_of_several_answers(
-        self, mocked_read_yaml_file, mocked_yaml_file_exists
+        self, mocked_read_yaml_file
     ):
         mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({
           "manifest.yml": """
@@ -126,9 +124,10 @@ class TestContentLoader(unittest.TestCase):
 
           """
         })
-        content = ContentLoader(
+        content = ContentBuilder(
             "manifest.yml",
-            "folder/"
+            "folder/",
+            YAMLLoader()
         )
         sections = content.get_sections_filtered_by({
             "lot": "SaaS"
@@ -139,7 +138,7 @@ class TestContentLoader(unittest.TestCase):
         )
 
     def test_a_question_which_depends_on_one_of_several_answers(
-        self, mocked_read_yaml_file, mocked_yaml_file_exists
+        self, mocked_read_yaml_file
     ):
         mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({
           "manifest.yml": """
@@ -160,9 +159,10 @@ class TestContentLoader(unittest.TestCase):
 
           """
         })
-        content = ContentLoader(
+        content = ContentBuilder(
             "manifest.yml",
-            "folder/"
+            "folder/",
+            YAMLLoader()
         )
         sections = content.get_sections_filtered_by({
             "lot": "IaaS"
@@ -173,7 +173,7 @@ class TestContentLoader(unittest.TestCase):
         )
 
     def test_a_section_which_has_a_mixture_of_dependencies(
-        self, mocked_read_yaml_file, mocked_yaml_file_exists
+        self, mocked_read_yaml_file
     ):
         mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({
           "manifest.yml": """
@@ -206,9 +206,10 @@ class TestContentLoader(unittest.TestCase):
 
           """
         })
-        content = ContentLoader(
+        content = ContentBuilder(
             "manifest.yml",
-            "folder/"
+            "folder/",
+            YAMLLoader()
         )
         sections = content.get_sections_filtered_by({
             "lot": "IaaS"
@@ -218,9 +219,7 @@ class TestContentLoader(unittest.TestCase):
             1
         )
 
-    def test_that_filtering_isnt_cumulative(
-        self, mocked_read_yaml_file, mocked_yaml_file_exists
-    ):
+    def test_that_filtering_isnt_cumulative(self, mocked_read_yaml_file):
         mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({
           "manifest.yml": """
               -
@@ -248,9 +247,10 @@ class TestContentLoader(unittest.TestCase):
 
           """
         })
-        content = ContentLoader(
+        content = ContentBuilder(
             "manifest.yml",
-            "folder/"
+            "folder/",
+            YAMLLoader()
         )
 
         sections = content.get_sections_filtered_by({
@@ -277,9 +277,7 @@ class TestContentLoader(unittest.TestCase):
             0
         )
 
-    def test_get_next_section(
-        self, mocked_read_yaml_file, mocked_yaml_file_exists
-    ):
+    def test_get_next_section(self, mocked_read_yaml_file):
         mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({
             "manifest.yml": """
               -
@@ -298,9 +296,10 @@ class TestContentLoader(unittest.TestCase):
             "folder/firstQuestion.yml": "question: 'First question'"
         })
 
-        content = ContentLoader(
+        content = ContentBuilder(
             "manifest.yml",
-            "folder/"
+            "folder/",
+            YAMLLoader()
         )
 
         sections = content.sections

--- a/tests/test_presenters.py
+++ b/tests/test_presenters.py
@@ -4,7 +4,6 @@ import unittest
 import mock
 
 from dmutils.presenters import Presenters
-from dmutils.content_loader import ContentLoader
 presenters = Presenters()
 
 


### PR DESCRIPTION
_Reviewing the changes in this pull request will probably be a lot easier commit-by-commit_

---

Because files are slow to load, the intended use of ContentLoader was to do this once when starting the app.

This caused thread safety issues when using ContentLoader in an object-orientated way, because you couldn't reliably store state inside an instance.

Being able to store state in an instance is nice because it makes the interface cleaner.

This commit splits content loader into two parts:
- `YAMLLoader`, which is expected to instantiated once on startup and handles reading and parsing YAML files, and caching the results
- `ContentBuilder` which is expected to be instantiated once per request and therefore could maintain state

---

So now it's possible to bring back the `.filter()` method that was refactored out yesterday.

Once you have an instance of `ContentBuilder` this filters the content to only the questions relevant to the current service.

---

So it's now possible to add a `.get_next_section_id()` method which operates on the filtered content.

When passed the ID of the current section, it will return the ID of the next section. This will be useful when we want to go through the flow of pages for the SSP.

---

New usage:
``` python
from dmutils.content_loader import YAMLLoader, ContentBuilder

yaml_loader = YAMLLoader()

def view_service():
    content = ContentBuilder("manifest.yml", "g6/", yaml_loader)
    content.filter(service_data)
    render_template("service.html", sections=content.sections)
```
---
Goes towards [97275662](https://www.pivotaltracker.com/story/show/97275662)