### PR TITLE
Update our DATETIME format

### DIFF
--- a/dmutils/deprecation.py
+++ b/dmutils/deprecation.py
@@ -14,7 +14,7 @@ def deprecated(dies_at):
         @wraps(view)
         def func(*args, **kwargs):
             message = "Calling deprecated view '%s'. Dies in %s."
-            time_left = dies_at - datetime.now()
+            time_left = dies_at - datetime.utcnow()
             if time_left < timedelta(days=7):
                 current_app.logger.error(message, view.__name__, time_left)
             else:

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -1,2 +1,2 @@
-DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S%Z"
+DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_FORMAT = "%Y-%m-%d"

--- a/dmutils/metrics.py
+++ b/dmutils/metrics.py
@@ -54,7 +54,7 @@ class CloudWatchClient(object):
     def _put_metric(self, name, value=None, timestamp=None, unit=None,
                     dimensions=None, statistics=None):
         if timestamp is None:
-            timestamp = datetime.now()
+            timestamp = datetime.utcnow()
         self._conn.put_metric_data(
             namespace=self.namespace,
             name=name,
@@ -74,10 +74,10 @@ class Timer(ContextDecorator):
         self.name = name
 
     def __enter__(self):
-        self.start = datetime.now()
+        self.start = datetime.utcnow()
 
     def __exit__(self, *exc):
-        elapsed = datetime.now() - self.start
+        elapsed = datetime.utcnow() - self.start
         self.client._put_metric(
             self.name,
             int(elapsed.total_seconds() * 1000),


### PR DESCRIPTION
Python's datetime formatting won't always append a timezone to when
creating a string from a datetime, [which then throws an error when
trying to interpret back the string without a timezone](http://stackoverflow.com/questions/14762518/python-datetime-strptime-and-strftime-how-to-preserve-the-timezone-informat).
Instead of using another library, we're going to enforce a 'Z' on the
end of our datetime format string and use `utcnow()` everywhere.