### PR TITLE
Relative import for Py3 + bump version.

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,7 +2,7 @@ from . import logging, config, proxy_fix
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '1.0.5'
+__version__ = '1.0.6'
 
 
 def init_app(

--- a/dmutils/status.py
+++ b/dmutils/status.py
@@ -1,6 +1,6 @@
 import os
 import datetime
-from formats import DATE_FORMAT
+from .formats import DATE_FORMAT
 from flask_featureflags import FEATURE_FLAGS_CONFIG
 
 


### PR DESCRIPTION
Build was failing in Python 3 because I wasn't using a relative import.