### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,7 +2,7 @@ from . import logging, config, proxy_fix
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '1.0.6'
+__version__ = '2.0.0'
 
 
 def init_app(


### PR DESCRIPTION
Includes
- #74 Add .get_next_section_id() method to content loader 

This is a MAJOR version because it changes the interface to content_loader