### PR TITLE
Make YAML loader return None if file not found

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,7 +2,7 @@ from . import logging, config, proxy_fix
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 
 def init_app(

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -95,6 +95,8 @@ class YAMLLoader(object):
 
     def read(self, yaml_file):
         if yaml_file not in self._cache:
+            if not os.path.isfile(yaml_file):
+                return None
             with open(yaml_file, "r") as file:
                 self._cache[yaml_file] = yaml.load(file)
         return self._cache[yaml_file]


### PR DESCRIPTION
There are places where we, reasonably, do stuff like:
```
for key, value in service_data:
  content.get_question(key)
```

`service_data` has a number of attributes (eg `supplierName`, `status`) which don't have associated content because they're not editable.

Thus it is preferable for `.get_question` to return None, rather than throw an exception which would have to be caught somewhere further down the line.