### PR TITLE
Presenters should handle 'None' content

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,7 +2,7 @@ from . import logging, config, proxy_fix
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '2.0.1'
+__version__ = '2.0.2'
 
 
 def init_app(

--- a/dmutils/presenters.py
+++ b/dmutils/presenters.py
@@ -7,6 +7,10 @@ class Presenters(object):
         return None
 
     def present(self, value, question_content):
+
+        if question_content is None:
+            return value
+
         if "type" in question_content:
             field_type = question_content["type"]
         else:

--- a/tests/test_presenters.py
+++ b/tests/test_presenters.py
@@ -31,6 +31,24 @@ class TestPresenters(unittest.TestCase):
             }
         )
 
+    def test_present_all_with_none(self):
+        content = mock.Mock()
+        content.get_question.return_value = None
+
+        self.assertEqual(
+            presenters.present_all(
+                {
+                    "foo": "bar",
+                    "bar": True,
+                },
+                content
+            ),
+            {
+                "foo": "bar",
+                "bar": True,
+            }
+        )
+
     def test_service_id(self):
         G5 = presenters.present(
             "5.G5.12345",


### PR DESCRIPTION
[Previously](https://github.com/alphagov/digitalmarketplace-utils/blob/1ebfc0ce311c220e00f3a3e49e9a0caedca4f79c/dmutils/content_loader.py#L33), ContentLoader returned `{}` for question content that didn't exist.

[Now](https://github.com/alphagov/digitalmarketplace-utils/blob/3a604744c628dc8c9f944cc6f0452ad7e7506f93/dmutils/content_loader.py#L99) it returns `None`, which the Presenters choke on.

This commit adds an extra check in the Presenters for ContentLoader passing `None`.