### PR TITLE
Add ID to each question

### DIFF
--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -24,7 +24,11 @@ class ContentBuilder(object):
         return None
 
     def get_question(self, question):
-        return self.yaml_loader.read(self._directory + question + ".yml")
+        question_content = self.yaml_loader.read(
+            self._directory + question + ".yml"
+        )
+        question_content["id"] = question
+        return question_content
 
     def filter(self, service_data):
         self.sections = [

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -47,6 +47,10 @@ class TestContentBuilder(unittest.TestCase):
             content.get_question("firstQuestion").get("question"),
             "First question"
         )
+        self.assertEqual(
+            content.get_question("firstQuestion").get("id"),
+            "firstQuestion"
+        )
 
     def test_a_question_with_a_dependency(self, mocked_read_yaml_file):
         mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({


### PR DESCRIPTION
The admin app depends on each question having an `id` property.

Somewhere along the line this got lost. This commit puts it back.

This commit also adds a test to make sure we don't lose it again.