### PR TITLE
Rename selection question audit type

### DIFF
--- a/dmutils/audit.py
+++ b/dmutils/audit.py
@@ -16,8 +16,7 @@ class AuditTypes(Enum):
     user_auth_failed = "user_auth_failed"
     create_user = "create_user"
     update_user = "update_user"
-    create_selection_questions = "create_selection_questions"
-    update_selection_questions = "update_selection_questions"
+    answer_selection_questions = "answer_selection_questions"
 
     @staticmethod
     def is_valid_audit_type(test_audit_type):


### PR DESCRIPTION
The previous audit types made it sound like we were updating the
questions rather than providing answers to them.