### PR TITLE
Add `create_new_draft_service` to DataAPIClient

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,7 +2,7 @@ from . import logging, config, proxy_fix
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '2.0.4'
+__version__ = '2.1.0'
 
 
 def init_app(

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -7,6 +7,8 @@ class DataAPIClient(BaseAPIClient):
         self.base_url = app.config['DM_DATA_API_URL']
         self.auth_token = app.config['DM_DATA_API_AUTH_TOKEN']
 
+    # Audit Events
+
     def find_audit_events(
             self,
             audit_type=None,
@@ -37,6 +39,113 @@ class DataAPIClient(BaseAPIClient):
                     "updated_by": user
                 }
             })
+
+    # Suppliers
+
+    def find_suppliers(self, prefix=None, page=None):
+        params = {}
+        if prefix:
+            params["prefix"] = prefix
+        if page is not None:
+            params['page'] = page
+
+        return self._get(
+            "/suppliers",
+            params=params
+        )
+
+    def get_supplier(self, supplier_id):
+        return self._get(
+            "/suppliers/{}".format(supplier_id)
+        )
+
+    def create_supplier(self, supplier_id, supplier):
+        return self._put(
+            "/suppliers/{}".format(supplier_id),
+            data={"suppliers": supplier},
+        )
+
+    def update_supplier(self, supplier_id, supplier, user):
+        return self._post(
+            "/suppliers/{}".format(supplier_id),
+            data={
+                "suppliers": supplier,
+                "updated_by": user,
+            },
+        )
+
+    def update_contact_information(self, supplier_id, contact_id,
+                                   contact, user):
+        return self._post(
+            "/suppliers/{}/contact-information/{}".format(
+                supplier_id, contact_id),
+            data={
+                "contactInformation": contact,
+                "updated_by": user,
+            },
+        )
+
+    # Users
+
+    def create_user(self, user):
+        return self._post(
+            "/users",
+            data={
+                "users": user,
+            })
+
+    def get_user(self, user_id=None, email_address=None):
+        if user_id is not None and email_address is not None:
+            raise ValueError(
+                "Cannot get user by both user_id and email_address")
+        elif user_id is not None:
+            url = "{}/users/{}".format(self.base_url, user_id)
+            params = {}
+        elif email_address is not None:
+            url = "{}/users".format(self.base_url)
+            params = {"email": email_address}
+        else:
+            raise ValueError("Either user_id or email_address must be set")
+
+        try:
+            return self._get(url, params=params)
+        except HTTPError as e:
+            if e.status_code != 404:
+                raise
+        return None
+
+    def authenticate_user(self, email_address, password, supplier=True):
+        try:
+            response = self._post(
+                '/users/auth',
+                data={
+                    "authUsers": {
+                        "emailAddress": email_address,
+                        "password": password,
+                    }
+                })
+            if not supplier or "supplier" in response['users']:
+                return response
+        except HTTPError as e:
+            if e.status_code not in [400, 403, 404]:
+                raise
+        return None
+
+    def update_user_password(self, user_id, new_password):
+        try:
+            self._post(
+                '/users/{}'.format(user_id),
+                data={"users": {"password": new_password}}
+            )
+
+            logger.info("Updated password for user %s", user_id)
+            return True
+        except HTTPError as e:
+            logger.info("Password update failed for user %s: %s",
+                        user_id, e.status_code)
+            return False
+
+    # Services
 
     def create_new_draft_service(self, framework_slug, supplier_id, user, lot):
         return self._post(
@@ -103,49 +212,6 @@ class DataAPIClient(BaseAPIClient):
                 },
             })
 
-    def find_suppliers(self, prefix=None, page=None):
-        params = {}
-        if prefix:
-            params["prefix"] = prefix
-        if page is not None:
-            params['page'] = page
-
-        return self._get(
-            "/suppliers",
-            params=params
-        )
-
-    def get_supplier(self, supplier_id):
-        return self._get(
-            "/suppliers/{}".format(supplier_id)
-        )
-
-    def create_supplier(self, supplier_id, supplier):
-        return self._put(
-            "/suppliers/{}".format(supplier_id),
-            data={"suppliers": supplier},
-        )
-
-    def update_supplier(self, supplier_id, supplier, user):
-        return self._post(
-            "/suppliers/{}".format(supplier_id),
-            data={
-                "suppliers": supplier,
-                "updated_by": user,
-            },
-        )
-
-    def update_contact_information(self, supplier_id, contact_id,
-                                   contact, user):
-        return self._post(
-            "/suppliers/{}/contact-information/{}".format(
-                supplier_id, contact_id),
-            data={
-                "contactInformation": contact,
-                "updated_by": user,
-            },
-        )
-
     def get_archived_service(self, archived_service_id):
         return self._get("/archived-services/{}".format(archived_service_id))
 
@@ -200,61 +266,3 @@ class DataAPIClient(BaseAPIClient):
                     "update_reason": reason,
                 },
             })
-
-    def create_user(self, user):
-        return self._post(
-            "/users",
-            data={
-                "users": user,
-            })
-
-    def get_user(self, user_id=None, email_address=None):
-        if user_id is not None and email_address is not None:
-            raise ValueError(
-                "Cannot get user by both user_id and email_address")
-        elif user_id is not None:
-            url = "{}/users/{}".format(self.base_url, user_id)
-            params = {}
-        elif email_address is not None:
-            url = "{}/users".format(self.base_url)
-            params = {"email": email_address}
-        else:
-            raise ValueError("Either user_id or email_address must be set")
-
-        try:
-            return self._get(url, params=params)
-        except HTTPError as e:
-            if e.status_code != 404:
-                raise
-        return None
-
-    def authenticate_user(self, email_address, password, supplier=True):
-        try:
-            response = self._post(
-                '/users/auth',
-                data={
-                    "authUsers": {
-                        "emailAddress": email_address,
-                        "password": password,
-                    }
-                })
-            if not supplier or "supplier" in response['users']:
-                return response
-        except HTTPError as e:
-            if e.status_code not in [400, 403, 404]:
-                raise
-        return None
-
-    def update_user_password(self, user_id, new_password):
-        try:
-            self._post(
-                '/users/{}'.format(user_id),
-                data={"users": {"password": new_password}}
-            )
-
-            logger.info("Updated password for user %s", user_id)
-            return True
-        except HTTPError as e:
-            logger.info("Password update failed for user %s: %s",
-                        user_id, e.status_code)
-            return False

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -147,11 +147,18 @@ class DataAPIClient(BaseAPIClient):
 
     # Services
 
-    # Also optionally accepts a service_id and a framework
-    def list_draft_services(self, supplier_id):
-        return self._get(
-            "/draft-services?supplier_id={}".format(supplier_id)
-        )
+    def list_draft_services(
+            self, supplier_id, service_id=None, framework=None):
+
+        url = "/draft-services?supplier_id={}".format(supplier_id)
+
+        if service_id:
+            url = "{}&service_id={}".format(url, service_id)
+
+        if framework:
+            url = "{}&framework={}".format(url, framework)
+
+        return self._get(url)
 
     def get_draft_service(self, draft_id):
         return self._get(

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -38,6 +38,20 @@ class DataAPIClient(BaseAPIClient):
                 }
             })
 
+    def create_new_draft_service(self, framework_slug, supplier_id, user, lot):
+        return self._post(
+            "/draft-services/{}/create".format(framework_slug),
+            data={
+                "update_details": {
+                    "updated_by": user,
+                },
+                "services": {
+                    "supplierId": supplier_id,
+                    "lot": lot
+                }
+
+            })
+
     def find_draft_services(self, supplier_id):
         return self._get(
             "/draft-services?supplier_id={}".format(supplier_id)
@@ -58,9 +72,9 @@ class DataAPIClient(BaseAPIClient):
                 },
             })
 
-    def create_draft_service(self, service_id, user):
+    def copy_draft_service_from_existing_service(self, service_id, user):
         return self._put(
-            "/services/{}/draft".format(service_id),
+            "/draft-services/copy-from/{}".format(service_id),
             data={
                 "update_details": {
                     "updated_by": user,
@@ -155,7 +169,7 @@ class DataAPIClient(BaseAPIClient):
             self.base_url + "/services",
             params=params)
 
-    def create_service(self, service_id, service, user, reason):
+    def import_service(self, service_id, service, user, reason):
         return self._put(
             "/services/{}".format(service_id),
             data={

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -152,7 +152,7 @@ class DataAPIClient(BaseAPIClient):
             "/draft-services/{}/create".format(framework_slug),
             data={
                 "update_details": {
-                    "updated_by": user,
+                    "updated_by": user
                 },
                 "services": {
                     "supplierId": supplier_id,
@@ -161,19 +161,20 @@ class DataAPIClient(BaseAPIClient):
 
             })
 
-    def find_draft_services(self, supplier_id):
+    # Also optionally accepts a service_id and a framework
+    def list_draft_services(self, supplier_id):
         return self._get(
             "/draft-services?supplier_id={}".format(supplier_id)
         )
 
-    def get_draft_service(self, service_id):
+    def get_draft_service(self, draft_id):
         return self._get(
-            "/services/{}/draft".format(service_id)
+            "/draft-services/{}".format(draft_id)
         )
 
-    def delete_draft_service(self, service_id, user):
+    def delete_draft_service(self, draft_id, user):
         return self._delete(
-            "/services/{}/draft".format(service_id),
+            "/draft-services/{}".format(draft_id),
             data={
                 "update_details": {
                     "updated_by": user,
@@ -191,9 +192,9 @@ class DataAPIClient(BaseAPIClient):
                 },
             })
 
-    def update_draft_service(self, service_id, service, user):
+    def update_draft_service(self, draft_id, service, user):
         return self._post(
-            "/services/{}/draft".format(service_id),
+            "/draft-services/{}".format(draft_id),
             data={
                 "update_details": {
                     "updated_by": user,
@@ -202,9 +203,9 @@ class DataAPIClient(BaseAPIClient):
                 "services": service,
             })
 
-    def launch_draft_service(self, service_id, user):
+    def publish_draft_service(self, draft_id, user):
         return self._post(
-            "/services/{}/draft/publish".format(service_id),
+            "/draft-services/{}/publish".format(draft_id),
             data={
                 "update_details": {
                     "updated_by": user,

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -147,20 +147,6 @@ class DataAPIClient(BaseAPIClient):
 
     # Services
 
-    def create_new_draft_service(self, framework_slug, supplier_id, user, lot):
-        return self._post(
-            "/draft-services/{}/create".format(framework_slug),
-            data={
-                "update_details": {
-                    "updated_by": user
-                },
-                "services": {
-                    "supplierId": supplier_id,
-                    "lot": lot
-                }
-
-            })
-
     # Also optionally accepts a service_id and a framework
     def list_draft_services(self, supplier_id):
         return self._get(
@@ -211,6 +197,20 @@ class DataAPIClient(BaseAPIClient):
                     "updated_by": user,
                     "update_reason": "deprecated",
                 },
+            })
+
+    def create_new_draft_service(self, framework_slug, supplier_id, user, lot):
+        return self._post(
+            "/draft-services/{}/create".format(framework_slug),
+            data={
+                "update_details": {
+                    "updated_by": user
+                },
+                "services": {
+                    "supplierId": supplier_id,
+                    "lot": lot
+                }
+
             })
 
     def get_archived_service(self, archived_service_id):

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -147,7 +147,7 @@ class DataAPIClient(BaseAPIClient):
 
     # Services
 
-    def list_draft_services(
+    def find_draft_services(
             self, supplier_id, service_id=None, framework=None):
 
         url = "/draft-services?supplier_id={}".format(supplier_id)

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -807,7 +807,8 @@ class TestDataApiClient(object):
             }
         }
 
-    def test_copy_draft_service_from_existing_service(self, data_client, rmock):
+    def test_copy_draft_service_from_existing_service(
+            self, data_client, rmock):
         rmock.put(
             "http://baseurl/draft-services/copy-from/2",
             json={"done": "it"},
@@ -864,6 +865,29 @@ class TestDataApiClient(object):
         assert rmock.request_history[0].json() == {
             'update_details': {
                 'update_reason': 'deprecated', 'updated_by': 'user'
+            }
+        }
+
+    def test_create_new_draft_service(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/draft-services/g-cloud-7/create",
+            json={"done": "it"},
+            status_code=201,
+        )
+
+        result = data_client.create_new_draft_service(
+            'g-cloud-7', 2, 'user', 'IaaS'
+        )
+
+        assert result == {"done": "it"}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'update_details': {
+                'updated_by': 'user'
+            },
+            'services': {
+                    'supplierId': 2,
+                    'lot': 'IaaS'
             }
         }
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -771,7 +771,8 @@ class TestDataApiClient(object):
             status_code=200,
         )
 
-        result = data_client.list_draft_services(2)
+        result = data_client.list_draft_services(
+            2, service_id='1234567890123456', framework='g-cloud-6')
 
         assert result == {"draft-services": "result"}
         assert rmock.called

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -463,14 +463,14 @@ class TestDataApiClient(object):
         assert result == {"services": "result"}
         assert rmock.called
 
-    def test_create_service(self, data_client, rmock):
+    def test_import_service(self, data_client, rmock):
         rmock.put(
             "http://baseurl/services/123",
             json={"services": "result"},
             status_code=201,
         )
 
-        result = data_client.create_service(
+        result = data_client.import_service(
             123, {"foo": "bar"}, "person", "reason")
 
         assert result == {"services": "result"}
@@ -764,21 +764,21 @@ class TestDataApiClient(object):
             'contactInformation': {'foo': 'bar'}, 'updated_by': 'supplier'
         }
 
-    def test_find_draft_services(self, data_client, rmock):
+    def test_list_draft_services(self, data_client, rmock):
         rmock.get(
             "http://baseurl/draft-services?supplier_id=2",
             json={"draft-services": "result"},
             status_code=200,
         )
 
-        result = data_client.find_draft_services(2)
+        result = data_client.list_draft_services(2)
 
         assert result == {"draft-services": "result"}
         assert rmock.called
 
     def test_get_draft_service(self, data_client, rmock):
         rmock.get(
-            "http://baseurl/services/2/draft",
+            "http://baseurl/draft-services/2",
             json={"draft-services": "result"},
             status_code=200,
         )
@@ -790,7 +790,7 @@ class TestDataApiClient(object):
 
     def test_delete_draft_service(self, data_client, rmock):
         rmock.delete(
-            "http://baseurl/services/2/draft",
+            "http://baseurl/draft-services/2",
             json={"done": "it"},
             status_code=200,
         )
@@ -807,14 +807,14 @@ class TestDataApiClient(object):
             }
         }
 
-    def test_create_draft_service(self, data_client, rmock):
+    def test_copy_draft_service_from_existing_service(self, data_client, rmock):
         rmock.put(
-            "http://baseurl/services/2/draft",
+            "http://baseurl/draft-services/copy-from/2",
             json={"done": "it"},
             status_code=201,
         )
 
-        result = data_client.create_draft_service(
+        result = data_client.copy_draft_service_from_existing_service(
             2, 'user'
         )
 
@@ -828,7 +828,7 @@ class TestDataApiClient(object):
 
     def test_update_draft_service(self, data_client, rmock):
         rmock.post(
-            "http://baseurl/services/2/draft",
+            "http://baseurl/draft-services/2",
             json={"done": "it"},
             status_code=200,
         )
@@ -848,14 +848,14 @@ class TestDataApiClient(object):
             }
         }
 
-    def test_launch_draft_service(self, data_client, rmock):
+    def test_publish_draft_service(self, data_client, rmock):
         rmock.post(
-            "http://baseurl/services/2/draft/publish",
+            "http://baseurl/draft-services/2/publish",
             json={"done": "it"},
             status_code=200,
         )
 
-        result = data_client.launch_draft_service(
+        result = data_client.publish_draft_service(
             2, 'user'
         )
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -764,14 +764,14 @@ class TestDataApiClient(object):
             'contactInformation': {'foo': 'bar'}, 'updated_by': 'supplier'
         }
 
-    def test_list_draft_services(self, data_client, rmock):
+    def test_find_draft_services(self, data_client, rmock):
         rmock.get(
             "http://baseurl/draft-services?supplier_id=2",
             json={"draft-services": "result"},
             status_code=200,
         )
 
-        result = data_client.list_draft_services(
+        result = data_client.find_draft_services(
             2, service_id='1234567890123456', framework='g-cloud-6')
 
         assert result == {"draft-services": "result"}


### PR DESCRIPTION
Anticipates @TheDoubleK's [pull request in the digitalmarketplace-api](https://github.com/alphagov/digitalmarketplace-api/pull/156).

Related to two stories in Pivotal: [#97275564](https://www.pivotaltracker.com/story/show/97275564) and [#97275432](https://www.pivotaltracker.com/story/show/97275432)

(As a final note, changes are easier to read by going commit-by-commit.)

### In Sum

* Adds `create_new_draft_service` method which corresponds to similarly named method in API.
* Renamed some of the DataAPIClient methods
```python
  - create_service()       -> import_service()
  - create_draft_service() -> copy_draft_service_from_existing_service()
  - launch_draft_service() -> publish_draft_service()
```
* Changed `service_id` parameter to `draft_id` in most of the draft methods
* Changed url structures from `/services/{id}/draft` to `/draft-services/{id}`
* Grouped together relevant methods by the framework models they operate on.
Order is as follows:
Audit Events  -> Suppliers -> Users -> Services.

I don't think anyone is using draft service methods yet or the `create_service` method (which no one *should* use anyway), so I'm pretty sure this is backwards compatible.

***
### Discussion

#### 1. Use of the word "publish"

I changed the `launch_draft_service()` method to `publish_draft_service()` because we use "publish" in the method name in the API as well as in the URL route itself.  So now we're using "publish" everywhere.
*However*, we also have a status called `published`, and currently "publishing" a draft service -- as it currently exists in @TheDoubleK's [pull request](https://github.com/alphagov/digitalmarketplace-api/pull/156) -- will set its status to `enabled`.  So this seems like not the best name to keep.

#### 2. `updated_reason`s

Currently a few of the methods are passing `updated_reason`s back to the API, and, in the case of the draft service methods (which don't have a `reason` parameter) are just sending `"deprecated"`.

The API itself doesn't want updated_reasons.  Neither the [JSON schema](https://github.com/alphagov/digitalmarketplace-api/blob/master/json_schemas/services-update.json), the [draft](https://github.com/alphagov/digitalmarketplace-api/blob/master/app/main/views/drafts.py) routes, nor the [service](https://github.com/alphagov/digitalmarketplace-api/blob/master/app/main/views/services.py) routes use them. Can I get rid of them, or are upstream frontend apps still using them?