### PR TITLE
Make .get_section() use filtered list of questions

### DIFF
--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -18,7 +18,7 @@ class ContentBuilder(object):
         self.sections = self._all_sections
 
     def get_section(self, requested_section):
-        for section in self._all_sections:
+        for section in self.sections:
             if section["id"] == requested_section:
                 return section
         return None
@@ -50,9 +50,15 @@ class ContentBuilder(object):
 
         return None
 
+    def _get_section_from_all(self, requested_section):
+        for section in self._all_sections:
+            if section["id"] == requested_section:
+                return section
+        return None
+
     def _get_section_filtered_by(self, section_id, service_data):
 
-        section = self.get_section(section_id)
+        section = self._get_section_from_all(section_id)
 
         filtered_questions = [
             question for question in section["questions"]

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -288,6 +288,56 @@ class TestContentBuilder(unittest.TestCase):
             0
         )
 
+    def test_get_section(self, mocked_read_yaml_file):
+        mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({
+          "manifest.yml": """
+              -
+                name: First section
+                questions:
+                  - firstQuestion
+              -
+                name: Second section
+                questions:
+                  - secondQuestion
+          """,
+          "folder/firstQuestion.yml": """
+                question: 'First question'
+                depends:
+                    -
+                      "on": lot
+                      being: IaaS
+          """,
+          "folder/secondQuestion.yml": """
+                question: 'Second question'
+                depends:
+                    -
+                      "on": lot
+                      being: PaaS
+
+          """
+        })
+        content = ContentBuilder(
+            "manifest.yml",
+            "folder/",
+            YAMLLoader()
+        )
+
+        content.filter({
+            "lot": "IaaS"
+        })
+        self.assertEqual(
+            content.get_section("first_section").get("id"),
+            "first_section"
+        )
+
+        content.filter({
+            "lot": "SCS"
+        })
+        self.assertEqual(
+            content.get_section("first_section"),
+            None
+        )
+
     def test_get_next_section(self, mocked_read_yaml_file):
         mocked_read_yaml_file.side_effect = get_mocked_yaml_reader({
             "manifest.yml": """


### PR DESCRIPTION
The admin app needs:
✔ to be able to get one section of questions
✖ for that section to only have the relevant questions

This commit makes ✖ into ✔.