### PR TITLE
Make .get_next_section() default to first section, filter by editable sections

### DIFF
--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -38,7 +38,10 @@ class ContentBuilder(object):
             ] if section is not None
         ]
 
-    def get_next_section_id(self, section_id):
+    def get_next_section_id(self, section_id=None):
+
+        if section_id is None:
+            return self.sections[0]["id"]
 
         previous_section_is_current = False
 

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -38,20 +38,30 @@ class ContentBuilder(object):
             ] if section is not None
         ]
 
-    def get_next_section_id(self, section_id=None):
+    def get_next_section_id(self, section_id=None, only_editable=False):
 
-        if section_id is None:
-            return self.sections[0]["id"]
-
-        previous_section_is_current = False
+        previous_section_is_current = section_id is None
 
         for section in self.sections:
-            if previous_section_is_current:
-                return section["id"]
+
+            if only_editable:
+                if (
+                    previous_section_is_current and
+                    "editable" in section and
+                    section["editable"]
+                ):
+                    return section["id"]
+            else:
+                if previous_section_is_current:
+                    return section["id"]
+
             if section["id"] == section_id:
                 previous_section_is_current = True
 
         return None
+
+    def get_next_editable_section_id(self, section_id=None):
+        return self.get_next_section_id(section_id, True)
 
     def _get_section_from_all(self, requested_section):
         for section in self._all_sections:

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -351,6 +351,7 @@ class TestContentBuilder(unittest.TestCase):
                   - firstQuestion
               -
                 name: Third section
+                editable: True
                 questions:
                   - firstQuestion
             """,
@@ -380,6 +381,15 @@ class TestContentBuilder(unittest.TestCase):
         self.assertEqual(
             content.get_next_section_id("third_section"),
             None
+        )
+
+        self.assertEqual(
+            content.get_next_editable_section_id(),
+            "third_section"
+        )
+        self.assertEqual(
+            content.get_next_editable_section_id("second_section"),
+            "third_section"
         )
 
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -366,6 +366,10 @@ class TestContentBuilder(unittest.TestCase):
         sections = content.sections
 
         self.assertEqual(
+            content.get_next_section_id(),
+            "first_section"
+        )
+        self.assertEqual(
             content.get_next_section_id("first_section"),
             "second_section"
         )


### PR DESCRIPTION
This will be used when working out which page to go to once a user has chosen a lot for their service.

This pull request:
- Makes .get_next_section() return the first section when passed `None` as a section ID
- Adds a new method, `.get_next_editable_section()` which keeps looking through the pages of questions until it finds one that can be edited (ie "Select lot" is the first section of questions, but you can go back and change it afterwards)