### PR TITLE
Framework param passed to supplier fetch calls

### DIFF
--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -89,12 +89,14 @@ class DataAPIClient(BaseAPIClient):
                 },
             })
 
-    def find_suppliers(self, prefix=None, page=None):
+    def find_suppliers(self, prefix=None, page=None, framework=None):
         params = {}
         if prefix:
             params["prefix"] = prefix
         if page is not None:
             params['page'] = page
+        if framework is not None:
+            params['framework'] = framework
 
         return self._get(
             "/suppliers",

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -687,6 +687,17 @@ class TestDataApiClient(object):
         assert result == {"services": "result"}
         assert rmock.called
 
+    def test_find_suppliers_with_framework(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/suppliers?framework=gcloud",
+            json={"services": "result"},
+            status_code=200)
+
+        result = data_client.find_suppliers(framework='gcloud')
+
+        assert result == {"services": "result"}
+        assert rmock.called
+
     def test_find_supplier_adds_page_parameter(self, data_client, rmock):
         rmock.get(
             "http://baseurl/suppliers?page=2",


### PR DESCRIPTION
Adds the framework param to calls to the fetch suppliers endpoints

- enables https://github.com/alphagov/digitalmarketplace-api/pull/160