### PR TITLE
Chainable content builder

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,7 +2,7 @@ from . import logging, config, proxy_fix
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '2.1.1'
+__version__ = '3.0.0'
 
 
 def init_app(

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -110,7 +110,7 @@ class ContentLoader(object):
         question_content = read_yaml(
             self._directory + question + ".yml"
         )
-        question_content["id"] = question
+        question_content["id"] = self._make_question_id(question)
 
         return question_content
 
@@ -118,6 +118,11 @@ class ContentLoader(object):
         return inflection.underscore(
             re.sub("\s", "_", name)
         )
+
+    def _make_question_id(self, question):
+        if re.match('^serviceTypes(SCS|SaaS|PaaS|IaaS)', question):
+            return 'serviceTypes'
+        return question
 
 
 def read_yaml(yaml_file):

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -8,6 +8,9 @@ class ContentBuilder(object):
     def __init__(self, sections):
         self.sections = list(sections)
 
+    def __iter__(self):
+        return self.sections.__iter__()
+
     def get_section(self, requested_section):
         for section in self.sections:
             if section["id"] == requested_section:

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -77,13 +77,10 @@ class ContentBuilder(object):
 
 class ContentLoader(object):
     def __init__(self, manifest, content_directory):
-        self._cache = {}
-        self._directory = content_directory
-
         manifest_sections = read_yaml(manifest)
 
         self._questions = {
-            q: self._load_question(q)
+            q: _load_question(q, content_directory)
             for section in manifest_sections
             for q in section["questions"]
         }
@@ -99,30 +96,33 @@ class ContentLoader(object):
         return ContentBuilder(self._sections)
 
     def _populate_section(self, section):
-        section["id"] = self._make_id(section["name"])
+        section["id"] = _make_section_id(section["name"])
         section["questions"] = [
             self.get_question(q) for q in section["questions"]
         ]
 
         return section
 
-    def _load_question(self, question):
-        question_content = read_yaml(
-            self._directory + question + ".yml"
-        )
-        question_content["id"] = self._make_question_id(question)
 
-        return question_content
+def _load_question(question, directory):
+    question_content = read_yaml(
+        directory + question + ".yml"
+    )
+    question_content["id"] = _make_question_id(question)
 
-    def _make_id(self, name):
-        return inflection.underscore(
-            re.sub("\s", "_", name)
-        )
+    return question_content
 
-    def _make_question_id(self, question):
-        if re.match('^serviceTypes(SCS|SaaS|PaaS|IaaS)', question):
-            return 'serviceTypes'
-        return question
+
+def _make_section_id(name):
+    return inflection.underscore(
+        re.sub("\s", "_", name)
+    )
+
+
+def _make_question_id(question):
+    if re.match('^serviceTypes(SCS|SaaS|PaaS|IaaS)', question):
+        return 'serviceTypes'
+    return question
 
 
 def read_yaml(yaml_file):

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -1,2 +1,39 @@
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_FORMAT = "%Y-%m-%d"
+
+LOTS = [
+    {
+        'lot': 'saas',
+        'lot_case': 'SaaS',
+        'label': u'Software as a Service',
+    },
+    {
+        'lot': 'paas',
+        'lot_case': 'PaaS',
+        'label': u'Platform as a Service',
+    },
+    {
+        'lot': 'iaas',
+        'lot_case': 'IaaS',
+        'label': u'Infrastructure as a Service',
+    },
+    {
+        'lot': 'scs',
+        'lot_case': 'SCS',
+        'label': u'Specialist Cloud Services',
+    },
+]
+
+
+def lot_to_lot_case(lot_to_check):
+    lot_i_found = [lot for lot in LOTS if lot['lot'] == lot_to_check]
+    if lot_i_found:
+        return lot_i_found[0]['lot_case']
+    return None
+
+
+def get_label_for_lot_param(lot_to_check):
+    lot_i_found = [lot for lot in LOTS if lot['lot'] == lot_to_check]
+    if lot_i_found:
+        return lot_i_found[0]['label']
+    return None

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -898,8 +898,8 @@ class TestDataApiClient(object):
                 'updated_by': 'user'
             },
             'services': {
-                    'supplierId': 2,
-                    'lot': 'IaaS'
+                'supplierId': 2,
+                'lot': 'IaaS'
             }
         }
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -30,6 +30,11 @@ class TestContentBuilder(unittest.TestCase):
         sections.append('new')
         self.assertEqual(content.sections, [])
 
+    def test_content_builder_iteration(self):
+        content = ContentBuilder([1, 2, 3])
+
+        self.assertEqual(list(content), [1, 2, 3])
+
     def test_a_question_with_a_dependency(self):
         content = ContentBuilder([{
             "name": "First section",

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,0 +1,32 @@
+
+from dmutils.formats import get_label_for_lot_param, lot_to_lot_case
+import pytest
+
+
+class TestFormats(object):
+
+    def test_returns_lot_in_lot_case(self):
+
+        cases = [
+            ("saas", "SaaS"),
+            ("iaas", "IaaS"),
+            ("paas", "PaaS"),
+            ("scs", "SCS"),
+            ("dewdew", None),
+        ]
+
+        for example, expected in cases:
+            assert lot_to_lot_case(example) == expected
+
+    def test_returns_label_for_lot(self):
+
+        cases = [
+            ("saas", "Software as a Service"),
+            ("iaas", "Infrastructure as a Service"),
+            ("paas", "Platform as a Service"),
+            ("scs", "Specialist Cloud Services"),
+            ("dewdew", None),
+        ]
+
+        for example, expected in cases:
+            assert get_label_for_lot_param(example) == expected


### PR DESCRIPTION
### Change ContentLoader.filter to return a new object

* Replaces YAMLLoader with ContentLoader. ContentLoader instances should
  be created for each manifest/section file on app startup.
* Moved .get_question method to ContentLoader. Return a copy of the
  question dictionary.
* ContentLoader.get_builder() will return a new builder instance with a full list of sections.
* ContentBuilder.filter now returns a new ContentBuilder instance, so filter calls can be chained:

      content_builder.filter({'lot': "SaaS"}).filter({'lot': "PaaS"})

  would return questions and sections relevant for both SaaS and PaaS.

Example use of the new ContentLoader and ContentBuilder classes:

`app/__init__.py`:

    sections_content = ContentLoader('sections_order.yml', 'app/content/g6/')

Creating a filtered ContentBuilder in a view method:

    content = section_content.get_builder().filter({'lot': "SaaS"})

Getting individual question data:

    content = section_content.get_question("questionId")

### 	Make ContentBuilder an iterator
 
Instead of `for section in content_builder.sections` it's now possible
to do `for section in content_builder`

Paired with @quis 