### PR TITLE
Remove special minimumContractPeriod handling from search apiclient

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,7 +2,7 @@ from . import logging, config, proxy_fix
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '3.1.0'
+__version__ = '3.1.1'
 
 
 def init_app(

--- a/dmutils/apiclient/search.py
+++ b/dmutils/apiclient/search.py
@@ -58,20 +58,15 @@ class SearchAPIClient(BaseAPIClient):
                 raise
         return None
 
-    def search_services(self, q="", page=None, **filters):
-        if isinstance(q, list):
-            q = q[0]
-        params = dict()
-        if q != "":
+    def search_services(self, q=None, page=None, **filters):
+        params = {}
+        if q is not None:
             params['q'] = q
 
         if page:
             params['page'] = page
 
         for filter_name, filter_values in six.iteritems(filters):
-            if filter_name == "minimumContractPeriod":
-                filter_values = ','.join(filter_values)
-
             params['filter_{}'.format(filter_name)] = filter_values
 
         response = self._get(self._url("/search"), params=params)

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -304,22 +304,22 @@ class TestSearchApiClient(object):
     def test_search_services(self, search_client, rmock):
         rmock.get(
             'http://baseurl/g-cloud/services/search?q=foo&'
-            'filter_minimumContractPeriod=a,b&'
+            'filter_minimumContractPeriod=a&'
             'filter_something=a&filter_something=b',
             json={'services': "myresponse"},
             status_code=200)
         result = search_client.search_services(
             q='foo',
-            minimumContractPeriod=['a', 'b'],
+            minimumContractPeriod=['a'],
             something=['a', 'b'])
         assert result == {'services': "myresponse"}
 
     def test_search_services_with_blank_query(self, search_client, rmock):
         rmock.get(
-            'http://baseurl/g-cloud/services/search?',
+            'http://baseurl/g-cloud/services/search',
             json={'services': "myresponse"},
             status_code=200)
-        result = search_client.search_services(q='')
+        result = search_client.search_services()
         assert result == {'services': "myresponse"}
         assert rmock.last_request.query == ''
 
@@ -328,7 +328,7 @@ class TestSearchApiClient(object):
             'http://baseurl/g-cloud/services/search?page=10',
             json={'services': "myresponse"},
             status_code=200)
-        result = search_client.search_services(q='', page=10)
+        result = search_client.search_services(page=10)
         assert result == {'services': "myresponse"}
         assert rmock.last_request.query == 'page=10'
 


### PR DESCRIPTION
Buyer frontend has access to the questions content so it should build
the correct OR/AND value for each filter type without relying on
special cases in apiclient.