### PR TITLE
Add copy_draft_service method to DataAPIClient

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '3.5.2'
+__version__ = '3.6.0'
 
 
 def init_app(

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -237,6 +237,15 @@ class DataAPIClient(BaseAPIClient):
                 },
             })
 
+    def copy_draft_service(self, draft_id, user):
+        return self._post(
+            "/draft-services/{}/copy".format(draft_id),
+            data={
+                "update_details": {
+                    "updated_by": user
+                }
+            })
+
     def update_draft_service(self, draft_id, service, user):
         return self._post(
             "/draft-services/{}".format(draft_id),

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -825,6 +825,23 @@ class TestDataApiClient(object):
             }
         }
 
+    def test_copy_draft_service(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/draft-services/2/copy",
+            json={"done": "copy"},
+            status_code=201,
+        )
+
+        result = data_client.copy_draft_service(2, 'user')
+
+        assert result == {"done": "copy"}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'update_details': {
+                'updated_by': 'user'
+            }
+        }
+
     def test_update_draft_service(self, data_client, rmock):
         rmock.post(
             "http://baseurl/draft-services/2",


### PR DESCRIPTION
Takes a `draft_id` of an existing service draft and creates a copy.

Depends (?) on https://github.com/alphagov/digitalmarketplace-api/pull/172