### PR TITLE
Add find_users method and test.

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,7 +2,7 @@ from . import logging, config, proxy_fix
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '3.2.0'
+__version__ = '3.3.0'
 
 
 def init_app(

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -130,7 +130,13 @@ class DataAPIClient(BaseAPIClient):
             raise ValueError("Either user_id or email_address must be set")
 
         try:
-            return self._get(url, params=params)
+            user = self._get(url, params=params)
+
+            if isinstance(user['users'], list):
+                user['users'] = user['users'][0]
+
+            return user
+
         except HTTPError as e:
             if e.status_code != 404:
                 raise

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -113,6 +113,9 @@ class DataAPIClient(BaseAPIClient):
                 "users": user,
             })
 
+    def find_users(self, supplier_id):
+        return self._get("/users?supplier_id={}".format(supplier_id))
+
     def get_user(self, user_id=None, email_address=None):
         if user_id is not None and email_address is not None:
             raise ValueError(
@@ -122,7 +125,7 @@ class DataAPIClient(BaseAPIClient):
             params = {}
         elif email_address is not None:
             url = "{}/users".format(self.base_url)
-            params = {"email": email_address}
+            params = {"email_address": email_address}
         else:
             raise ValueError("Either user_id or email_address must be set")
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -425,6 +425,15 @@ class TestDataApiClient(object):
         assert result == {"services": "result"}
         assert rmock.called
 
+    def test_find_users_by_supplier_id(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/users?supplier_id=1234",
+            json=self.user(),
+            status_code=200)
+        user = data_client.find_users(1234)
+
+        assert user == self.user()
+
     def test_get_user_by_id(self, data_client, rmock):
         rmock.get(
             "http://baseurl/users/1234",
@@ -436,7 +445,7 @@ class TestDataApiClient(object):
 
     def test_get_user_by_email_address(self, data_client, rmock):
         rmock.get(
-            "http://baseurl/users?email=myemail",
+            "http://baseurl/users?email_address=myemail",
             json=self.user(),
             status_code=200)
         user = data_client.get_user(email_address="myemail")


### PR DESCRIPTION
**[Pull request #170](https://github.com/alphagov/digitalmarketplace-api/pull/170) in the API needs to be merged before these methods can be used**

Adds a `find_users` method to list users, but enforces a `supplier_id` as a parameter.  While the API doesn't care if a `supplier_id` is given, we probably don't want frontend apps to have access to that functionality at this point.

Additionally, the query parameter for getting a user's email has changed in the API (so I've changed that in the `get_user` method), but there's no change to the interface presented by the DataAPIClient.

[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/98628954)