### PR TITLE
Update users

### DIFF
--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -57,14 +57,9 @@ class DataAPIClient(BaseAPIClient):
         )
 
     def get_supplier(self, supplier_id):
-        try:
-            return self._get(
-                "/suppliers/{}".format(supplier_id)
-            )
-        except HTTPError as e:
-            if e.status_code != 404:
-                raise
-        return None
+        return self._get(
+            "/suppliers/{}".format(supplier_id)
+        )
 
     def create_supplier(self, supplier_id, supplier):
         return self._put(
@@ -179,33 +174,28 @@ class DataAPIClient(BaseAPIClient):
             return False
 
     def update_user(self, user_id, locked=None, active=None):
-        try:
-            fields = {}
-            if locked is not None:
-                fields.update({
-                    'locked': locked
-                })
+        fields = {}
+        if locked is not None:
+            fields.update({
+                'locked': locked
+            })
 
-            if active is not None:
-                fields.update({
-                    'active': active
-                })
+        if active is not None:
+            fields.update({
+                'active': active
+            })
 
-            params = {
-                "users": fields
-            }
+        params = {
+            "users": fields
+        }
 
-            user = self._post(
-                '/users/{}'.format(user_id),
-                data=params
-            )
+        user = self._post(
+            '/users/{}'.format(user_id),
+            data=params
+        )
 
-            logger.info("Updated user %s fields %s", user_id, params)
-            return user
-        except HTTPError as e:
-            logger.info("User update failed for user %s : %s",
-                        user_id, e.status_code)
-            return None
+        logger.info("Updated user %s fields %s", user_id, params)
+        return user
 
     # Services
 

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -173,6 +173,35 @@ class DataAPIClient(BaseAPIClient):
                         user_id, e.status_code)
             return False
 
+    def update_user(self, user_id, locked=None, active=None):
+        try:
+            fields = {}
+            if locked is not None:
+                fields.update({
+                    'locked': locked
+                })
+
+            if active is not None:
+                fields.update({
+                    'active': active
+                })
+
+            params = {
+                "users": fields
+            }
+
+            user = self._post(
+                '/users/{}'.format(user_id),
+                data=params
+            )
+
+            logger.info("Updated user %s fields %s", user_id, params)
+            return user
+        except HTTPError as e:
+            logger.info("User update failed for user %s : %s",
+                        user_id, e.status_code)
+            return None
+
     # Services
 
     def find_draft_services(

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -57,9 +57,14 @@ class DataAPIClient(BaseAPIClient):
         )
 
     def get_supplier(self, supplier_id):
-        return self._get(
-            "/suppliers/{}".format(supplier_id)
-        )
+        try:
+            return self._get(
+                "/suppliers/{}".format(supplier_id)
+            )
+        except HTTPError as e:
+            if e.status_code != 404:
+                raise
+        return None
 
     def create_supplier(self, supplier_id, supplier):
         return self._put(

--- a/dmutils/user.py
+++ b/dmutils/user.py
@@ -7,20 +7,23 @@ def user_has_role(user, role):
 
 class User():
     def __init__(self, user_id, email_address, supplier_id, supplier_name,
-                 locked):
+                 locked, active):
         self.id = user_id
         self.email_address = email_address
         self.supplier_id = supplier_id
         self.supplier_name = supplier_name
         self.locked = locked
+        self.active = active
 
     @staticmethod
     def is_authenticated():
         return True
 
-    @staticmethod
-    def is_active():
-        return True
+    def is_active(self):
+        return self.active
+
+    def is_locked(self):
+        return self.locked
 
     @staticmethod
     def is_anonymous():
@@ -54,5 +57,6 @@ class User():
             email_address=user['emailAddress'],
             supplier_id=supplier_id,
             supplier_name=supplier_name,
-            locked=user['locked']
+            locked=user['locked'],
+            active=user['active']
         )

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -579,14 +579,16 @@ class TestDataApiClient(object):
                 status_code=status_code)
             assert not data_client.update_user_password(123, "newpassword")
 
-    def test_update_user_returns_false_on_non_200(
-            self, data_client, rmock):
+    def test_update_user_returns_false_on_non_200(self, data_client, rmock):
         for status_code in [400, 403, 404, 500]:
             rmock.post(
-                "http://baseurl/users/123",
-                json={},
-                status_code=status_code)
-            assert not data_client.update_user(123, active=True)
+                    "http://baseurl/users/123",
+                    json={},
+                    status_code=status_code)
+            with pytest.raises(HTTPError) as e:
+                data_client.update_user(123)
+
+            assert e.value.status_code == status_code
 
     def test_can_unlock_user(self, data_client, rmock):
         rmock.post(
@@ -710,10 +712,10 @@ class TestDataApiClient(object):
             "http://baseurl/suppliers/123",
             status_code=404)
 
-        result = data_client.get_supplier(123)
-
-        assert not result
-        assert rmock.called
+        try:
+            data_client.get_supplier(123)
+        except HTTPError:
+            assert rmock.called
 
     def test_create_supplier(self, data_client, rmock):
         rmock.put(

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -705,6 +705,16 @@ class TestDataApiClient(object):
         assert result == {"services": "result"}
         assert rmock.called
 
+    def test_get_supplier_by_id_should_return_404(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/suppliers/123",
+            status_code=404)
+
+        result = data_client.get_supplier(123)
+
+        assert not result
+        assert rmock.called
+
     def test_create_supplier(self, data_client, rmock):
         rmock.put(
             "http://baseurl/suppliers/123",

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -579,6 +579,48 @@ class TestDataApiClient(object):
                 status_code=status_code)
             assert not data_client.update_user_password(123, "newpassword")
 
+    def test_update_user_returns_false_on_non_200(
+            self, data_client, rmock):
+        for status_code in [400, 403, 404, 500]:
+            rmock.post(
+                "http://baseurl/users/123",
+                json={},
+                status_code=status_code)
+            assert not data_client.update_user(123, active=True)
+
+    def test_can_unlock_user(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/users/123",
+            json={},
+            status_code=200)
+        data_client.update_user(123, locked=False)
+        assert rmock.called
+        assert rmock.last_request.json() == {
+            "users": {"locked": False}
+        }
+
+    def test_can_activate_user(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/users/123",
+            json={},
+            status_code=200)
+        data_client.update_user(123, active=True)
+        assert rmock.called
+        assert rmock.last_request.json() == {
+            "users": {"active": True}
+        }
+
+    def test_can_deactivate_user(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/users/123",
+            json={},
+            status_code=200)
+        data_client.update_user(123, active=False)
+        assert rmock.called
+        assert rmock.last_request.json() == {
+            "users": {"active": False}
+        }
+
     @staticmethod
     def user():
         return {'users': {

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -22,10 +22,13 @@ def test_User_from_json():
         'id': 123,
         'emailAddress': 'test@example.com',
         'locked': False,
+        'active': True
     }})
 
     assert user.id == 123
     assert user.email_address == 'test@example.com'
+    assert not user.is_locked()
+    assert user.is_active()
 
 
 def test_User_from_json_with_supplier():
@@ -33,6 +36,7 @@ def test_User_from_json_with_supplier():
         'id': 123,
         'emailAddress': 'test@example.com',
         'locked': False,
+        'active': True,
         'supplier': {
             'supplierId': 321,
             'name': 'test supplier',


### PR DESCRIPTION
Added:

- Handler for 404 on get supplier - so client gets a None not an exeption in case of missing resource

- Update user endpoint so can updated *active* and *locked* aspects of a service

- Added an active flag to the user
