### PR TITLE
Add asset fingerprinting

### DIFF
--- a/dmutils/asset_fingerprint.py
+++ b/dmutils/asset_fingerprint.py
@@ -1,20 +1,45 @@
 import hashlib
 
 
-def get_asset_fingerprint(asset_file_path):
+class AssetFingerprinter():
     """
         Get a unique hash for an asset file, so that it doesn't stay cached
         when it changes
 
         Usage:
-        get('app/static/stylesheets/application.css')
+
+            Config.py:
+            base_template_data.asset_fingerprinter = AssetFingerprinter(
+                asset_root='/suppliers/static/'
+            )
+
+            _base_template.html:
+            {{ asset_fingerprinter.get_url('stylesheets/application.css') }}
+
+        * 'app/static' is assumed to be the root for all asset files
     """
-    return hashlib.md5().update(
-        get_asset_file_contents(asset_file_path)
-    ).hexdigest()
 
+    def __init__(self, asset_root='/static/', filesystem_path='app/static/'):
+        self._cache = {}
+        self._asset_root = asset_root
+        self._filesystem_path = filesystem_path
 
-def get_asset_file_contents(asset_file_path):
-    with open(asset_file_path, 'rb') as asset_file:
-        contents = asset_file.read()
-    return contents
+    def get_url(self, asset_path):
+        if asset_path not in self._cache:
+            self._cache[asset_path] = (
+                self._asset_root +
+                asset_path +
+                '?' +
+                self.get_asset_fingerprint(self._filesystem_path + asset_path)
+            )
+        return self._cache[asset_path]
+
+    def get_asset_fingerprint(self, asset_file_path):
+        return hashlib.md5(
+            self.get_asset_file_contents(asset_file_path).encode('utf-8')
+        ).hexdigest()
+
+    def get_asset_file_contents(self, asset_file_paths):
+        with open(asset_file_path, 'rb') as asset_file:
+            contents = asset_file.read()
+        return contents

--- a/dmutils/asset_fingerprint.py
+++ b/dmutils/asset_fingerprint.py
@@ -1,0 +1,20 @@
+import hashlib
+
+
+def get_asset_fingerprint(asset_file_path):
+    """
+        Get a unique hash for an asset file, so that it doesn't stay cached
+        when it changes
+
+        Usage:
+        get('app/static/stylesheets/application.css')
+    """
+    return hashlib.md5().update(
+        get_asset_file_contents(asset_file_path)
+    ).hexdigest()
+
+
+def get_asset_file_contents(asset_file_path):
+    with open(asset_file_path, 'rb') as asset_file:
+        contents = asset_file.read()
+    return contents

--- a/tests/test_asset_fingerprint.py
+++ b/tests/test_asset_fingerprint.py
@@ -1,0 +1,89 @@
+# coding=utf-8
+import mock
+
+from dmutils.asset_fingerprint import AssetFingerprinter
+
+
+@mock.patch(
+    'dmutils.asset_fingerprint.AssetFingerprinter.get_asset_file_contents'
+)
+class TestAssetFingerprint(object):
+    def test_url_format(self, get_file_content_mock):
+        get_file_content_mock.return_value = """
+            body {
+                font-family: nta;
+            }
+        """
+        asset_fingerprinter = AssetFingerprinter(
+            asset_root='/suppliers/static/'
+        )
+        assert (
+            asset_fingerprinter.get_url('application.css') ==
+            '/suppliers/static/application.css?418e6f4a6cdf1142e45c072ed3e1c90a'  # noqa
+        )
+        assert (
+            asset_fingerprinter.get_url('application-ie6.css') ==
+            '/suppliers/static/application-ie6.css?418e6f4a6cdf1142e45c072ed3e1c90a'  # noqa
+        )
+
+    def test_building_file_path(self, get_file_content_mock):
+        get_file_content_mock.return_value = """
+            document.write('Hello world!');
+        """
+        fingerprinter = AssetFingerprinter()
+        fingerprinter.get_url('javascripts/application.js')
+        fingerprinter.get_asset_file_contents.assert_called_with(
+            'app/static/javascripts/application.js'
+        )
+
+    def test_hashes_are_consistent(self, get_file_content_mock):
+        get_file_content_mock.return_value = """
+            body {
+                font-family: nta;
+            }
+        """
+        asset_fingerprinter = AssetFingerprinter()
+        assert (
+            asset_fingerprinter.get_asset_fingerprint('application.css') ==
+            asset_fingerprinter.get_asset_fingerprint('same_contents.css')
+        )
+
+    def test_hashes_are_different_for_different_files(
+        self, get_file_content_mock
+    ):
+        asset_fingerprinter = AssetFingerprinter()
+        get_file_content_mock.return_value = """
+            body {
+                font-family: nta;
+            }
+        """
+        css_hash = asset_fingerprinter.get_asset_fingerprint('application.css')
+        get_file_content_mock.return_value = """
+            document.write('Hello world!');
+        """
+        js_hash = asset_fingerprinter.get_asset_fingerprint('application.js')
+        assert (
+            js_hash != css_hash
+        )
+
+    def test_hash_gets_cached(self, get_file_content_mock):
+        get_file_content_mock.return_value = """
+            body {
+                font-family: nta;
+            }
+        """
+        fingerprinter = AssetFingerprinter()
+        assert (
+            fingerprinter.get_url('application.css') ==
+            '/static/application.css?418e6f4a6cdf1142e45c072ed3e1c90a'
+        )
+        fingerprinter._cache[
+            'application.css'
+        ] = 'a1a1a1'
+        assert (
+            fingerprinter.get_url('application.css') ==
+            'a1a1a1'
+        )
+        fingerprinter.get_asset_file_contents.assert_called_once_with(
+            'app/static/application.css'
+        )


### PR DESCRIPTION
## 1. 	Extract generation of asset fingerprints from apps

This util generates a hash of file contents. This enables us to serve assets from different URLs if they are changed, which means they wont be loaded from browser cache.

This is already [implemented in the buyer app](https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/111) but it seems sensible to share it between the apps.

## 2. Generate URLs within the util

@robyoung pointed out that we need to generate URLs for about 6 asset files now (rather than two), which would mean quite a lot of repetition in each apps templates and `Config.py`s.

This commit makes 'asset fingerprinter' into a class, and gives it a method to return the path and querystring for an asset, rather than just the hash.

Usage

**`Config.py`:**
```
config.asset_fingerprinter = AssetFingerprinter()
```

**`_base_template.html`:**
```
{{ asset_fingerprinter.get_url('stylesheets/application.css') }}
```

**Result:**
```
static/stylesheets/application.css?418e6f4a6cdf1142e45c072ed3e1c90a
```
"""

Addresses [98936730](https://www.pivotaltracker.com/story/show/98936730)