### PR TITLE
Add display date formats and template filters

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -1,8 +1,9 @@
-from . import logging, config, proxy_fix
+from . import logging, config, proxy_fix, formats
+from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '3.4.0'
+__version__ = '3.5.0'
 
 
 def init_app(
@@ -45,3 +46,21 @@ def init_app(
     def add_header(response):
         response.headers['X-Frame-Options'] = 'DENY'
         return response
+
+    @application.template_filter('timeformat')
+    def timeformat(value):
+        if not isinstance(value, datetime):
+            value = datetime.strptime(value, formats.DATETIME_FORMAT)
+        return value.strftime(formats.DISPLAY_TIME_FORMAT)
+
+    @application.template_filter('dateformat')
+    def dateformat(value):
+        if not isinstance(value, datetime):
+            value = datetime.strptime(value, formats.DATETIME_FORMAT)
+        return value.strftime(formats.DISPLAY_DATE_FORMAT)
+
+    @application.template_filter('datetimeformat')
+    def datetimeformat(value):
+        if not isinstance(value, datetime):
+            value = datetime.strptime(value, formats.DATETIME_FORMAT)
+        return value.strftime(formats.DISPLAY_DATETIME_FORMAT)

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -1,5 +1,8 @@
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_FORMAT = "%Y-%m-%d"
+DISPLAY_DATE_FORMAT = '%d/%m/%Y'
+DISPLAY_TIME_FORMAT = '%H:%M:%S'
+DISPLAY_DATETIME_FORMAT = '%A, %d %B %Y at %H:%M'
 
 LOTS = [
     {


### PR DESCRIPTION
Both in the admin app and the supplier app we need to display dates, so it was just a matter of time before the date display logic ended up here.

After this update, all apps using dmutils will be able to use `timeformat`, `dateformat`, and `datetimeformat` in their templates.