### PR TITLE
Return all (in)active users from the API.

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '3.6.0'
+__version__ = '3.7.0'
 
 
 def init_app(

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -113,8 +113,15 @@ class DataAPIClient(BaseAPIClient):
                 "users": user,
             })
 
-    def find_users(self, supplier_id):
-        return self._get("/users?supplier_id={}".format(supplier_id))
+    def find_users(self, supplier_id, active=None):
+        params = {
+            'supplier_id': supplier_id
+        }
+
+        if active is not None:
+            params["active"] = active
+
+        return self._get("/users", params=params)
 
     def get_user(self, user_id=None, email_address=None):
         if user_id is not None and email_address is not None:

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -434,6 +434,23 @@ class TestDataApiClient(object):
 
         assert user == self.user()
 
+    def test_find_active_or_inactive_users_by_supplier_id(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/users?supplier_id=1234&active=true",
+            json=self.user(),
+            status_code=200)
+        user = data_client.find_users(1234, active=True)
+
+        assert user == self.user()
+
+        rmock.get(
+            "http://baseurl/users?supplier_id=1234&active=false",
+            json={},
+            status_code=200)
+        user = data_client.find_users(1234, active=False)
+
+        assert user == {}
+
     def test_get_user_by_id(self, data_client, rmock):
         rmock.get(
             "http://baseurl/users/1234",


### PR DESCRIPTION
Added optional `active` parameter to `find_users` in the DataAPIClient.
Now we can choose to return either all active or all inactive users belonging to a supplier.
Or we can just return them all as before, if we're not particularly bothered.