### PR TITLE
Make User model better reflect auth state

### DIFF
--- a/dmutils/user.py
+++ b/dmutils/user.py
@@ -58,3 +58,13 @@ class User():
             locked=user['locked'],
             active=user['active']
         )
+
+    @staticmethod
+    def load_user(data_api_client, user_id):
+        """Load a user from the API and hydrate the User model"""
+        user_json = data_api_client.get_user(user_id=int(user_id))
+
+        if user_json:
+            user = User.from_json(user_json)
+            if user.is_active():
+                return user

--- a/dmutils/user.py
+++ b/dmutils/user.py
@@ -15,18 +15,16 @@ class User():
         self.locked = locked
         self.active = active
 
-    @staticmethod
-    def is_authenticated():
-        return True
+    def is_authenticated(self):
+        return self.is_active()
 
     def is_active(self):
-        return self.active
+        return self.active and not self.locked
 
     def is_locked(self):
         return self.locked
 
-    @staticmethod
-    def is_anonymous():
+    def is_anonymous(self):
         return False
 
     def get_id(self):

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,4 +1,10 @@
+import pytest
 from dmutils.user import user_has_role, User
+
+
+@pytest.fixture
+def user():
+    return User(123, 'test@example.com', 321, 'test supplier', False, True)
 
 
 def test_user_has_role():
@@ -46,3 +52,38 @@ def test_User_from_json_with_supplier():
     assert user.email_address == 'test@example.com'
     assert user.supplier_id == 321
     assert user.supplier_name == 'test supplier'
+
+
+def test_user_is_active(user):
+    user.active = True
+    user.locked = False
+
+    assert user.is_active()
+
+
+def test_user_is_not_active_if_locked(user):
+    user.active = True
+    user.locked = True
+
+    assert not user.is_active()
+
+
+def test_user_is_authenticated(user):
+    user.active = True
+    user.locked = False
+
+    assert user.is_authenticated()
+
+
+def test_user_is_not_authenticated_if_not_active(user):
+    user.active = False
+    user.locked = False
+
+    assert not user.is_authenticated()
+
+
+def test_user_is_not_authenticated_if_locked(user):
+    user.active = True
+    user.locked = True
+
+    assert not user.is_authenticated()


### PR DESCRIPTION
This change makes the Flask-Login interface methods on the User model better reflect the intended authentication state of a user account. After this change the following statements hold true.

- A Flask-Login User cannot be considered active if the account is locked.
- A Flask-Login User cannot be considered authenticated if it is not active.