### PR TITLE
Adding email integration into utils

### DIFF
--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -173,7 +173,12 @@ class DataAPIClient(BaseAPIClient):
                         user_id, e.status_code)
             return False
 
-    def update_user(self, user_id, locked=None, active=None):
+    def update_user(self,
+                    user_id,
+                    locked=None,
+                    active=None,
+                    role=None,
+                    supplier_id=None):
         fields = {}
         if locked is not None:
             fields.update({
@@ -183,6 +188,16 @@ class DataAPIClient(BaseAPIClient):
         if active is not None:
             fields.update({
                 'active': active
+            })
+
+        if role is not None:
+            fields.update({
+                'role': role
+            })
+
+        if supplier_id is not None:
+            fields.update({
+                'supplierId': supplier_id
             })
 
         params = {

--- a/dmutils/email.py
+++ b/dmutils/email.py
@@ -1,0 +1,74 @@
+from flask import url_for, current_app, render_template
+import mandrill
+from itsdangerous import URLSafeTimedSerializer
+from datetime import datetime
+from dmutils.formats import DATETIME_FORMAT
+
+
+def send_password_email(
+        user_id,
+        email_address,
+        locked,
+        api_key,
+        subject,
+        from_email,
+        from_name,
+        secret_key,
+        salt):
+    try:
+        mandrill_client = mandrill.Mandrill(api_key)
+        url = generate_reset_url(user_id, email_address, secret_key, salt)
+        body = render_template("emails/reset_password_email.html",
+                               url=url, locked=locked)
+        message = {'html': body,
+                   'subject': subject,
+                   'from_email': from_email,
+                   'from_name': from_name,
+                   'to': [{'email': email_address,
+                           'name': 'Recipient Name',
+                           'type': 'to'}],
+                   'important': False,
+                   'track_opens': None,
+                   'track_clicks': None,
+                   'auto_text': True,
+                   'tags': ['password-resets'],
+                   'headers': {'Reply-To': from_email},  # noqa
+                   'recipient_metadata': [
+                       {'rcpt': email_address,
+                        'values': {'user_id': user_id}}]
+        }
+        result = mandrill_client.messages.send(message=message, async=False,
+                                               ip_pool='Main Pool')
+    except mandrill.Error as e:
+        # Mandrill errors are thrown as exceptions
+        current_app.logger.error("A mandrill error occurred: %s", e)
+        return
+    current_app.logger.info("Sent password email: %s", result)
+
+
+def generate_reset_url(user_id, email_address, secret_key, salt):
+    ts = URLSafeTimedSerializer(secret_key)
+    token = ts.dumps(
+        {
+            "user": user_id,
+            "email": email_address
+        },
+        salt=salt)
+    url = url_for('main.reset_password', token=token, _external=True)
+    current_app.logger.debug("Generated reset URL: %s", url)
+    return url
+
+
+def decode_email(token, key, salt):
+    ts = URLSafeTimedSerializer(key)
+    decoded = ts.loads(token,
+                       salt=salt,
+                       max_age=86400, return_timestamp=True)
+    return decoded
+
+
+def token_created_before_password_last_changed(token_timestamp, user):
+
+        password_last_changed = datetime.strptime(
+            user['users']['passwordChangedAt'], DATETIME_FORMAT)
+        return token_timestamp < password_last_changed

--- a/dmutils/email.py
+++ b/dmutils/email.py
@@ -47,7 +47,7 @@ def send_email(
     except Error as e:
         # Mandrill errors are thrown as exceptions
         current_app.logger.error("A mandrill error occurred: %s", e)
-        raise MandrillException(e.message)
+        raise MandrillException(e)
 
     current_app.logger.info("Sent password email: %s", result)
 

--- a/dmutils/email.py
+++ b/dmutils/email.py
@@ -8,7 +8,6 @@ class MandrillException(Exception):
 
 
 def send_email(
-        user_id,
         email_address,
         email_body,
         api_key,
@@ -36,10 +35,7 @@ def send_email(
             'tags': tags,
             'headers': {'Reply-To': from_email},  # noqa
             'recipient_metadata': [{
-                'rcpt': email_address,
-                'values': {
-                    'user_id': user_id
-                }
+                'rcpt': email_address
             }]
         }
 

--- a/dmutils/email.py
+++ b/dmutils/email.py
@@ -1,4 +1,4 @@
-from flask import url_for, current_app, render_template
+from flask import current_app
 import mandrill
 from itsdangerous import URLSafeTimedSerializer
 from datetime import datetime
@@ -56,10 +56,3 @@ def decode_token(token, secret_key, salt):
         return_timestamp=True
     )
     return decoded, timestamp
-
-
-def token_created_before_password_last_changed(token_timestamp, user):
-
-        password_last_changed = datetime.strptime(
-            user['users']['passwordChangedAt'], DATETIME_FORMAT)
-        return token_timestamp < password_last_changed

--- a/dmutils/user.py
+++ b/dmutils/user.py
@@ -7,9 +7,10 @@ def user_has_role(user, role):
 
 class User():
     def __init__(self, user_id, email_address, supplier_id, supplier_name,
-                 locked, active):
+                 locked, active, name):
         self.id = user_id
         self.email_address = email_address
+        self.name = name
         self.supplier_id = supplier_id
         self.supplier_name = supplier_name
         self.locked = locked
@@ -38,6 +39,7 @@ class User():
     def serialize(self):
         return {
             'id': self.id,
+            'name': self.name,
             'emailAddress': self.email_address,
             'supplierId': self.supplier_id,
             'supplierName': self.supplier_name,
@@ -59,4 +61,5 @@ class User():
             supplier_name=supplier_name,
             locked=user.get('locked', False),
             active=user.get('active', True),
+            name=user['name']
         )

--- a/dmutils/user.py
+++ b/dmutils/user.py
@@ -57,6 +57,6 @@ class User():
             email_address=user['emailAddress'],
             supplier_id=supplier_id,
             supplier_name=supplier_name,
-            locked=user['locked'],
-            active=user['active']
+            locked=user.get('locked', False),
+            active=user.get('active', True),
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyyaml==3.11
 inflection==0.2.1
 Flask-FeatureFlags==0.6
 enum34==1.0.4
+mandrill==1.0.57

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -590,6 +590,42 @@ class TestDataApiClient(object):
 
             assert e.value.status_code == status_code
 
+    def test_can_change_user_role(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/users/123",
+            json={},
+            status_code=200)
+        data_client.update_user(123, role='supplier')
+        assert rmock.called
+        assert rmock.last_request.json() == {
+            "users": {"role": 'supplier'}
+        }
+
+    def test_can_add_user_supplier_id(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/users/123",
+            json={},
+            status_code=200)
+        data_client.update_user(123, supplier_id=123)
+        assert rmock.called
+        assert rmock.last_request.json() == {
+            "users": {"supplierId": 123}
+        }
+
+    def test_make_user_a_supplier(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/users/123",
+            json={},
+            status_code=200)
+        data_client.update_user(123, supplier_id=123, role='supplier')
+        assert rmock.called
+        assert rmock.last_request.json() == {
+            "users": {
+                "supplierId": 123,
+                "role": "supplier"
+            }
+        }
+
     def test_can_unlock_user(self, data_client, rmock):
         rmock.post(
             "http://baseurl/users/123",

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,11 +1,6 @@
-from datetime import datetime, timedelta
-
-from dmutils.email import token_created_before_password_last_changed, \
-    generate_token, decode_token
-from dmutils.formats import DATETIME_FORMAT
+from dmutils.email import generate_token, decode_token
 from itsdangerous import BadTimeSignature
 import pytest
-
 
 
 def test_can_generate_token():

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -81,7 +81,7 @@ def test_should_throw_exception_if_mandrill_fails(email_app, mandrill):
 
             )
         except MandrillException as e:
-            assert e.message == "this is an error"
+            assert str(e) == "this is an error"
 
 
 def test_can_generate_token():

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,7 +1,10 @@
 from datetime import datetime, timedelta
 
-from dmutils.email import token_created_before_password_last_changed
+from dmutils.email import token_created_before_password_last_changed, \
+    generate_token, decode_token
 from dmutils.formats import DATETIME_FORMAT
+from itsdangerous import BadTimeSignature
+import pytest
 
 
 def test_returns_true_if_user_changed_password_after_token():
@@ -30,3 +33,41 @@ def test_returns_false_if_user_changed_password_after_token():
     }
 
     assert not token_created_before_password_last_changed(tomorrow, user)
+
+
+def test_can_generate_token():
+    token = generate_token({
+        "key1": "value1",
+        "key2": "value2"},
+        secret_key="1234567890",
+        salt="1234567890")
+
+    token, timestamp = decode_token(token, "1234567890", "1234567890")
+    assert {
+        "key1": "value1",
+        "key2": "value2"} == token
+    assert timestamp
+
+
+def test_cant_decode_token_with_wrong_salt():
+    token = generate_token({
+        "key1": "value1",
+        "key2": "value2"},
+        secret_key="1234567890",
+        salt="1234567890")
+
+    with pytest.raises(BadTimeSignature) as error:
+        decode_token(token, "1234567890", "failed")
+    assert "does not match" in str(error.value)
+
+
+def test_cant_decode_token_with_wrong_key():
+    token = generate_token({
+        "key1": "value1",
+        "key2": "value2"},
+        secret_key="1234567890",
+        salt="1234567890")
+
+    with pytest.raises(BadTimeSignature) as error:
+        decode_token(token, "failed", "1234567890")
+    assert "does not match" in str(error.value)

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -42,15 +42,11 @@ def test_calls_send_email_with_correct_params(email_app, mandrill):
             'tags': ['password-resets'],
             'headers': {'Reply-To': "from_email"},  # noqa
             'recipient_metadata': [{
-                'rcpt': "email_address",
-                'values': {
-                    'user_id': 123
-                }
+                'rcpt': "email_address"
             }]
         }
 
         send_email(
-            123,
             "email_address",
             "body",
             "api_key",
@@ -75,7 +71,6 @@ def test_should_throw_exception_if_mandrill_fails(email_app, mandrill):
 
         try:
             send_email(
-                123,
                 "email_address",
                 "body",
                 "api_key",

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,6 +1,92 @@
-from dmutils.email import generate_token, decode_token
+from dmutils.email import generate_token, decode_token, \
+    send_email, MandrillException
 from itsdangerous import BadTimeSignature
 import pytest
+import mock
+from dmutils.config import init_app
+from mandrill import Error
+
+
+@pytest.yield_fixture
+def mandrill():
+    with mock.patch('dmutils.email.Mandrill') as Mandrill:
+        instance = Mandrill.return_value
+        yield instance
+
+
+@pytest.yield_fixture
+def email_app(app):
+    init_app(app)
+    yield app
+
+
+def test_calls_send_email_with_correct_params(email_app, mandrill):
+    with email_app.app_context():
+
+        mandrill.messages.send.return_value = True
+
+        expected_call = {
+            'html': "body",
+            'subject': "subject",
+            'from_email': "from_email",
+            'from_name': "from_name",
+            'to': [{
+                'email': "email_address",
+                'name': 'Recipient Name',
+                'type': 'to'
+            }],
+            'important': False,
+            'track_opens': None,
+            'track_clicks': None,
+            'auto_text': True,
+            'tags': ['password-resets'],
+            'headers': {'Reply-To': "from_email"},  # noqa
+            'recipient_metadata': [{
+                'rcpt': "email_address",
+                'values': {
+                    'user_id': 123
+                }
+            }]
+        }
+
+        send_email(
+            123,
+            "email_address",
+            "body",
+            "api_key",
+            "subject",
+            "from_email",
+            "from_name",
+            ["password-resets"]
+
+        )
+
+        mandrill.messages.send.assert_called_once_with(
+            message=expected_call,
+            async=False,
+            ip_pool='Main Pool'
+        )
+
+
+def test_should_throw_exception_if_mandrill_fails(email_app, mandrill):
+    with email_app.app_context():
+
+        mandrill.messages.send.side_effect = Error("this is an error")
+
+        try:
+            send_email(
+                123,
+                "email_address",
+                "body",
+                "api_key",
+                "subject",
+                "from_email",
+                "from_name",
+                ["password-resets"]
+
+            )
+        except MandrillException as e:
+            assert e.message == "this is an error"
 
 
 def test_can_generate_token():

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -7,33 +7,6 @@ from itsdangerous import BadTimeSignature
 import pytest
 
 
-def test_returns_true_if_user_changed_password_after_token():
-
-    now = datetime.now()
-    yesterday = datetime.today() - timedelta(days=1)
-
-    user = {
-        "users": {
-            "passwordChangedAt": now.strftime(DATETIME_FORMAT)
-        }
-    }
-
-    assert token_created_before_password_last_changed(yesterday, user)
-
-
-def test_returns_false_if_user_changed_password_after_token():
-
-    now = datetime.now()
-    tomorrow = datetime.today() + timedelta(days=1)
-
-    user = {
-        "users": {
-            "passwordChangedAt": now.strftime(DATETIME_FORMAT)
-        }
-    }
-
-    assert not token_created_before_password_last_changed(tomorrow, user)
-
 
 def test_can_generate_token():
     token = generate_token({

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timedelta
+
+from dmutils.email import token_created_before_password_last_changed
+from dmutils.formats import DATETIME_FORMAT
+
+
+def test_returns_true_if_user_changed_password_after_token():
+
+    now = datetime.now()
+    yesterday = datetime.today() - timedelta(days=1)
+
+    user = {
+        "users": {
+            "passwordChangedAt": now.strftime(DATETIME_FORMAT)
+        }
+    }
+
+    assert token_created_before_password_last_changed(yesterday, user)
+
+
+def test_returns_false_if_user_changed_password_after_token():
+
+    now = datetime.now()
+    tomorrow = datetime.today() + timedelta(days=1)
+
+    user = {
+        "users": {
+            "passwordChangedAt": now.strftime(DATETIME_FORMAT)
+        }
+    }
+
+    assert not token_created_before_password_last_changed(tomorrow, user)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -5,7 +5,7 @@ from dmutils.user import user_has_role, User
 
 @pytest.fixture
 def user():
-    return User(123, 'test@example.com', 321, 'test supplier', False, True)
+    return User(123, 'test@example.com', 321, 'test supplier', False, True, "Name")
 
 
 @pytest.fixture
@@ -14,6 +14,7 @@ def user_json():
         "users": {
             "id": 123,
             "emailAddress": "test@example.com",
+            "name": "name",
             "locked": False,
             "active": True,
             "supplier": {

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -22,10 +22,12 @@ def test_User_from_json():
         'id': 123,
         'emailAddress': 'test@example.com',
         'locked': False,
-        'active': True
+        'active': True,
+        'name': 'Name'
     }})
 
     assert user.id == 123
+    assert user.name == 'Name'
     assert user.email_address == 'test@example.com'
     assert not user.is_locked()
     assert user.is_active()
@@ -34,6 +36,7 @@ def test_User_from_json():
 def test_User_from_json_with_supplier():
     user = User.from_json({'users': {
         'id': 123,
+        'name': 'Name',
         'emailAddress': 'test@example.com',
         'locked': False,
         'active': True,
@@ -43,6 +46,7 @@ def test_User_from_json_with_supplier():
         }
     }})
     assert user.id == 123
+    assert user.name == 'Name'
     assert user.email_address == 'test@example.com'
     assert user.supplier_id == 321
     assert user.supplier_name == 'test supplier'


### PR DESCRIPTION
Pull request to support sending of emails in utils

This migrates the mandrill code out of the supplier app and into the utils classes. This supports pivotal stories:

https://www.pivotaltracker.com/n/projects/997836/stories/98628914
and
https://www.pivotaltracker.com/n/projects/997836/stories/100192466

Moves all mandrill code into an email.py class with associated tests.

Also adds some extensions to user functionality:

- adds name to response
- allows updating of supplier_id and role