### PR TITLE
Extract attribute helper from buyer frontend

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '3.7.0'
+__version__ = '3.8.0'
 
 
 def init_app(

--- a/dmutils/service_attribute.py
+++ b/dmutils/service_attribute.py
@@ -1,0 +1,44 @@
+class Attribute(object):
+    """Wrapper to handle accessing an attribute in service_data"""
+
+    def __init__(
+        self,
+        value,
+        question_type,
+        label='',
+        optional=False,
+    ):
+        self.label = label
+        self.answer_required = False
+        if value in ['', [], None]:
+            self.value = ''
+            self.type = 'text'
+            self.assurance = False
+            if not optional:
+                self.answer_required = True
+        else:
+            self.value, self.assurance = self._unpack_assurance(value)
+            self.type = question_type
+
+    def _unpack_assurance(self, value):
+        if (
+            isinstance(value, dict) and
+            'assurance' in value
+        ):
+            if (value['assurance'] == 'Service provider assertion'):
+                assurance = False
+            else:
+                assurance = lowercase_first_character_unless_part_of_acronym(
+                    value['assurance']
+                )
+            return (value['value'], assurance)
+        else:
+            return (value, False)
+
+
+def lowercase_first_character_unless_part_of_acronym(string):
+    if not string:
+        return ''
+    if string[1:2] == string[1:2].upper():
+        return string
+    return string[:1].lower() + string[1:]

--- a/tests/test_service_attribute.py
+++ b/tests/test_service_attribute.py
@@ -6,12 +6,6 @@ from dmutils.service_attribute import (
 
 class TestAttribute(unittest.TestCase):
 
-    def test_Attribute_works_if_the_key_is_in_service_data(self):
-        try:
-            attribute = Attribute('supportAvailability', 'text')
-        except KeyError:
-            self.fail("'supportAvailability' key should be in service data")
-
     def test_get_data_value_retrieves_correct_value(self):
         self.assertEqual(
             Attribute('24/7, 365 days a year', 'text').value,

--- a/tests/test_service_attribute.py
+++ b/tests/test_service_attribute.py
@@ -1,0 +1,148 @@
+import unittest
+from dmutils.service_attribute import (
+    Attribute, lowercase_first_character_unless_part_of_acronym
+)
+
+
+class TestAttribute(unittest.TestCase):
+
+    def test_Attribute_works_if_the_key_is_in_service_data(self):
+        try:
+            attribute = Attribute('supportAvailability', 'text')
+        except KeyError:
+            self.fail("'supportAvailability' key should be in service data")
+
+    def test_get_data_value_retrieves_correct_value(self):
+        self.assertEqual(
+            Attribute('24/7, 365 days a year', 'text').value,
+            '24/7, 365 days a year'
+        )
+
+    def test_get_data_type_handles_empty_data(self):
+        self.assertEqual(
+            Attribute('', 'text').type,
+            'text'
+        )
+        self.assertEqual(
+            Attribute('', 'text').value,
+            ''
+        )
+        self.assertEqual(
+            Attribute(None, 'percentage').type,
+            'text'
+        )
+        self.assertEqual(
+            Attribute(None, 'percentage').value,
+            ''
+        )
+        self.assertEqual(
+            Attribute([], 'list').type,
+            'text'
+        )
+        self.assertEqual(
+            Attribute([], 'text').value,
+            ''
+        )
+
+    def test_an_attribute_with_assurance(self):
+        attribute = Attribute(
+            {
+                'value': 'Managed email service',
+                'assurance': 'CESG-assured components'
+            },
+            'text'
+        )
+        self.assertEqual(
+            attribute.value,
+            'Managed email service'
+        )
+        self.assertEqual(
+            attribute.assurance,
+            'CESG-assured components'
+        )
+
+    def test_rendering_of_list_with_assurance(self):
+        attribute = Attribute(
+            {
+                "value": [
+                    'Gold certification', 'Silver certification'
+                ],
+                "assurance": "CESG-assured componenents"
+            },
+            'list'
+        )
+        self.assertEqual(
+            attribute.value,
+            ['Gold certification', 'Silver certification']
+        )
+        self.assertEqual(
+            attribute.assurance,
+            "CESG-assured componenents"
+        )
+
+    def test_an_attribute_with_assurance_being_service_provider_assertion(self):
+        attribute = Attribute(
+            {
+                'value': 'Managed email service',
+                'assurance': 'Service provider assertion'
+            },
+            'text'
+        )
+        self.assertEqual(
+            attribute.value,
+            'Managed email service'
+        )
+        self.assertEqual(
+            attribute.assurance,
+            False
+        )
+
+    def test_a_required_attribute_with_no_value(self):
+        attribute = Attribute(
+            '',
+            'text',
+            optional=False
+        )
+        self.assertEqual(attribute.answer_required, True)
+
+    def test_a_required_attribute_with_a_value(self):
+        attribute = Attribute(
+            'Managed email service',
+            'text',
+            optional=False
+        )
+        self.assertEqual(attribute.answer_required, False)
+
+    def test_a_optional_attribute_with_no_value(self):
+        attribute = Attribute(
+            '',
+            'text',
+            optional=True
+        )
+        self.assertEqual(attribute.answer_required, False)
+
+    def test_a_optional_attribute_with_a_value(self):
+        attribute = Attribute(
+            'Managed email service',
+            'text',
+            optional=True
+        )
+        self.assertEqual(attribute.answer_required, False)
+
+
+class TestHelpers(unittest.TestCase):
+    def test_normal_string_can_be_lowercased(self):
+        self.assertEqual(
+            lowercase_first_character_unless_part_of_acronym(
+                "Independent validation of assertion"
+            ),
+            "independent validation of assertion"
+        )
+
+    def test_string_starting_with_acronym_can_be_lowercased(self):
+        self.assertEqual(
+            lowercase_first_character_unless_part_of_acronym(
+                "CESG-assured components"
+            ),
+            "CESG-assured components"
+        )


### PR DESCRIPTION
The idea is that all frontend apps will use this to transform data from the API before sending it to the toolkit templates.