### PR TITLE
Send draft update page_questions outside service data

### DIFF
--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -246,16 +246,19 @@ class DataAPIClient(BaseAPIClient):
                 }
             })
 
-    def update_draft_service(self, draft_id, service, user):
-        return self._post(
-            "/draft-services/{}".format(draft_id),
-            data={
-                "update_details": {
-                    "updated_by": user,
-                    "update_reason": "deprecated",
-                },
-                "services": service,
-            })
+    def update_draft_service(self, draft_id, service, user, page_questions=None):
+        data = {
+            "update_details": {
+                "updated_by": user,
+                "update_reason": "deprecated",
+            },
+            "services": service,
+        }
+
+        if page_questions is not None:
+            data['page_questions'] = page_questions
+
+        return self._post("/draft-services/{}".format(draft_id), data=data)
 
     def publish_draft_service(self, draft_id, user):
         return self._post(

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -861,7 +861,30 @@ class TestDataApiClient(object):
             },
             'update_details': {
                 'update_reason': 'deprecated', 'updated_by': 'user'
-            }
+            },
+        }
+
+    def test_update_draft_service_with_page_questions(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/draft-services/2",
+            json={"done": "it"},
+            status_code=200,
+        )
+
+        result = data_client.update_draft_service(
+            2, {"field": "value"}, 'user', ['question1', 'question2']
+        )
+
+        assert result == {"done": "it"}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'services': {
+                "field": "value"
+            },
+            'update_details': {
+                'update_reason': 'deprecated', 'updated_by': 'user'
+            },
+            'page_questions': ['question1', 'question2']
         }
 
     def test_publish_draft_service(self, data_client, rmock):


### PR DESCRIPTION
Adds additional argument to draft update method to pass
`page_questions`.

This way, `page_questions` is more explicit as a meta field and is
not mixed with the service data.