### PR TITLE
Move file validation functions to dmutils.documents

### DIFF
--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -62,6 +62,7 @@ def upload_document(uploader, documents_url, service, field, file_contents):
 
     """
     file_path = generate_file_name(
+        service['frameworkSlug'],
         service['supplierId'],
         service['id'],
         field,
@@ -101,7 +102,7 @@ def file_is_open_document_format(file_object):
     ]
 
 
-def generate_file_name(supplier_id, service_id, field, filename, suffix=None):
+def generate_file_name(framework_slug, supplier_id, service_id, field, filename, suffix=None):
     if suffix is None:
         suffix = default_file_suffix()
 
@@ -112,7 +113,8 @@ def generate_file_name(supplier_id, service_id, field, filename, suffix=None):
         'pricingDocumentURL': 'pricing-document',
     }
 
-    return 'documents/{}/{}-{}-{}{}'.format(
+    return '{}/{}/{}-{}-{}{}'.format(
+        framework_slug,
         supplier_id,
         service_id,
         ID_TO_FILE_NAME_SUFFIX[field],

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -45,7 +45,7 @@ def validate_documents(files):
     return errors
 
 
-def upload_document(uploader, documents_url, service, field, file_contents):
+def upload_document(uploader, documents_url, service, field, file_contents, public=True):
     """Upload the document to S3 bucket and return the document URL
 
     :param uploader: S3 uploader object
@@ -56,6 +56,8 @@ def upload_document(uploader, documents_url, service, field, file_contents):
     :param field: name of the service field that the document URL is saved to,
                   used to generate the document name
     :param file_contents: attached file object
+    :param public: if True, set file permission to 'public-read'. Otherwise file
+                   is private.
 
     :return: generated document URL or ``False`` if document upload
              failed
@@ -69,8 +71,10 @@ def upload_document(uploader, documents_url, service, field, file_contents):
         file_contents.filename
     )
 
+    acl = 'public-read' if public else 'private'
+
     try:
-        uploader.save(file_path, file_contents)
+        uploader.save(file_path, file_contents, acl=acl)
     except S3ResponseError:
         return False
 

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -1,0 +1,130 @@
+import os
+import datetime
+
+try:
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
+
+from .s3 import S3ResponseError
+
+
+def filter_empty_files(files):
+    """Remove any empty files from the list.
+
+    :param files: a dictionary of file attachments
+    :return: a dictionary of files with all empty files removed
+
+    """
+    return {
+        key: contents for key, contents in files.items()
+        if file_is_not_empty(contents)
+    }
+
+
+def validate_documents(files):
+    """Validate document files for size and format
+
+    :param files: a dictionary of file attachments
+
+    :return: a dictionary of errors, where keys match
+             the keys from the ``files`` argument and
+             values are validator names used to look
+             up the message in the question content
+             files. If no errors were found an empty
+             dictionary is returned.
+
+    """
+    errors = {}
+    for field, contents in files.items():
+        if not file_is_open_document_format(contents):
+            errors[field] = 'file_is_open_document_format'
+        elif not file_is_less_than_5mb(contents):
+            errors[field] = 'file_is_less_than_5mb'
+
+    return errors
+
+
+def upload_document(uploader, documents_url, service, field, file_contents):
+    """Upload the document to S3 bucket and return the document URL
+
+    :param uploader: S3 uploader object
+    :param documents_url: base assets URL used as root for creating the full
+                          document URL.
+    :param service: service object used to look up service and supplier id
+                    for the generated document name
+    :param field: name of the service field that the document URL is saved to,
+                  used to generate the document name
+    :param file_contents: attached file object
+
+    :return: generated document URL or ``False`` if document upload
+             failed
+
+    """
+    file_path = generate_file_name(
+        service['supplierId'],
+        service['id'],
+        field,
+        file_contents.filename
+    )
+
+    try:
+        uploader.save(file_path, file_contents)
+    except S3ResponseError:
+        return False
+
+    full_url = urlparse.urljoin(
+        documents_url,
+        file_path
+    )
+
+    return full_url
+
+
+def file_is_not_empty(file_contents):
+    not_empty = len(file_contents.read(1)) > 0
+    file_contents.seek(0)
+    return not_empty
+
+
+def file_is_less_than_5mb(file_contents):
+    size_limit = 5400000
+    below_size_limit = len(file_contents.read(size_limit)) < size_limit
+    file_contents.seek(0)
+
+    return below_size_limit
+
+
+def file_is_open_document_format(file_object):
+    return get_extension(file_object.filename) in [
+        ".pdf", ".pda", ".odt", ".ods", ".odp"
+    ]
+
+
+def generate_file_name(supplier_id, service_id, field, filename, suffix=None):
+    if suffix is None:
+        suffix = default_file_suffix()
+
+    ID_TO_FILE_NAME_SUFFIX = {
+        'serviceDefinitionDocumentURL': 'service-definition-document',
+        'termsAndConditionsDocumentURL': 'terms-and-conditions',
+        'sfiaRateDocumentURL': 'sfia-rate-card',
+        'pricingDocumentURL': 'pricing-document',
+    }
+
+    return 'documents/{}/{}-{}-{}{}'.format(
+        supplier_id,
+        service_id,
+        ID_TO_FILE_NAME_SUFFIX[field],
+        suffix,
+        get_extension(filename)
+    )
+
+
+def default_file_suffix():
+    return datetime.datetime.utcnow().strftime("%Y-%m-%d-%H%M")
+
+
+def get_extension(filename):
+    file_name, file_extension = os.path.splitext(filename)
+    return file_extension.lower()

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -3,3 +3,4 @@ pytest==2.7.0
 mock==1.0.1
 requests-mock==0.6.0
 pep8==1.6.2
+freezegun==0.3.4

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,0 +1,138 @@
+import unittest
+
+import mock
+from freezegun import freeze_time
+
+from dmutils.s3 import S3ResponseError
+
+from dmutils.documents import (
+    generate_file_name,
+    file_is_not_empty, filter_empty_files,
+    file_is_less_than_5mb,
+    file_is_open_document_format,
+    validate_documents,
+    upload_document
+)
+
+
+class TestGenerateFilename(unittest.TestCase):
+    def test_filename_format(self):
+        self.assertEquals(
+            'documents/2/1-pricing-document-123.pdf',
+            generate_file_name(
+                2, 1,
+                'pricingDocumentURL', 'test.pdf',
+                suffix='123'
+            ))
+
+    def test_default_suffix_is_datetime(self):
+        with freeze_time('2015-01-02 03:04:05'):
+            self.assertEquals(
+                'documents/2/1-pricing-document-2015-01-02-0304.pdf',
+                generate_file_name(
+                    2, 1,
+                    'pricingDocumentURL', 'test.pdf',
+                ))
+
+
+class TestValidateDocuments(unittest.TestCase):
+    def test_file_is_not_empty(self):
+        self.assertTrue(file_is_not_empty(mock_file('file1', 1)))
+
+    def test_file_is_empty(self):
+        self.assertFalse(file_is_not_empty(mock_file('file1', 0)))
+
+    def test_filter_empty_files(self):
+        file1 = mock_file('file1', 1)
+        file2 = mock_file('file2', 0)
+        file3 = mock_file('file3', 10)
+        self.assertEquals(
+            filter_empty_files({'f1': file1, 'f2': file2, 'f3': file3}),
+            {'f1': file1, 'f3': file3}
+        )
+
+    def test_file_is_less_than_5mb(self):
+        self.assertTrue(file_is_less_than_5mb(mock_file('file1', 1)))
+
+    def test_file_is_more_than_5mb(self):
+        self.assertFalse(file_is_less_than_5mb(mock_file('file1', 5400001)))
+
+    def test_file_is_open_document_format(self):
+        self.assertTrue(file_is_open_document_format(mock_file('file1.pdf', 1)))
+
+    def test_file_is_not_open_document_format(self):
+        self.assertFalse(file_is_open_document_format(mock_file('file1.doc', 1)))
+
+    def test_validate_documents(self):
+        self.assertEqual(
+            validate_documents({'file1': mock_file('file1.pdf', 1)}),
+            {}
+        )
+
+    def test_validate_documents_not_open_document_format(self):
+        self.assertEqual(
+            validate_documents({'file1': mock_file('file1.doc', 1)}),
+            {'file1': 'file_is_open_document_format'}
+        )
+
+    def test_validate_documents_not_less_than_5mb(self):
+        self.assertEqual(
+            validate_documents({'file1': mock_file('file1.pdf', 5400001)}),
+            {'file1': 'file_is_less_than_5mb'}
+        )
+
+    def test_validate_documents_not_open_document_above_5mb(self):
+        self.assertEqual(
+            validate_documents({'file1': mock_file('file1.doc', 5400001)}),
+            {'file1': 'file_is_open_document_format'}
+        )
+
+    def test_validate_multiple_documents(self):
+        self.assertEqual(
+            validate_documents({
+                'file1': mock_file('file1.pdf', 5400001),
+                'file2': mock_file('file1.pdf', 1),
+                'file3': mock_file('file1.doc', 1),
+            }),
+            {
+                'file1': 'file_is_less_than_5mb',
+                'file3': 'file_is_open_document_format',
+            }
+        )
+
+
+class TestUploadDocument(unittest.TestCase):
+    def test_document_upload(self):
+        uploader = mock.Mock()
+        with freeze_time('2015-01-02 04:05:00'):
+            self.assertEquals(
+                upload_document(
+                    uploader,
+                    'http://assets',
+                    {'id': "123", 'supplierId': 5},
+                    "pricingDocumentURL",
+                    mock_file('file.pdf', 1)
+                ),
+                'http://assets/documents/5/123-pricing-document-2015-01-02-0405.pdf'
+            )
+
+    def test_document_upload_s3_error(self):
+        uploader = mock.Mock()
+        uploader.save.side_effect = S3ResponseError(403, 'Forbidden')
+        with freeze_time('2015-01-02 04:05:00'):
+            self.assertFalse(upload_document(
+                uploader,
+                'http://assets',
+                {'id': "123", 'supplierId': 5},
+                "pricingDocumentURL",
+                mock_file('file.pdf', 1)
+            ))
+
+
+def mock_file(filename, length, name=None):
+    mock_file = mock.MagicMock()
+    mock_file.read.return_value = '*' * length
+    mock_file.filename = filename
+    mock_file.name = name
+
+    return mock_file

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -116,6 +116,33 @@ class TestUploadDocument(unittest.TestCase):
                 'http://assets/g-cloud-6/5/123-pricing-document-2015-01-02-0405.pdf'
             )
 
+        uploader.save.assert_called_once_with(
+            'g-cloud-6/5/123-pricing-document-2015-01-02-0405.pdf',
+            mock.ANY,
+            acl='public-read'
+        )
+
+    def test_document_private_upload(self):
+        uploader = mock.Mock()
+        with freeze_time('2015-01-02 04:05:00'):
+            self.assertEquals(
+                upload_document(
+                    uploader,
+                    'http://assets',
+                    {'id': "123", 'supplierId': 5, 'frameworkSlug': 'g-cloud-6'},
+                    "pricingDocumentURL",
+                    mock_file('file.pdf', 1),
+                    public=False
+                ),
+                'http://assets/g-cloud-6/5/123-pricing-document-2015-01-02-0405.pdf'
+            )
+
+        uploader.save.assert_called_once_with(
+            'g-cloud-6/5/123-pricing-document-2015-01-02-0405.pdf',
+            mock.ANY,
+            acl='private'
+        )
+
     def test_document_upload_s3_error(self):
         uploader = mock.Mock()
         uploader.save.side_effect = S3ResponseError(403, 'Forbidden')

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -18,9 +18,9 @@ from dmutils.documents import (
 class TestGenerateFilename(unittest.TestCase):
     def test_filename_format(self):
         self.assertEquals(
-            'documents/2/1-pricing-document-123.pdf',
+            'slug/2/1-pricing-document-123.pdf',
             generate_file_name(
-                2, 1,
+                'slug', 2, 1,
                 'pricingDocumentURL', 'test.pdf',
                 suffix='123'
             ))
@@ -28,9 +28,9 @@ class TestGenerateFilename(unittest.TestCase):
     def test_default_suffix_is_datetime(self):
         with freeze_time('2015-01-02 03:04:05'):
             self.assertEquals(
-                'documents/2/1-pricing-document-2015-01-02-0304.pdf',
+                'slug/2/1-pricing-document-2015-01-02-0304.pdf',
                 generate_file_name(
-                    2, 1,
+                    'slug', 2, 1,
                     'pricingDocumentURL', 'test.pdf',
                 ))
 
@@ -109,11 +109,11 @@ class TestUploadDocument(unittest.TestCase):
                 upload_document(
                     uploader,
                     'http://assets',
-                    {'id': "123", 'supplierId': 5},
+                    {'id': "123", 'supplierId': 5, 'frameworkSlug': 'g-cloud-6'},
                     "pricingDocumentURL",
                     mock_file('file.pdf', 1)
                 ),
-                'http://assets/documents/5/123-pricing-document-2015-01-02-0405.pdf'
+                'http://assets/g-cloud-6/5/123-pricing-document-2015-01-02-0405.pdf'
             )
 
     def test_document_upload_s3_error(self):
@@ -123,7 +123,7 @@ class TestUploadDocument(unittest.TestCase):
             self.assertFalse(upload_document(
                 uploader,
                 'http://assets',
-                {'id': "123", 'supplierId': 5},
+                {'id': "123", 'supplierId': 5, 'frameworkSlug': 'g-cloud-6'},
                 "pricingDocumentURL",
                 mock_file('file.pdf', 1)
             ))

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -12,6 +12,7 @@ class TestValidate(unittest.TestCase):
         self.service = {
             'id': 1,
             'supplierId': 2,
+            'frameworkSlug': 'g-cloud-6',
         }
         self.data = {}
         self.content = {}
@@ -264,12 +265,12 @@ class TestValidate(unittest.TestCase):
         self.assertEquals(self.validate.errors, {})
 
         self.uploader.save.assert_called_once_with(
-            'documents/2/1-pricing-document-2015-01-01-1200.pdf',
+            'g-cloud-6/2/1-pricing-document-2015-01-01-1200.pdf',
             self.data['pricingDocumentURL']
         )
 
         self.assertEquals(self.validate.clean_data, {
-            'pricingDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/documents/2/1-pricing-document-2015-01-01-1200.pdf',  # noqa
+            'pricingDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/g-cloud-6/2/1-pricing-document-2015-01-01-1200.pdf',  # noqa
         })
 
     def test_failed_file_upload(self):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,35 +1,10 @@
 # coding=utf-8
 
 import unittest
-import datetime
 
 import mock
 from dmutils.s3 import S3ResponseError
-from dmutils.validation import Validate, generate_file_name
-
-
-class TestGenerateFilename(unittest.TestCase):
-    def test_filename_format(self):
-        self.assertEquals(
-            'documents/2/1-pricing-document-123.pdf',
-            generate_file_name(
-                2, 1,
-                'pricingDocumentURL', 'test.pdf',
-                suffix='123'
-            ))
-
-    def test_default_suffix_is_datetime(self):
-        now = datetime.datetime(2015, 1, 2, 3, 4, 5, 6)
-
-        with mock.patch.object(datetime, 'datetime',
-                               mock.Mock(wraps=datetime.datetime)) as patched:
-            patched.utcnow.return_value = now
-            self.assertEquals(
-                'documents/2/1-pricing-document-2015-01-02-0304.pdf',
-                generate_file_name(
-                    2, 1,
-                    'pricingDocumentURL', 'test.pdf',
-                ))
+from dmutils.validation import Validate
 
 
 class TestValidate(unittest.TestCase):
@@ -43,7 +18,7 @@ class TestValidate(unittest.TestCase):
         self.uploader = mock.Mock()
 
         self.default_suffix_patch = mock.patch(
-            'dmutils.validation.default_file_suffix',
+            'dmutils.documents.default_file_suffix',
             return_value='2015-01-01-1200'
         ).start()
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -266,7 +266,8 @@ class TestValidate(unittest.TestCase):
 
         self.uploader.save.assert_called_once_with(
             'g-cloud-6/2/1-pricing-document-2015-01-01-1200.pdf',
-            self.data['pricingDocumentURL']
+            self.data['pricingDocumentURL'],
+            acl='public-read'
         )
 
         self.assertEquals(self.validate.clean_data, {


### PR DESCRIPTION
## Move file validation functions to dmutils.documents
Extracts file validation checks from validator class to standalone
functions. Validate methods are preserved and call added functions.

Adds `validate_documents` and `filter_empty_files` methods used to
check `request.files` for any errors before uploading documents to
S3.

## Use framework slug as the S3 documents folder
Separating documents for each framework would allow us to control
access using nginx - e.g. redirecting /g-cloud-7 asset URLs to a
static page until G-Cloud 7 goes live.

All existing documents are still in the '/documents' folder, but
future document uploads for G5 and G6 will end up in separate
folders.

## Add `public` argument to document_upload
Allows setting the S3 file object ACL:
* `public=True` sets ACL to `"public-read"`
* `public=False` sets ACL to `"private"`