### PR TITLE
[#100216314] Delete method does not allow JSON payload

### DIFF
--- a/dmutils/apiclient/base.py
+++ b/dmutils/apiclient/base.py
@@ -30,8 +30,8 @@ class BaseAPIClient(object):
     def _post(self, url, data):
         return self._request("POST", url, data=data)
 
-    def _delete(self, url, data=None):
-        return self._request("DELETE", url, data=data)
+    def _delete(self, url):
+        return self._request("DELETE", url)
 
     def _request(self, method, url, data=None, params=None):
         if not self.enabled:

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -217,15 +217,10 @@ class DataAPIClient(BaseAPIClient):
             "/draft-services/{}".format(draft_id)
         )
 
-    def delete_draft_service(self, draft_id, user):
+    def delete_draft_service(self, draft_id, user_id):
         return self._delete(
-            "/draft-services/{}".format(draft_id),
-            data={
-                "update_details": {
-                    "updated_by": user,
-                    "update_reason": "deprecated",
-                },
-            })
+            "/draft-services/{0}?user_id={1}".format(draft_id, user_id)
+        )
 
     def copy_draft_service_from_existing_service(self, service_id, user):
         return self._put(

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -794,16 +794,13 @@ class TestDataApiClient(object):
         )
 
         result = data_client.delete_draft_service(
-            2, 'user'
+            2, 12345
         )
 
         assert result == {"done": "it"}
         assert rmock.called
-        assert rmock.request_history[0].json() == {
-            'update_details': {
-                'update_reason': 'deprecated', 'updated_by': 'user'
-            }
-        }
+        assert rmock.request_history[0].method == 'DELETE'
+        assert rmock.request_history[0].url == 'http://baseurl/draft-services/2?user_id=12345'
 
     def test_copy_draft_service_from_existing_service(
             self, data_client, rmock):


### PR DESCRIPTION
Instead of passing updater details in a JSON request the DELETE method needs to pass the user id as a parameter.

The corresponding API pull-request is here: https://github.com/alphagov/digitalmarketplace-api/pull/199