### PR TITLE
Improve find users

### DIFF
--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -117,12 +117,10 @@ class DataAPIClient(BaseAPIClient):
                 "users": user,
             })
 
-    def find_users(self, supplier_id=None, active=None, page=None):
+    def find_users(self, supplier_id=None, page=None):
         params = {}
         if supplier_id is not None:
             params['supplier_id'] = supplier_id
-        if active is not None:
-            params['active'] = 'true' if active else 'false'
         if page is not None:
             params['page'] = page
         return self._get("/users", params=params)

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -206,8 +206,7 @@ class DataAPIClient(BaseAPIClient):
 
     # Services
 
-    def find_draft_services(
-            self, supplier_id, service_id=None, framework=None):
+    def find_draft_services(self, supplier_id, service_id=None, framework=None):
 
         params = {
             'supplier_id': supplier_id

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -1,4 +1,4 @@
-from .base import BaseAPIClient, logger
+from .base import BaseAPIClient, logger, make_iter_method
 from .errors import HTTPError
 
 
@@ -31,6 +31,8 @@ class DataAPIClient(BaseAPIClient):
             params=params
         )
 
+    find_audit_events_iter = make_iter_method('find_audit_events', 'auditEvents', 'audit-events')
+
     def acknowledge_audit_event(self, audit_event_id, user):
         return self._post(
             "/audit-events/{}/acknowledge".format(audit_event_id),
@@ -55,6 +57,8 @@ class DataAPIClient(BaseAPIClient):
             "/suppliers",
             params=params
         )
+
+    find_suppliers_iter = make_iter_method('find_suppliers', 'suppliers', 'suppliers')
 
     def get_supplier(self, supplier_id):
         return self._get(
@@ -122,6 +126,8 @@ class DataAPIClient(BaseAPIClient):
         if page is not None:
             params['page'] = page
         return self._get("/users", params=params)
+
+    find_users_iter = make_iter_method('find_users', 'users', 'users')
 
     def get_user(self, user_id=None, email_address=None):
         if user_id is not None and email_address is not None:
@@ -218,6 +224,8 @@ class DataAPIClient(BaseAPIClient):
 
         return self._get('/draft-services', params=params)
 
+    find_draft_services_iter = make_iter_method('find_draft_services', 'services', 'draft-services')
+
     def get_draft_service(self, draft_id):
         return self._get(
             "/draft-services/{}".format(draft_id)
@@ -310,6 +318,8 @@ class DataAPIClient(BaseAPIClient):
             params['page'] = page
 
         return self._get("/services", params=params)
+
+    find_services_iter = make_iter_method('find_services', 'services', 'services')
 
     def import_service(self, service_id, service, user, reason):
         return self._put(

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -28,7 +28,7 @@ class DataAPIClient(BaseAPIClient):
 
         return self._get(
             "/audit-events",
-            params
+            params=params
         )
 
     def acknowledge_audit_event(self, audit_event_id, user):
@@ -209,15 +209,15 @@ class DataAPIClient(BaseAPIClient):
     def find_draft_services(
             self, supplier_id, service_id=None, framework=None):
 
-        url = "/draft-services?supplier_id={}".format(supplier_id)
+        params = {
+            'supplier_id': supplier_id
+        }
+        if service_id is not None:
+            params['service_id'] = service_id
+        if framework is not None:
+            params['framework'] = framework
 
-        if service_id:
-            url = "{}&service_id={}".format(url, service_id)
-
-        if framework:
-            url = "{}&framework={}".format(url, framework)
-
-        return self._get(url)
+        return self._get('/draft-services', params=params)
 
     def get_draft_service(self, draft_id):
         return self._get(

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -113,8 +113,15 @@ class DataAPIClient(BaseAPIClient):
                 "users": user,
             })
 
-    def find_users(self, supplier_id):
-        return self._get("/users?supplier_id={}".format(supplier_id))
+    def find_users(self, supplier_id=None, active=None, page=None):
+        params = {}
+        if supplier_id is not None:
+            params['supplier_id'] = supplier_id
+        if active is not None:
+            params['active'] = 'true' if active else 'false'
+        if page is not None:
+            params['page'] = page
+        return self._get("/users", params=params)
 
     def get_user(self, user_id=None, email_address=None):
         if user_id is not None and email_address is not None:

--- a/dmutils/apiclient/errors.py
+++ b/dmutils/apiclient/errors.py
@@ -23,6 +23,19 @@ class APIError(Exception):
 
 
 class HTTPError(APIError):
+    @staticmethod
+    def create(e):
+        error = HTTPError(e.response)
+        if error.status_code == 503:
+            error = HTTP503Error(e.response)
+        return error
+
+
+class HTTP503Error(HTTPError):
+    """Specific instance of HTTPError for 503 errors
+
+    Used for detecting whether failed requests should be retried.
+    """
     pass
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-backoff
+backoff==1.0.7
 boto==2.38.0
 contextlib2==0.4.0
 Flask>=0.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+backoff
 boto==2.38.0
 contextlib2==0.4.0
 Flask>=0.10

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -434,6 +434,24 @@ class TestDataApiClient(object):
 
         assert user == self.user()
 
+    def test_find_users_by_active(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/users?active=false",
+            json=self.user(),
+            status_code=200)
+        user = data_client.find_users(active=False)
+
+        assert user == self.user()
+
+    def test_find_users_by_page(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/users?page=12",
+            json=self.user(),
+            status_code=200)
+        user = data_client.find_users(page=12)
+
+        assert user == self.user()
+
     def test_get_user_by_id(self, data_client, rmock):
         rmock.get(
             "http://baseurl/users/1234",

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1048,7 +1048,6 @@ class TestDataAPIClientIterMethods(object):
         assert results[1]['id'] == 2
         assert results[2]['id'] == 3
 
-
     def test_find_users_iter(self, data_client, rmock):
         self._test_find_iter(
             data_client, rmock,
@@ -1120,7 +1119,7 @@ class TestDataAPIClientIterMethods(object):
         rmock.get(
             'http://baseurl/services',
             [{'json': {}, 'status_code': 503},
-             {'json': {'links':{}, 'services': [{'id': 1}]}, 'status_code': 200}])
+             {'json': {'links': {}, 'services': [{'id': 1}]}, 'status_code': 200}])
 
         result = data_client.find_services_iter()
         results = list(result)

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -434,15 +434,6 @@ class TestDataApiClient(object):
 
         assert user == self.user()
 
-    def test_find_users_by_active(self, data_client, rmock):
-        rmock.get(
-            "http://baseurl/users?active=false",
-            json=self.user(),
-            status_code=200)
-        user = data_client.find_users(active=False)
-
-        assert user == self.user()
-
     def test_find_users_by_page(self, data_client, rmock):
         rmock.get(
             "http://baseurl/users?page=12",


### PR DESCRIPTION
## Add query parameters to find_users method

The API endpoint allows users to be listed by supplier_id, active and page. Being able to iterate through all active users is needed for generating an email list.

## Add page iteration to the DataAPIClient

This allows any 'find' method to be called in a way that automatically iterates through pages and retries failed requests.

Any method that starts with 'find_' and ends with '_iter' it will be called with an exponential backoff. From the response the records will be yielded and then the 'next' URL will be fetched and yielded until there are no pages.

This is most often needed for scripts that export or migrate large numbers of records where occasional requests may fail.

## Example

The following will iterate through all pages of active users, recovering from 503s if they happen.

```python
client = DataAPIClient('http://host', 'token')

for user in client.find_users_iter(active=True):
  print(user)
```