### PR TITLE
Add S3.get_signed_url method

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '4.2.0'
+__version__ = '4.3.0'
 
 
 def init_app(

--- a/dmutils/s3.py
+++ b/dmutils/s3.py
@@ -27,6 +27,21 @@ class S3(object):
         key.set_acl(acl)
         return key
 
+    def get_signed_url(self, path, expires_in=30):
+        """Create a signed S3 document URL
+
+        :param path: S3 object path within the bucket
+        :param expires_in: how long the generated URL is valid
+                           for, in seconds
+
+        :return: signed URL or ``None`` if object was not found
+
+        """
+
+        key = self.bucket.get_key(path)
+        if key:
+            return key.generate_url(expires_in)
+
     def _move_existing(self, existing_path, move_prefix=None):
         if move_prefix is None:
             move_prefix = default_move_prefix()

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -21,6 +21,20 @@ class TestS3Uploader(unittest.TestCase):
         S3('test-bucket')
         self.s3_mock.get_bucket.assert_called_with('test-bucket')
 
+    def test_get_signed_url(self):
+        mock_bucket = FakeBucket(['documents/file.pdf'])
+        self.s3_mock.get_bucket.return_value = mock_bucket
+
+        S3('test-bucket').get_signed_url('documents/file.pdf')
+        mock_bucket.s3_key_mock.generate_url.assert_called_with(30)
+
+    def test_get_signed_url_with_expires_at(self):
+        mock_bucket = FakeBucket(['documents/file.pdf'])
+        self.s3_mock.get_bucket.return_value = mock_bucket
+
+        S3('test-bucket').get_signed_url('documents/file.pdf', 10)
+        mock_bucket.s3_key_mock.generate_url.assert_called_with(10)
+
     def test_save_file(self):
         mock_bucket = FakeBucket()
         self.s3_mock.get_bucket.return_value = mock_bucket


### PR DESCRIPTION
Creates a temporary link to the private S3 document. Link expires
in `expires_at` seconds (defaults to 30 seconds).

Can be used for documents that require authorization and should not
be shared publicly (eg service submission documents).