### PR TITLE
New endpoint for creating suppliers

### DIFF
--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -61,9 +61,15 @@ class DataAPIClient(BaseAPIClient):
             "/suppliers/{}".format(supplier_id)
         )
 
-    def create_supplier(self, supplier_id, supplier):
+    def import_supplier(self, supplier_id, supplier):
         return self._put(
             "/suppliers/{}".format(supplier_id),
+            data={"suppliers": supplier},
+        )
+
+    def create_supplier(self, supplier):
+        return self._post(
+            "/suppliers",
             data={"suppliers": supplier},
         )
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -753,14 +753,26 @@ class TestDataApiClient(object):
         except HTTPError:
             assert rmock.called
 
-    def test_create_supplier(self, data_client, rmock):
+    def test_import_supplier(self, data_client, rmock):
         rmock.put(
             "http://baseurl/suppliers/123",
             json={"suppliers": "result"},
             status_code=201,
         )
 
-        result = data_client.create_supplier(123, {"foo": "bar"})
+        result = data_client.import_supplier(123, {"foo": "bar"})
+
+        assert result == {"suppliers": "result"}
+        assert rmock.called
+
+    def test_create_supplier(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/suppliers",
+            json={"suppliers": "result"},
+            status_code=201,
+        )
+
+        result = data_client.create_supplier({"foo": "bar"})
 
         assert result == {"suppliers": "result"}
         assert rmock.called


### PR DESCRIPTION
Breaking change to supplier interface

- create_supplier renamed to import_supplier
- new create_supplier endpoing

import_supplier is the PUT endpoint used in migrations
- expects a supplier_id

create_supplier is the POST endpoing for new suppliers
- does not expect a supplier_id