### PR TITLE
Get form data from content builder

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '4.3.0'
+__version__ = '4.4.0'
 
 
 def init_app(

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -114,7 +114,7 @@ class ContentSection(object):
     @classmethod
     def create(cls, section):
         if isinstance(section, ContentSection):
-            return section
+            return section.copy()
         else:
             return ContentSection(
                 id=section['id'],

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -228,10 +228,7 @@ class ContentLoader(object):
         ]
 
     def get_question(self, question):
-        q = self._questions.get(question, {}).copy()
-        if q:
-            q['id'] = question
-        return q
+        return self._questions.get(question, {}).copy()
 
     def get_builder(self):
         return ContentBuilder(self._sections)

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -10,11 +10,13 @@ from .config import convert_to_boolean, convert_to_number
 class ContentBuilder(object):
     """An ordered set of sections each made up of one or more questions.
 
-    Usage::
+    Example::
+        # Get hold of a section
+        content = ContentBuilder(sections)
+        section = content.get_section(section_id)
 
-        >>> content = ContentBuilder(sections)
-        >>> content.get_section_data(section_id, form_data)
-        {'field': 'value', 'field2': 'value2'}
+        # Extract data from form data
+        section.get_data(form_data)
     """
     def __init__(self, sections):
         self.sections = [ContentSection(section) for section in sections]
@@ -36,7 +38,7 @@ class ContentBuilder(object):
         :type form_data: :class:`werkzeug.ImmutableMultiDict`
         :return: parsed and filtered data
 
-        See :func:`ContentBuilder.get_section_data` for more details.
+        See :func:`SectionContent.get_data` for more details.
         """
         all_data = {}
         for section in self:

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -136,7 +136,7 @@ class ContentSection(object):
             id=self.id,
             name=self.name,
             editable=self.editable,
-            questions=self.questions.copy())
+            questions=self.questions[:])
 
     def get_data(self, form_data):
         """Extract data for a section from a submitted form

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 
 import mock
+from werkzeug.datastructures import ImmutableMultiDict
+import pytest
 
 import io
 
@@ -35,6 +37,7 @@ class TestContentBuilder(object):
         content = ContentBuilder([{
             "name": "First section",
             "questions": [{
+                "id": "q1",
                 "question": 'First question',
                 "depends": [{
                     "on": "lot",
@@ -49,6 +52,7 @@ class TestContentBuilder(object):
         content = ContentBuilder([{
             "name": "First section",
             "questions": [{
+                "id": "q1",
                 "question": 'First question',
                 "depends": [{
                     "on": "lot",
@@ -63,6 +67,7 @@ class TestContentBuilder(object):
         content = ContentBuilder([{
             "name": "First section",
             "questions": [{
+                "id": "q1",
                 "question": 'First question',
             }]
         }]).filter({'lot': 'SaaS'})
@@ -73,6 +78,7 @@ class TestContentBuilder(object):
         content = ContentBuilder([{
             "name": "First section",
             "questions": [{
+                "id": "q1",
                 "question": 'First question',
                 "depends": [{
                     "on": "lot",
@@ -87,6 +93,7 @@ class TestContentBuilder(object):
         content = ContentBuilder([{
             "name": "First section",
             "questions": [{
+                "id": "q1",
                 "question": 'First question',
                 "depends": [{
                     "on": "lot",
@@ -103,6 +110,7 @@ class TestContentBuilder(object):
         content = ContentBuilder([{
             "name": "First section",
             "questions": [{
+                "id": "q1",
                 "question": 'First question',
                 "depends": [{
                     "on": "lot",
@@ -118,6 +126,7 @@ class TestContentBuilder(object):
             "name": "First section",
             "questions": [
                 {
+                    "id": "q1",
                     "question": 'First question',
                     "depends": [{
                         "on": "lot",
@@ -125,6 +134,7 @@ class TestContentBuilder(object):
                     }]
                 },
                 {
+                    "id": "q2",
                     "question": 'Second question',
                     "depends": [{
                         "on": "lot",
@@ -141,6 +151,7 @@ class TestContentBuilder(object):
             "name": "First section",
             "questions": [
                 {
+                    "id": "q1",
                     "question": 'First question',
                     "depends": [{
                         "on": "lot",
@@ -148,6 +159,7 @@ class TestContentBuilder(object):
                     }]
                 },
                 {
+                    "id": "q2",
                     "question": 'Second question',
                     "depends": [{
                         "on": "lot",
@@ -167,6 +179,7 @@ class TestContentBuilder(object):
             "name": "First section",
             "questions": [
                 {
+                    "id": "q1",
                     "question": 'First question',
                     "depends": [{
                         "on": "lot",
@@ -174,6 +187,7 @@ class TestContentBuilder(object):
                     }]
                 },
                 {
+                    "id": "q2",
                     "question": 'Second question',
                     "depends": [{
                         "on": "lot",
@@ -181,6 +195,7 @@ class TestContentBuilder(object):
                     }]
                 },
                 {
+                    "id": "q3",
                     "question": 'Third question',
                     "depends": [{
                         "on": "lot",
@@ -205,6 +220,7 @@ class TestContentBuilder(object):
             "name": "First section",
             "questions": [
                 {
+                    "id": "q1",
                     "question": 'First question',
                     "depends": [{
                         "on": "lot",
@@ -220,12 +236,13 @@ class TestContentBuilder(object):
         content = content.filter({"lot": "IaaS"})
         assert content.get_section("first_section") is None
 
-    def test_get_next_section(self):
+    def test_get_question(self):
         content = ContentBuilder([
             {
                 "id": "first_section",
                 "name": "First section",
                 "questions": [{
+                    "id": "q1",
                     "question": 'First question',
                     "depends": [{
                         "on": "lot",
@@ -237,6 +254,7 @@ class TestContentBuilder(object):
                 "id": "second_section",
                 "name": "Second section",
                 "questions": [{
+                    "id": "q2",
                     "question": 'First question',
                     "depends": [{
                         "on": "lot",
@@ -249,6 +267,53 @@ class TestContentBuilder(object):
                 "name": "Third section",
                 "editable": True,
                 "questions": [{
+                    "id": "q3",
+                    "question": 'First question',
+                    "depends": [{
+                        "on": "lot",
+                        "being": ["SCS", "SaaS", "PaaS"]
+                    }]
+                }]
+            },
+        ])
+
+        assert content.get_question('q1').get('id') == 'q1'
+
+        content = content.filter({'lot': 'IaaS'})
+        assert content.get_question('q1') is None
+
+    def test_get_next_section(self):
+        content = ContentBuilder([
+            {
+                "id": "first_section",
+                "name": "First section",
+                "questions": [{
+                    "id": "q1",
+                    "question": 'First question',
+                    "depends": [{
+                        "on": "lot",
+                        "being": ["SCS", "SaaS", "PaaS"]
+                    }]
+                }]
+            },
+            {
+                "id": "second_section",
+                "name": "Second section",
+                "questions": [{
+                    "id": "q2",
+                    "question": 'First question',
+                    "depends": [{
+                        "on": "lot",
+                        "being": ["SCS", "SaaS", "PaaS"]
+                    }]
+                }]
+            },
+            {
+                "id": "third_section",
+                "name": "Third section",
+                "editable": True,
+                "questions": [{
+                    "id": "q3",
                     "question": 'First question',
                     "depends": [{
                         "on": "lot",
@@ -266,6 +331,158 @@ class TestContentBuilder(object):
         assert content.get_next_editable_section_id() == "third_section"
         assert content.get_next_editable_section_id(
             "second_section") == "third_section"
+
+    def test_get_section_data(self):
+        content = ContentBuilder([
+            {
+                "id": "first_section",
+                "name": "First section",
+                "questions": [{
+                    "id": "q1",
+                    "question": "Boolean question",
+                    "type": "boolean",
+                }, {
+                    "id": "q2",
+                    "question": "Text question",
+                    "type": "text",
+                }, {
+                    "id": "q3",
+                    "question": "Radios question",
+                    "type": "radios",
+                }, {
+                    "id": "q4",
+                    "question": "List question",
+                    "type": "list",
+                }, {
+                    "id": "q5",
+                    "question": "Checkboxes question",
+                    "type": "checkboxes",
+                }, {
+                    "id": "q6",
+                    "question": "Service ID question",
+                    "type": "service_id",
+                    "assuranceApproach": "2answers-type1",
+                }, {
+                    "id": "q7",
+                    "question": "Pricing question",
+                    "type": "pricing",
+                }, {
+                    "id": "q8",
+                    "question": "Upload question",
+                    "type": "upload",
+                }, {
+                    "id": "q9",
+                    "question": "Percentage question",
+                    "type": "percentage",
+                }, {
+                    "id": "q10",
+                    "question": "Large text question",
+                    "type": "textbox_large",
+                }, {
+                    "id": "q11",
+                    "question": "Text question",
+                    "type": "text"
+                }]
+            }, {
+                "id": "second_section",
+                "name": "Second section",
+                "question": [{
+                    "id": "q12",
+                    "question": "Text question",
+                    "type": "text",
+                }]
+            }
+        ])
+
+        form = ImmutableMultiDict([
+            ('q1', 'true'),
+            ('q2', 'Some text stuff'),
+            ('q3', 'value'),
+            ('q3', 'Should be lost'),
+            ('q4', 'value 1'),
+            ('q4', 'value 2'),
+            ('q5', 'check 1'),
+            ('q5', 'check 2'),
+            ('q6', '71234567890'),
+            ('q6--assurance', 'yes I am'),
+            ('q7', '12.12'),
+            ('q7', '13.13'),
+            ('q7', 'Unit'),
+            ('q7', 'Hour'),
+            ('q8', 'blah blah'),
+            ('q9', '12.12'),
+            ('q10', 'Looooooooaaaaaaaaads of text'),
+            ('extra_field', 'Should be lost'),
+            ('q12', 'Should be lost'),
+        ])
+
+        data = content.get_section_data('first_section', form)
+
+        assert data == {
+            'q1': True,
+            'q2': 'Some text stuff',
+            'q3': 'value',
+            'q4': ['value 1', 'value 2'],
+            'q5': ['check 1', 'check 2'],
+            'q6': {'assurance': 'yes I am', 'value': '71234567890'},
+            'priceMin': '12.12',
+            'priceMax': '13.13',
+            'priceUnit': 'Unit',
+            'priceInterval': 'Hour',
+            'q9': 12.12,
+            'q10': 'Looooooooaaaaaaaaads of text',
+        }
+
+        # Failure modes
+        form = ImmutableMultiDict([
+            ('q1', 'not boolean')
+        ])
+        assert content.get_section_data('first_section', form)['q1'] == 'not boolean'
+
+        form = ImmutableMultiDict([
+            ('q9', 'not a number')
+        ])
+        assert content.get_section_data('first_section', form)['q9'] == 'not a number'
+
+        with pytest.raises(ValueError):
+            form = ImmutableMultiDict([
+                ('q7', '12.12'),
+            ])
+            content.get_section_data('first_section', form)
+
+    def test_get_all_data(self):
+        content = ContentBuilder([
+            {
+                "id": "first_section",
+                "name": "First section",
+                "questions": [{
+                    "id": "q1",
+                    "question": "Question one",
+                    "type": "text",
+                }]
+            },
+            {
+                "id": "second_section",
+                "name": "Second section",
+                "questions": [{
+                    "id": "q2",
+                    "question": "Question two",
+                    "type": "text",
+                }]
+            }
+        ])
+
+        form = ImmutableMultiDict([
+            ('q1', 'some text'),
+            ('q2', 'other text'),
+        ])
+
+        data = content.get_all_data(form)
+
+        assert data == {
+            'q1': 'some text',
+            'q2': 'other text',
+        }
 
 
 class TestReadYaml(object):

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -6,7 +6,7 @@ import pytest
 
 import io
 
-from dmutils.content_loader import ContentLoader, ContentBuilder, read_yaml
+from dmutils.content_loader import ContentLoader, ContentSection, ContentBuilder, read_yaml
 
 from sys import version_info
 if version_info.major == 2:
@@ -29,9 +29,9 @@ class TestContentBuilder(object):
         assert content.sections == []
 
     def test_content_builder_iteration(self):
-        content = ContentBuilder([1, 2, 3])
+        content = ContentBuilder([{'id': 1}, {'id': 2}, {'id': 3}])
 
-        assert list(content) == [1, 2, 3]
+        assert list(content) == [{'id': 1}, {'id': 2}, {'id': 3}]
 
     def test_a_question_with_a_dependency(self):
         content = ContentBuilder([{
@@ -332,124 +332,6 @@ class TestContentBuilder(object):
         assert content.get_next_editable_section_id(
             "second_section") == "third_section"
 
-    def test_get_section_data(self):
-        content = ContentBuilder([
-            {
-                "id": "first_section",
-                "name": "First section",
-                "questions": [{
-                    "id": "q1",
-                    "question": "Boolean question",
-                    "type": "boolean",
-                }, {
-                    "id": "q2",
-                    "question": "Text question",
-                    "type": "text",
-                }, {
-                    "id": "q3",
-                    "question": "Radios question",
-                    "type": "radios",
-                }, {
-                    "id": "q4",
-                    "question": "List question",
-                    "type": "list",
-                }, {
-                    "id": "q5",
-                    "question": "Checkboxes question",
-                    "type": "checkboxes",
-                }, {
-                    "id": "q6",
-                    "question": "Service ID question",
-                    "type": "service_id",
-                    "assuranceApproach": "2answers-type1",
-                }, {
-                    "id": "q7",
-                    "question": "Pricing question",
-                    "type": "pricing",
-                }, {
-                    "id": "q8",
-                    "question": "Upload question",
-                    "type": "upload",
-                }, {
-                    "id": "q9",
-                    "question": "Percentage question",
-                    "type": "percentage",
-                }, {
-                    "id": "q10",
-                    "question": "Large text question",
-                    "type": "textbox_large",
-                }, {
-                    "id": "q11",
-                    "question": "Text question",
-                    "type": "text"
-                }]
-            }, {
-                "id": "second_section",
-                "name": "Second section",
-                "question": [{
-                    "id": "q12",
-                    "question": "Text question",
-                    "type": "text",
-                }]
-            }
-        ])
-
-        form = ImmutableMultiDict([
-            ('q1', 'true'),
-            ('q2', 'Some text stuff'),
-            ('q3', 'value'),
-            ('q3', 'Should be lost'),
-            ('q4', 'value 1'),
-            ('q4', 'value 2'),
-            ('q5', 'check 1'),
-            ('q5', 'check 2'),
-            ('q6', '71234567890'),
-            ('q6--assurance', 'yes I am'),
-            ('q7', '12.12'),
-            ('q7', '13.13'),
-            ('q7', 'Unit'),
-            ('q7', 'Hour'),
-            ('q8', 'blah blah'),
-            ('q9', '12.12'),
-            ('q10', 'Looooooooaaaaaaaaads of text'),
-            ('extra_field', 'Should be lost'),
-            ('q12', 'Should be lost'),
-        ])
-
-        data = content.get_section_data('first_section', form)
-
-        assert data == {
-            'q1': True,
-            'q2': 'Some text stuff',
-            'q3': 'value',
-            'q4': ['value 1', 'value 2'],
-            'q5': ['check 1', 'check 2'],
-            'q6': {'assurance': 'yes I am', 'value': '71234567890'},
-            'priceMin': '12.12',
-            'priceMax': '13.13',
-            'priceUnit': 'Unit',
-            'priceInterval': 'Hour',
-            'q9': 12.12,
-            'q10': 'Looooooooaaaaaaaaads of text',
-        }
-
-        # Failure modes
-        form = ImmutableMultiDict([
-            ('q1', 'not boolean')
-        ])
-        assert content.get_section_data('first_section', form)['q1'] == 'not boolean'
-
-        form = ImmutableMultiDict([
-            ('q9', 'not a number')
-        ])
-        assert content.get_section_data('first_section', form)['q9'] == 'not a number'
-
-        with pytest.raises(ValueError):
-            form = ImmutableMultiDict([
-                ('q7', '12.12'),
-            ])
-            content.get_section_data('first_section', form)
-
     def test_get_all_data(self):
         content = ContentBuilder([
             {
@@ -483,6 +365,132 @@ class TestContentBuilder(object):
             'q1': 'some text',
             'q2': 'other text',
         }
+
+
+class TestContentSection(object):
+    def test_get_data(self):
+        section = ContentSection({
+            "id": "first_section",
+            "name": "First section",
+            "questions": [{
+                "id": "q1",
+                "question": "Boolean question",
+                "type": "boolean",
+            }, {
+                "id": "q2",
+                "question": "Text question",
+                "type": "text",
+            }, {
+                "id": "q3",
+                "question": "Radios question",
+                "type": "radios",
+            }, {
+                "id": "q4",
+                "question": "List question",
+                "type": "list",
+            }, {
+                "id": "q5",
+                "question": "Checkboxes question",
+                "type": "checkboxes",
+            }, {
+                "id": "q6",
+                "question": "Service ID question",
+                "type": "service_id",
+                "assuranceApproach": "2answers-type1",
+            }, {
+                "id": "q7",
+                "question": "Pricing question",
+                "type": "pricing",
+            }, {
+                "id": "q8",
+                "question": "Upload question",
+                "type": "upload",
+            }, {
+                "id": "q9",
+                "question": "Percentage question",
+                "type": "percentage",
+            }, {
+                "id": "q10",
+                "question": "Large text question",
+                "type": "textbox_large",
+            }, {
+                "id": "q11",
+                "question": "Text question",
+                "type": "text"
+            }]
+        })
+
+        form = ImmutableMultiDict([
+            ('q1', 'true'),
+            ('q2', 'Some text stuff'),
+            ('q3', 'value'),
+            ('q3', 'Should be lost'),
+            ('q4', 'value 1'),
+            ('q4', 'value 2'),
+            ('q5', 'check 1'),
+            ('q5', 'check 2'),
+            ('q6', '71234567890'),
+            ('q6--assurance', 'yes I am'),
+            ('q7', '12.12'),
+            ('q7', '13.13'),
+            ('q7', 'Unit'),
+            ('q7', 'Hour'),
+            ('q8', 'blah blah'),
+            ('q9', '12.12'),
+            ('q10', 'Looooooooaaaaaaaaads of text'),
+            ('extra_field', 'Should be lost'),
+            ('q12', 'Should be lost'),
+        ])
+
+        data = section.get_data(form)
+
+        assert data == {
+            'q1': True,
+            'q2': 'Some text stuff',
+            'q3': 'value',
+            'q4': ['value 1', 'value 2'],
+            'q5': ['check 1', 'check 2'],
+            'q6': {'assurance': 'yes I am', 'value': '71234567890'},
+            'priceMin': '12.12',
+            'priceMax': '13.13',
+            'priceUnit': 'Unit',
+            'priceInterval': 'Hour',
+            'q9': 12.12,
+            'q10': 'Looooooooaaaaaaaaads of text',
+        }
+
+        # Failure modes
+        form = ImmutableMultiDict([
+            ('q1', 'not boolean')
+        ])
+        assert section.get_data(form)['q1'] == 'not boolean'
+
+        form = ImmutableMultiDict([
+            ('q9', 'not a number')
+        ])
+        assert section.get_data(form)['q9'] == 'not a number'
+
+        with pytest.raises(ValueError):
+            form = ImmutableMultiDict([
+                ('q7', '12.12'),
+            ])
+            section.get_data(form)
+
+    def test_get_question(self):
+        section = ContentSection({
+            "id": "first_section",
+            "name": "First section",
+            "questions": [{
+                "id": "q1",
+                "question": 'First question',
+                "depends": [{
+                    "on": "lot",
+                    "being": ["SCS", "SaaS", "PaaS"]
+                }]
+            }]
+        })
+
+        assert section.get_question('q1').get('id') == 'q1'
 
 
 class TestReadYaml(object):

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -29,12 +29,20 @@ class TestContentBuilder(object):
         assert content.sections == []
 
     def test_content_builder_iteration(self):
-        content = ContentBuilder([{'id': 1}, {'id': 2}, {'id': 3}])
+        def section(id):
+            return {
+                'id': id,
+                'name': 'name',
+                'questions': []
+            }
 
-        assert list(content) == [{'id': 1}, {'id': 2}, {'id': 3}]
+        content = ContentBuilder([section(1), section(2), section(3)])
+
+        assert [section.id for section in content] == [1, 2, 3]
 
     def test_a_question_with_a_dependency(self):
         content = ContentBuilder([{
+            "id": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "q1",
@@ -50,6 +58,7 @@ class TestContentBuilder(object):
 
     def test_missing_depends_key_filter(self):
         content = ContentBuilder([{
+            "id": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "q1",
@@ -65,6 +74,7 @@ class TestContentBuilder(object):
 
     def test_question_without_dependencies(self):
         content = ContentBuilder([{
+            "id": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "q1",
@@ -76,6 +86,7 @@ class TestContentBuilder(object):
 
     def test_a_question_with_a_dependency_that_doesnt_match(self):
         content = ContentBuilder([{
+            "id": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "q1",
@@ -91,6 +102,7 @@ class TestContentBuilder(object):
 
     def test_a_question_which_depends_on_one_of_several_answers(self):
         content = ContentBuilder([{
+            "id": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "q1",
@@ -108,6 +120,7 @@ class TestContentBuilder(object):
 
     def test_a_question_which_shouldnt_be_shown(self):
         content = ContentBuilder([{
+            "id": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "q1",
@@ -123,6 +136,7 @@ class TestContentBuilder(object):
 
     def test_a_section_which_has_a_mixture_of_dependencies(self):
         content = ContentBuilder([{
+            "id": "first_section",
             "name": "First section",
             "questions": [
                 {
@@ -148,6 +162,7 @@ class TestContentBuilder(object):
 
     def test_section_modification(self):
         content = ContentBuilder([{
+            "id": "first_section",
             "name": "First section",
             "questions": [
                 {
@@ -176,6 +191,7 @@ class TestContentBuilder(object):
 
     def test_that_filtering_is_cumulative(self):
         content = ContentBuilder([{
+            "id": "first_section",
             "name": "First section",
             "questions": [
                 {
@@ -230,8 +246,7 @@ class TestContentBuilder(object):
             ]
         }])
 
-        assert content.get_section(
-            "first_section").get("id") == "first_section"
+        assert content.get_section("first_section").id == "first_section"
 
         content = content.filter({"lot": "IaaS"})
         assert content.get_section("first_section") is None
@@ -369,7 +384,7 @@ class TestContentBuilder(object):
 
 class TestContentSection(object):
     def test_get_data(self):
-        section = ContentSection({
+        section = ContentSection.create({
             "id": "first_section",
             "name": "First section",
             "questions": [{
@@ -477,7 +492,7 @@ class TestContentSection(object):
             section.get_data(form)
 
     def test_get_question(self):
-        section = ContentSection({
+        section = ContentSection.create({
             "id": "first_section",
             "name": "First section",
             "questions": [{
@@ -572,7 +587,11 @@ class TestContentLoader(object):
 
         assert isinstance(yaml_loader.get_builder(), ContentBuilder)
 
-        assert yaml_loader.get_builder().sections == yaml_loader._sections
+        assert [
+            section.id for section in yaml_loader.get_builder().sections
+        ] == [
+            section['id'] for section in yaml_loader._sections
+        ]
 
     def test_multple_builders(self, read_yaml_mock):
         self.set_read_yaml_mock_response(read_yaml_mock)


### PR DESCRIPTION
This moves the form parsing and filtering logic implemented in the supplier frontend into the `ContentBuilder` so that it can be used on other content manifests and in other frontends. I have left a couple of TODOs in around allowing questions with multiple fields (ie. pricing). I don't want to implement it right now but I would like to when we have done pre-pag.

This will require changes in the supplier frontend to make use of it.

**Before this change:**
```python
posted_data = get_formatted_section_data(section)
```

**After this change:**
```python
posted_data = content.get_section_data(section, request.form)
```

## Pull out a ContentSection class

The `ContentBuilder.get_section_data` method made more sense on a specific section object as we're already getting hold of the section.

**Rather than:**
```python
section = content.get_section(section_id)
if not section:
    abort(404)
section_data = content.get_section_data(section_id, request.form)
```

**We do:**
```python
section = content.get_section(section_id)
if not section:
    abort(404)
section_data = section.get_data(request.form)
```