### PR TITLE
Fixed incorrect logging on send email

### DIFF
--- a/dmutils/email.py
+++ b/dmutils/email.py
@@ -49,7 +49,7 @@ def send_email(
         current_app.logger.error("A mandrill error occurred: %s", e)
         raise MandrillException(e)
 
-    current_app.logger.info("Sent password email: %s", result)
+    current_app.logger.info("Sent {} email: {}".format(tags, result))
 
 
 def generate_token(data, secret_key, salt):


### PR DESCRIPTION
logged stated "password reset"

- now uses type tags to record actual email sent.