### PR TITLE
Add method to ContentSection to get field names

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '4.4.0'
+__version__ = '4.5.0'
 
 
 def init_app(

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -138,6 +138,27 @@ class ContentSection(object):
             editable=self.editable,
             questions=self.questions[:])
 
+    def get_field_names(self):
+        """Return a list of field names that this section returns
+
+        This list of field names corresponds to the keys of the data returned
+        by :func:`ContentSection.get_data`. This only affects the pricing question
+        that gets expanded into the the pricing fields.
+        """
+        question_ids = self.get_question_ids()
+        if self._has_pricing_type():
+            question_ids = [
+                q for q in question_ids if not self._is_pricing_type(q)
+            ] + PRICE_FIELDS
+
+        return question_ids
+
+    def _has_pricing_type(self):
+        return any(self._is_pricing_type(q) for q in self.get_question_ids())
+
+    def get_question_ids(self):
+        return [question['id'] for question in self.questions]
+
     def get_data(self, form_data):
         """Extract data for a section from a submitted form
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -507,6 +507,32 @@ class TestContentSection(object):
 
         assert section.get_question('q1').get('id') == 'q1'
 
+    def test_get_field_names_with_pricing_question(self):
+        section = ContentSection.create({
+            "id": "first_section",
+            "name": "First section",
+            "questions": [{
+                "id": "q1",
+                "question": "First question",
+                "type": "pricing"
+            }]
+        })
+
+        assert section.get_field_names() == ['priceMin', 'priceMax', 'priceUnit', 'priceInterval']
+
+    def test_get_field_names_with_no_pricing_question(self):
+        section = ContentSection.create({
+            "id": "second_section",
+            "name": "Second section",
+            "questions": [{
+                "id": "q2",
+                "question": "Second question",
+                "type": "text",
+            }]
+        })
+
+        assert section.get_field_names() == ['q2']
+
 
 class TestReadYaml(object):
     @mock.patch('os.path.isfile', return_value=True)


### PR DESCRIPTION
This moves `get_section_questions` and `get_raw_section_questions` from the supplier frontend to avoid exposing the `_is_pricing_type` method externally. It also brings in a distinction between question IDs, which are used to identify questions in the SSP content. And field names, which are the keys in the API payload that is returned by `get_data`.