### PR TITLE
Monotonic timing and timing API requests

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '5.0.0'
+__version__ = '5.1.0'
 
 
 def init_app(

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -97,10 +97,10 @@ class AppNameFilter(logging.Filter):
 class RequestIdFilter(logging.Filter):
     @property
     def request_id(self):
-        if not has_request_context():
-            return 'no-request-id'
-        else:
+        if has_request_context() and hasattr(request, 'request_id'):
             return request.request_id
+        else:
+            return 'no-request-id'
 
     def filter(self, record):
         record.request_id = self.request_id

--- a/dmutils/metrics.py
+++ b/dmutils/metrics.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from boto.ec2.cloudwatch import connect_to_region
 from flask import current_app, _app_ctx_stack as stack
 from contextlib2 import ContextDecorator
+from monotonic import monotonic
 
 
 def flask_client():
@@ -74,11 +75,11 @@ class Timer(ContextDecorator):
         self.name = name
 
     def __enter__(self):
-        self.start = datetime.utcnow()
+        self.start = monotonic()
 
     def __exit__(self, *exc):
-        elapsed = datetime.utcnow() - self.start
+        elapsed = monotonic() - self.start
         self.client._put_metric(
             self.name,
-            int(elapsed.total_seconds() * 1000),
+            int(elapsed * 1000),
             unit="Milliseconds")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ inflection==0.2.1
 Flask-FeatureFlags==0.6
 enum34==1.0.4
 mandrill==1.0.57
+monotonic==0.3

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -75,6 +75,11 @@ def test_formatter_request_id(app_with_logging):
         assert RequestIdFilter().request_id == 'generated'
 
 
+def test_formatter_request_id_in_non_logging_app(app):
+    with app.test_request_context('/', headers={'DM-Request-Id': 'generated'}):
+        assert RequestIdFilter().request_id == 'no-request-id'
+
+
 def test_init_app_adds_stream_handler_in_debug(app):
     app.config['DEBUG'] = True
     init_app(app)


### PR DESCRIPTION
## Use monotonic time for metric time

Non-monotonic time can jump back or forward. AWS tends to be quite good at this, slewing time changes slowly. However, using a monotonic time function is more robust.

## Time all API requests.

This gives us the ability to see how long requests are taking from the perspective of the caller.