### PR TITLE
Complete draft service audit type and API client method

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '5.1.0'
+__version__ = '5.2.0'
 
 
 def init_app(

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -293,6 +293,15 @@ class DataAPIClient(BaseAPIClient):
 
         return self._post("/draft-services/{}".format(draft_id), data=data)
 
+    def complete_draft_service(self, draft_id, user):
+        return self._post(
+            "/draft-services/{}/complete".format(draft_id),
+            data={
+                "update_details": {
+                    "updated_by": user
+                }
+            })
+
     def publish_draft_service(self, draft_id, user):
         return self._post(
             "/draft-services/{}/publish".format(draft_id),

--- a/dmutils/audit.py
+++ b/dmutils/audit.py
@@ -8,6 +8,7 @@ class AuditTypes(Enum):
     supplier_update = "supplier_update"
     create_draft_service = "create_draft_service"
     update_draft_service = "update_draft_service"
+    complete_draft_service = "complete_draft_service"
     publish_draft_service = "publish_draft_service"
     delete_draft_service = "delete_draft_service"
     update_service = "update_service"

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -899,6 +899,23 @@ class TestDataApiClient(object):
             }
         }
 
+    def test_complete_draft_service(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/draft-services/2/complete",
+            json={"done": "complete"},
+            status_code=201,
+        )
+
+        result = data_client.complete_draft_service(2, 'user')
+
+        assert result == {"done": "complete"}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'update_details': {
+                'updated_by': 'user'
+            }
+        }
+
     def test_update_draft_service(self, data_client, rmock):
         rmock.post(
             "http://baseurl/draft-services/2",


### PR DESCRIPTION
### Add "complete_draft_service" audit type
Used when the service submission draft is marked as complete

### Add complete_draft_service apiclient method

Sending this before the API endpoint because the API needs the new audit type