### PR TITLE
Duns number added to fetch suppliers endpoint

### DIFF
--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -44,7 +44,7 @@ class DataAPIClient(BaseAPIClient):
 
     # Suppliers
 
-    def find_suppliers(self, prefix=None, page=None, framework=None):
+    def find_suppliers(self, prefix=None, page=None, framework=None, duns_number=None):
         params = {}
         if prefix:
             params["prefix"] = prefix
@@ -52,6 +52,8 @@ class DataAPIClient(BaseAPIClient):
             params['page'] = page
         if framework is not None:
             params['framework'] = framework
+        if duns_number is not None:
+            params['duns_number'] = duns_number
 
         return self._get(
             "/suppliers",

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -719,6 +719,17 @@ class TestDataApiClient(object):
         assert result == {"services": "result"}
         assert rmock.called
 
+    def test_find_suppliers_with_duns_number(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/suppliers?duns_number=1234",
+            json={"services": "result"},
+            status_code=200)
+
+        result = data_client.find_suppliers(duns_number='1234')
+
+        assert result == {"services": "result"}
+        assert rmock.called
+
     def test_find_supplier_adds_page_parameter(self, data_client, rmock):
         rmock.get(
             "http://baseurl/suppliers?page=2",


### PR DESCRIPTION
client updates to support:

https://github.com/alphagov/digitalmarketplace-api/pull/206

Adds duns number as a param on fetching suppliers