### PR TITLE
Create audit events

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '5.2.0'
+__version__ = '5.3.0'
 
 
 def init_app(

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -48,6 +48,21 @@ class DataAPIClient(BaseAPIClient):
                 }
             })
 
+    def create_audit_event(self, audit_type, user, data, object_type=None, object_id=None):
+        payload = {
+            "type": audit_type,
+            "user": user,
+            "data": data,
+        }
+        if object_type is not None:
+            payload['objectType'] = object_type
+        if object_id is not None:
+            payload['objectId'] = object_id
+
+        return self._post(
+            '/audit-events',
+            data={'auditEvents': payload})
+
     # Suppliers
 
     def find_suppliers(self, prefix=None, page=None, framework=None):

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -14,7 +14,9 @@ class DataAPIClient(BaseAPIClient):
             audit_type=None,
             audit_date=None,
             page=None,
-            acknowledged=None):
+            acknowledged=None,
+            object_type=None,
+            object_id=None):
 
         params = {}
         if audit_type:
@@ -25,6 +27,10 @@ class DataAPIClient(BaseAPIClient):
             params['audit-date'] = audit_date
         if acknowledged is not None:
             params['acknowledged'] = acknowledged
+        if object_type is not None:
+            params['object-type'] = object_type
+        if object_id is not None:
+            params['object-id'] = object_id
 
         return self._get(
             "/audit-events",

--- a/dmutils/audit.py
+++ b/dmutils/audit.py
@@ -18,6 +18,7 @@ class AuditTypes(Enum):
     create_user = "create_user"
     update_user = "update_user"
     answer_selection_questions = "answer_selection_questions"
+    register_framework_interest = "register_framework_interest"
 
     @staticmethod
     def is_valid_audit_type(test_audit_type):

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1029,7 +1029,7 @@ class TestDataApiClient(object):
 
     def test_find_audit_events_with_all_params(self, data_client, rmock):
         rmock.get(
-            "http://baseurl/audit-events?page=123&audit-type=sometype&audit-date=2010-01-01&acknowledged=all",  # noqa
+            "http://baseurl/audit-events?page=123&audit-type=sometype&audit-date=2010-01-01&acknowledged=all&object-type=foo&object-id=123",  # noqa
             json={"audit-event": "result"},
             status_code=200,
         )
@@ -1038,7 +1038,9 @@ class TestDataApiClient(object):
             page=123,
             audit_type='sometype',
             acknowledged='all',
-            audit_date='2010-01-01')
+            audit_date='2010-01-01',
+            object_type='foo',
+            object_id=123)
 
         assert result == {"audit-event": "result"}
         assert rmock.called

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1080,6 +1080,27 @@ class TestDataApiClient(object):
             }
         }
 
+    def test_create_audit_event(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/audit-events",
+            json={"auditEvents": "result"},
+            status_code=200)
+
+        result = data_client.create_audit_event(
+            "thing_happened", "a user", {"key": "value"}, "suppliers", "123")
+
+        assert rmock.called
+        assert result == {'auditEvents': 'result'}
+        assert rmock.request_history[0].json() == {
+            "auditEvents": {
+                "type": "thing_happened",
+                "user": "a user",
+                "data": {"key": "value"},
+                "objectType": "suppliers",
+                "objectId": "123",
+            }
+        }
+
 
 class TestDataAPIClientIterMethods(object):
     def _test_find_iter(self, data_client, rmock, method_name, model_name, url_path):


### PR DESCRIPTION
Add object type and id to find audit events. Add create_audit_event. Add audit type for register_framework_interest, a new type for registering when a supplier has shown interest in a framework.