### PR TITLE
Force AuditTypes instances to be used as arugments

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '5.4.0'
+__version__ = '6.0.0'
 
 
 def init_app(

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -1,3 +1,4 @@
+from ..audit import AuditTypes
 from .base import BaseAPIClient, logger, make_iter_method
 from .errors import HTTPError
 
@@ -20,7 +21,9 @@ class DataAPIClient(BaseAPIClient):
 
         params = {}
         if audit_type:
-            params["audit-type"] = audit_type
+            if not isinstance(audit_type, AuditTypes):
+                raise TypeError("Must be an AuditTypes")
+            params["audit-type"] = audit_type.value
         if page is not None:
             params['page'] = page
         if audit_date is not None:
@@ -49,8 +52,10 @@ class DataAPIClient(BaseAPIClient):
             })
 
     def create_audit_event(self, audit_type, user, data, object_type=None, object_id=None):
+        if not isinstance(audit_type, AuditTypes):
+            raise TypeError("Must be an AuditTypes")
         payload = {
-            "type": audit_type,
+            "type": audit_type.value,
             "user": user,
             "data": data,
         }

--- a/dmutils/audit.py
+++ b/dmutils/audit.py
@@ -20,6 +20,8 @@ class AuditTypes(Enum):
     answer_selection_questions = "answer_selection_questions"
     register_framework_interest = "register_framework_interest"
     invite_user = "invite_user"
+    send_clarification_question = "send_clarification_question"
+    view_clarification_questions = "view_clarification_questions"
 
     @staticmethod
     def is_valid_audit_type(test_audit_type):


### PR DESCRIPTION
For the `find_audit_events` and `create_audit_event` methods, force instances of `AuditTypes` be used as an argument.

Also add new audit types for clarification questions.