### PR TITLE
Allow audit events to be created with no user

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '6.0.0'
+__version__ = '6.1.0'
 
 
 def init_app(

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -51,14 +51,17 @@ class DataAPIClient(BaseAPIClient):
                 }
             })
 
-    def create_audit_event(self, audit_type, user, data, object_type=None, object_id=None):
+    def create_audit_event(self, audit_type, user=None, data=None, object_type=None, object_id=None):
         if not isinstance(audit_type, AuditTypes):
             raise TypeError("Must be an AuditTypes")
+        if data is None:
+            data = {}
         payload = {
             "type": audit_type.value,
-            "user": user,
             "data": data,
         }
+        if user is not None:
+            payload['user'] = user
         if object_type is not None:
             payload['objectType'] = object_type
         if object_id is not None:

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1116,7 +1116,7 @@ class TestDataApiClient(object):
         rmock.post(
             "http://baseurl/audit-events",
             json={"auditEvents": "result"},
-            status_code=200)
+            status_code=201)
 
         result = data_client.create_audit_event(
             AuditTypes.contact_update, "a user", {"key": "value"}, "suppliers", "123")
@@ -1130,6 +1130,62 @@ class TestDataApiClient(object):
                 "data": {"key": "value"},
                 "objectType": "suppliers",
                 "objectId": "123",
+            }
+        }
+
+    def test_create_audit_event_with_no_user(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/audit-events",
+            json={'auditEvents': 'result'},
+            status_code=201)
+
+        result = data_client.create_audit_event(
+            AuditTypes.contact_update, None, {'key': 'value'}, 'suppliers', '123')
+
+        assert rmock.called
+        assert result == {'auditEvents': 'result'}
+        assert rmock.request_history[0].json() == {
+            "auditEvents": {
+                "type": "contact_update",
+                "data": {"key": "value"},
+                "objectType": "suppliers",
+                "objectId": "123",
+            }
+        }
+
+    def test_create_audit_event_with_no_object(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/audit-events",
+            json={'auditEvents': 'result'},
+            status_code=201)
+
+        result = data_client.create_audit_event(
+            AuditTypes.contact_update, 'user', {'key': 'value'})
+
+        assert rmock.called
+        assert result == {'auditEvents': 'result'}
+        assert rmock.request_history[0].json() == {
+            "auditEvents": {
+                "type": "contact_update",
+                "user": "user",
+                "data": {"key": "value"},
+            }
+        }
+
+    def test_create_audit_with_no_data_defaults_to_empty_object(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/audit-events",
+            json={'auditEvents': 'result'},
+            status_code=201)
+
+        result = data_client.create_audit_event(AuditTypes.contact_update)
+
+        assert rmock.called
+        assert result == {'auditEvents': 'result'}
+        assert rmock.request_history[0].json() == {
+            "auditEvents": {
+                "type": "contact_update",
+                "data": {},
             }
         }
 


### PR DESCRIPTION
This is allowed by the API and needed by the supplier frontend.