### PR TITLE
Update date format and to timezones

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -47,21 +47,7 @@ def init_app(
         response.headers['X-Frame-Options'] = 'DENY'
         return response
 
-    @application.template_filter('timeformat')
-    def timeformat(value, default_value=None):
-        return format_helper(value, default_value, formats.DISPLAY_TIME_FORMAT)
+    application.template_filter(formats.timeformat)
+    application.template_filter(formats.dateformat)
+    application.template_filter(formats.datetimeformat)
 
-    @application.template_filter('dateformat')
-    def dateformat(value, default_value=None):
-        return format_helper(value, default_value, formats.DISPLAY_DATE_FORMAT)
-
-    @application.template_filter('datetimeformat')
-    def datetimeformat(value, default_value=None):
-        return format_helper(value, default_value, formats.DISPLAY_DATETIME_FORMAT)
-
-    def format_helper(value, default_value, format):
-        if not value:
-            return default_value
-        if not isinstance(value, datetime):
-            value = datetime.strptime(value, formats.DATETIME_FORMAT)
-        return value.strftime(format)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -50,4 +50,3 @@ def init_app(
     application.template_filter(formats.timeformat)
     application.template_filter(formats.dateformat)
     application.template_filter(formats.datetimeformat)
-

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '6.2.0'
+__version__ = '6.2.1'
 
 
 def init_app(

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
+import pytz
 
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_FORMAT = "%Y-%m-%d"
@@ -43,12 +44,16 @@ def datetimeformat(value, default_value=None):
     return _format_date(value, default_value, DISPLAY_DATETIME_FORMAT)
 
 
+EUROPE_LONDON = pytz.timezone("Europe/London")
+
 def _format_date(value, default_value, fmt):
     if not value:
         return default_value
     if not isinstance(value, datetime):
         value = datetime.strptime(value, DATETIME_FORMAT)
-    return value.strftime(fmt)
+    if value.tzinfo is None:
+        value = pytz.utc.localize(value)
+    return value.astimezone(EUROPE_LONDON).strftime(fmt)
 
 
 def lot_to_lot_case(lot_to_check):

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_FORMAT = "%Y-%m-%d"
-DISPLAY_DATE_FORMAT = '%d/%m/%Y'
+DISPLAY_DATE_FORMAT = '%A %d %B %Y'
 DISPLAY_TIME_FORMAT = '%H:%M:%S'
-DISPLAY_DATETIME_FORMAT = '%A, %d %B %Y at %H:%M'
+DISPLAY_DATETIME_FORMAT = '%A %d %B %Y at %H:%M'
 
 LOTS = [
     {

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime
+
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_FORMAT = "%Y-%m-%d"
 DISPLAY_DATE_FORMAT = '%A %d %B %Y'
@@ -27,6 +29,26 @@ LOTS = [
         'label': u'Specialist Cloud Services',
     },
 ]
+
+
+def timeformat(value, default_value=None):
+    return _format_date(value, default_value, DISPLAY_TIME_FORMAT)
+
+
+def dateformat(value, default_value=None):
+    return _format_date(value, default_value, DISPLAY_DATE_FORMAT)
+
+
+def datetimeformat(value, default_value=None):
+    return _format_date(value, default_value, DISPLAY_DATETIME_FORMAT)
+
+
+def _format_date(value, default_value, fmt):
+    if not value:
+        return default_value
+    if not isinstance(value, datetime):
+        value = datetime.strptime(value, DATETIME_FORMAT)
+    return value.strftime(fmt)
 
 
 def lot_to_lot_case(lot_to_check):

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -46,6 +46,7 @@ def datetimeformat(value, default_value=None):
 
 EUROPE_LONDON = pytz.timezone("Europe/London")
 
+
 def _format_date(value, default_value, fmt):
     if not value:
         return default_value

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ Flask-FeatureFlags==0.6
 enum34==1.0.4
 mandrill==1.0.57
 monotonic==0.3
+pytz==2015.4

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 from dmutils.formats import (
     get_label_for_lot_param, lot_to_lot_case,
-    format_price, format_service_price
+    format_price, format_service_price,
+    timeformat, dateformat, datetimeformat
 )
+from datetime import datetime
 import pytest
 
 
@@ -84,3 +86,42 @@ def test_format_price_errors():
 
     for case in cases:
         yield check_price_formatting, case
+
+
+def test_timeformat():
+    cases = [
+        (datetime(2012, 12, 12, 12, 12, 12, 12), "12:12:12"),
+        ("2012-12-12T12:12:12.0Z", "12:12:12"),
+    ]
+
+    def check_timeformat(dt, formatted_time):
+        assert timeformat(dt) == formatted_time
+
+    for dt, formatted_time in cases:
+        yield check_timeformat, dt, formatted_time
+
+
+def test_dateformat():
+    cases = [
+        (datetime(2012, 12, 12, 12, 12, 12, 12), "Wednesday 12 December 2012"),
+        ("2012-12-12T12:12:12.0Z", "Wednesday 12 December 2012"),
+    ]
+
+    def check_dateformat(dt, formatted_date):
+        assert dateformat(dt) == formatted_date
+
+    for dt, formatted_date in cases:
+        yield check_dateformat, dt, formatted_date
+
+
+def test_datetimeformat():
+    cases = [
+        (datetime(2012, 12, 12, 12, 12, 12, 12), "Wednesday 12 December 2012 at 12:12"),
+        ("2012-12-12T12:12:12.0Z", "Wednesday 12 December 2012 at 12:12"),
+    ]
+
+    def check_datetimeformat(dt, formatted_datetime):
+        assert datetimeformat(dt) == formatted_datetime
+
+    for dt, formatted_datetime in cases:
+        yield check_datetimeformat, dt, formatted_datetime

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -4,6 +4,7 @@ from dmutils.formats import (
     format_price, format_service_price,
     timeformat, dateformat, datetimeformat
 )
+import pytz
 from datetime import datetime
 import pytest
 
@@ -92,6 +93,9 @@ def test_timeformat():
     cases = [
         (datetime(2012, 12, 12, 12, 12, 12, 12), "12:12:12"),
         ("2012-12-12T12:12:12.0Z", "12:12:12"),
+        (datetime(2012, 8, 12, 12, 12, 12, 12), "13:12:12"),
+        ("2012-08-12T12:12:12.0Z", "13:12:12"),
+        (datetime(2012, 8, 12, 12, 12, 12, 12, tzinfo=pytz.utc), "13:12:12"),
     ]
 
     def check_timeformat(dt, formatted_time):
@@ -105,6 +109,9 @@ def test_dateformat():
     cases = [
         (datetime(2012, 12, 12, 12, 12, 12, 12), "Wednesday 12 December 2012"),
         ("2012-12-12T12:12:12.0Z", "Wednesday 12 December 2012"),
+        (datetime(2012, 8, 12, 12, 12, 12, 12), "Sunday 12 August 2012"),
+        ("2012-08-12T12:12:12.0Z", "Sunday 12 August 2012"),
+        (datetime(2012, 8, 12, 12, 12, 12, 12, tzinfo=pytz.utc), "Sunday 12 August 2012"),
     ]
 
     def check_dateformat(dt, formatted_date):
@@ -118,6 +125,9 @@ def test_datetimeformat():
     cases = [
         (datetime(2012, 12, 12, 12, 12, 12, 12), "Wednesday 12 December 2012 at 12:12"),
         ("2012-12-12T12:12:12.0Z", "Wednesday 12 December 2012 at 12:12"),
+        (datetime(2012, 8, 12, 12, 12, 12, 12), "Sunday 12 August 2012 at 13:12"),
+        ("2012-08-12T12:12:12.0Z", "Sunday 12 August 2012 at 13:12"),
+        (datetime(2012, 8, 12, 12, 12, 12, 12, tzinfo=pytz.utc), "Sunday 12 August 2012 at 13:12"),
     ]
 
     def check_datetimeformat(dt, formatted_datetime):

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -91,11 +91,11 @@ def test_format_price_errors():
 
 def test_timeformat():
     cases = [
-        (datetime(2012, 12, 12, 12, 12, 12, 12), "12:12:12"),
-        ("2012-12-12T12:12:12.0Z", "12:12:12"),
-        (datetime(2012, 8, 12, 12, 12, 12, 12), "13:12:12"),
+        (datetime(2012, 11, 10, 9, 8, 7, 6), "09:08:07"),
+        ("2012-11-10T09:08:07.0Z", "09:08:07"),
+        (datetime(2012, 8, 10, 9, 8, 7, 6), "10:08:07"),
         ("2012-08-12T12:12:12.0Z", "13:12:12"),
-        (datetime(2012, 8, 12, 12, 12, 12, 12, tzinfo=pytz.utc), "13:12:12"),
+        (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "10:08:07"),
     ]
 
     def check_timeformat(dt, formatted_time):
@@ -107,11 +107,11 @@ def test_timeformat():
 
 def test_dateformat():
     cases = [
-        (datetime(2012, 12, 12, 12, 12, 12, 12), "Wednesday 12 December 2012"),
-        ("2012-12-12T12:12:12.0Z", "Wednesday 12 December 2012"),
-        (datetime(2012, 8, 12, 12, 12, 12, 12), "Sunday 12 August 2012"),
-        ("2012-08-12T12:12:12.0Z", "Sunday 12 August 2012"),
-        (datetime(2012, 8, 12, 12, 12, 12, 12, tzinfo=pytz.utc), "Sunday 12 August 2012"),
+        (datetime(2012, 11, 10, 9, 8, 7, 6), "Saturday 10 November 2012"),
+        ("2012-11-10T09:08:07.0Z", "Saturday 10 November 2012"),
+        (datetime(2012, 8, 10, 9, 8, 7, 6), "Friday 10 August 2012"),
+        ("2012-08-10T09:08:07.0Z", "Friday 10 August 2012"),
+        (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "Friday 10 August 2012"),
     ]
 
     def check_dateformat(dt, formatted_date):
@@ -123,11 +123,11 @@ def test_dateformat():
 
 def test_datetimeformat():
     cases = [
-        (datetime(2012, 12, 12, 12, 12, 12, 12), "Wednesday 12 December 2012 at 12:12"),
-        ("2012-12-12T12:12:12.0Z", "Wednesday 12 December 2012 at 12:12"),
-        (datetime(2012, 8, 12, 12, 12, 12, 12), "Sunday 12 August 2012 at 13:12"),
-        ("2012-08-12T12:12:12.0Z", "Sunday 12 August 2012 at 13:12"),
-        (datetime(2012, 8, 12, 12, 12, 12, 12, tzinfo=pytz.utc), "Sunday 12 August 2012 at 13:12"),
+        (datetime(2012, 11, 10, 9, 8, 7, 6), "Saturday 10 November 2012 at 09:08"),
+        ("2012-11-10T09:08:07.0Z", "Saturday 10 November 2012 at 09:08"),
+        (datetime(2012, 8, 10, 9, 8, 7, 6), "Friday 10 August 2012 at 10:08"),
+        ("2012-08-10T09:08:07.0Z", "Friday 10 August 2012 at 10:08"),
+        (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "Friday 10 August 2012 at 10:08"),
     ]
 
     def check_datetimeformat(dt, formatted_datetime):


### PR DESCRIPTION
The date format in the designs is Tuesday 12 December 2012.

## Move date/time format filters into formats module
So that they can be more easily tested and moves them closer to the formats they wrap.

## Always convert datetimes to Europe/London timezone
As all our internal date times are UTC, if a date time has no time zone attached assume it to be UTC.