### PR TITLE
Add `status` field to declaration responses

### DIFF
--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -134,13 +134,14 @@ class DataAPIClient(BaseAPIClient):
                 supplier_id, framework_slug))
 
     def answer_selection_questions(self, supplier_id, framework_slug,
-                                   answers, user):
+                                   answers, status, user):
         return self._put(
             "/suppliers/{}/selection-answers/{}".format(
                 supplier_id, framework_slug),
             data={
                 "updated_by": user,
                 "selectionAnswers": {
+                    "status": status,
                     "questionAnswers": answers
                 }
             })


### PR DESCRIPTION
This will be either `started` or `complete`, depending on whether all declaration questions have been answered.

This will need to go in (along with a following version number bump), once this PR is updated: https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/206