### PR TITLE
Add snapshot_framework_stats audit event type

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '6.4.0'
+__version__ = '6.5.0'
 
 
 def init_app(

--- a/dmutils/audit.py
+++ b/dmutils/audit.py
@@ -22,6 +22,7 @@ class AuditTypes(Enum):
     invite_user = "invite_user"
     send_clarification_question = "send_clarification_question"
     view_clarification_questions = "view_clarification_questions"
+    snapshot_framework_stats = "snapshot_framework_stats"
 
     @staticmethod
     def is_valid_audit_type(test_audit_type):


### PR DESCRIPTION
After some discussion we've decided that the easiest way to store
framework stats is to save them as audit events in the API.

This adds a new audit type to use for these events.

Since audit events have a creation date we can store the framework
stats response as audit event data without any changes. The event
should be associated with the related framework object.