### PR TITLE
Unformat data in the content loader

### DIFF
--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -192,6 +192,31 @@ class ContentSection(object):
                 }
         return section_data
 
+    def unformat_data(self, data):
+        """Unpack assurance information to be used in a form
+
+        :param data: the service data as returned from the data API
+        :type data: dict
+        :return: service data with unpacked assurance
+
+        Unpack fields from service JSON that have assurance information. In the
+        data API response the field would be::
+
+            {"field": {"assurance": "some assurance", "value": "some value"}}
+
+        This then gets unpacked into two fields::
+
+            {"field": "some value", "field--assurance": "some assurance"}
+        """
+        result = {}
+        for key in data:
+            if self._has_assurance(key):
+                result[key + '--assurance'] = data[key]['assurance']
+                result[key] = data[key]['value']
+            else:
+                result[key] = data[key]
+        return result
+
     def _get_fields(self):
         return [q['id'] for q in self.questions]
 
@@ -231,7 +256,8 @@ class ContentSection(object):
 
     def _has_assurance(self, key):
         """Return True if a question has an assurance component"""
-        return self.get_question(key).get('assuranceApproach', False)
+        question = self.get_question(key)
+        return bool(question) and question.get('assuranceApproach', False)
 
 
 class ContentLoader(object):

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -491,6 +491,91 @@ class TestContentSection(object):
             ])
             section.get_data(form)
 
+    def test_unformat_data(self):
+        section = ContentSection.create({
+            "id": "first_section",
+            "name": "First section",
+            "questions": [{
+                "id": "q1",
+                "question": "Boolean question",
+                "type": "boolean",
+            }, {
+                "id": "q2",
+                "question": "Text question",
+                "type": "text",
+            }, {
+                "id": "q3",
+                "question": "Radios question",
+                "type": "radios",
+            }, {
+                "id": "q4",
+                "question": "List question",
+                "type": "list",
+            }, {
+                "id": "q5",
+                "question": "Checkboxes question",
+                "type": "checkboxes",
+            }, {
+                "id": "q6",
+                "question": "Service ID question",
+                "type": "service_id",
+                "assuranceApproach": "2answers-type1",
+            }, {
+                "id": "q7",
+                "question": "Pricing question",
+                "type": "pricing",
+            }, {
+                "id": "q8",
+                "question": "Upload question",
+                "type": "upload",
+            }, {
+                "id": "q9",
+                "question": "Percentage question",
+                "type": "percentage",
+            }, {
+                "id": "q10",
+                "question": "Large text question",
+                "type": "textbox_large",
+            }, {
+                "id": "q11",
+                "question": "Text question",
+                "type": "text"
+            }]
+        })
+
+        data = {
+            'q1': True,
+            'q2': 'Some text stuff',
+            'q3': 'value',
+            'q4': ['value 1', 'value 2'],
+            'q5': ['check 1', 'check 2'],
+            'q6': {'assurance': 'yes I am', 'value': '71234567890'},
+            'priceMin': '12.12',
+            'priceMax': '13.13',
+            'priceUnit': 'Unit',
+            'priceInterval': 'Hour',
+            'q9': 12.12,
+            'q10': 'Looooooooaaaaaaaaads of text',
+        }
+
+        form = section.unformat_data(data)
+
+        assert form == {
+            'q1': True,
+            'q2': 'Some text stuff',
+            'q3': 'value',
+            'q4': ['value 1', 'value 2'],
+            'q5': ['check 1', 'check 2'],
+            'q6': '71234567890',
+            'q6--assurance': 'yes I am',
+            'priceMin': '12.12',
+            'priceMax': '13.13',
+            'priceUnit': 'Unit',
+            'priceInterval': 'Hour',
+            'q9': 12.12,
+            'q10': 'Looooooooaaaaaaaaads of text',
+        }
+
     def test_get_question(self):
         section = ContentSection.create({
             "id": "first_section",


### PR DESCRIPTION
This moves the unformat_section_data function from the supplier frontend
into the ContentSection class.

See:
https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/d7e89ddc0abdc0d8e0e9d72035c1311ef948ad37/app/main/helpers/services.py#L83