### PR TITLE
Add DISPLAY_DAY_FORMAT

### DIFF
--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -4,6 +4,7 @@ import pytz
 
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_FORMAT = "%Y-%m-%d"
+DISPLAY_DAY_FORMAT = '%d %B'
 DISPLAY_DATE_FORMAT = '%A %d %B %Y'
 DISPLAY_TIME_FORMAT = '%H:%M:%S'
 DISPLAY_DATETIME_FORMAT = '%A %d %B %Y at %H:%M'
@@ -34,6 +35,10 @@ LOTS = [
 
 def timeformat(value, default_value=None):
     return _format_date(value, default_value, DISPLAY_TIME_FORMAT)
+
+
+def dayformat(value, default_value=None):
+    return _format_date(value, default_value, DISPLAY_DAY_FORMAT)
 
 
 def dateformat(value, default_value=None):

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -2,7 +2,7 @@
 from dmutils.formats import (
     get_label_for_lot_param, lot_to_lot_case,
     format_price, format_service_price,
-    timeformat, dateformat, datetimeformat
+    timeformat, dayformat, dateformat, datetimeformat
 )
 import pytz
 from datetime import datetime
@@ -103,6 +103,22 @@ def test_timeformat():
 
     for dt, formatted_time in cases:
         yield check_timeformat, dt, formatted_time
+
+
+def test_dayformat():
+    cases = [
+        (datetime(2012, 11, 10, 9, 8, 7, 6), "10 November"),
+        ("2012-11-10T09:08:07.0Z", "10 November"),
+        (datetime(2012, 8, 10, 9, 8, 7, 6), "10 August"),
+        ("2012-08-10T09:08:07.0Z", "10 August"),
+        (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "10 August"),
+    ]
+
+    def check_dayformat(dt, formatted_date):
+        assert dayformat(dt) == formatted_date
+
+    for dt, formatted_date in cases:
+        yield check_dayformat, dt, formatted_date
 
 
 def test_dateformat():


### PR DESCRIPTION
Adding a day format like `26 August` to be used in the frameworks dashboard.  It's shorter than `Wednesday 26 August 2015` and in a lot of cases we don't gain anything by having the extra information.