### PR TITLE
Empty max price

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '6.5.0'
+__version__ = '6.5.1'
 
 
 def init_app(

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -297,7 +297,6 @@ def expand_pricing_field(pricing):
         raise ValueError("The pricing field did not have enough elements: {}".format(pricing))
     return {
         field_name: pricing[i] for i, field_name in enumerate(PRICE_FIELDS)
-        if len(pricing[i]) > 0
     }
 
 


### PR DESCRIPTION
#### Don't filter empty values from price fields
Allows removing optional priceMax value by sending `{"priceMax": ""}`
update to the API

Related to https://github.com/alphagov/digitalmarketplace-api/pull/224, but can be merged in any order (as long as both are merged)