### PR TITLE
Add JSON application logs

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '6.5.2'
+__version__ = '6.6.0'
 
 
 def init_app(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ Flask>=0.10
 six==1.9.0
 requests==2.7.0
 pyyaml==3.11
+git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
 inflection==0.2.1
 Flask-FeatureFlags==0.6
 enum34==1.0.4

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -5,7 +5,7 @@ import logging
 from werkzeug.test import EnvironBuilder
 import mock
 
-from dmutils.logging import init_app, RequestIdFilter, CustomRequest
+from dmutils.logging import init_app, RequestIdFilter, CustomRequest, JSONFormatter
 
 
 def test_get_request_id_from_request_id_header():
@@ -88,11 +88,14 @@ def test_init_app_adds_stream_handler_in_debug(app):
     assert isinstance(app.logger.handlers[0], logging.StreamHandler)
 
 
-def test_init_app_adds_file_handler_in_non_debug(app):
+def test_init_app_adds_file_handlers_in_non_debug(app):
     with tempfile.NamedTemporaryFile() as f:
         app.config['DEBUG'] = False
         app.config['DM_LOG_PATH'] = f.name
         init_app(app)
 
-        assert len(app.logger.handlers) == 1
+        assert len(app.logger.handlers) == 2
         assert isinstance(app.logger.handlers[0], logging.FileHandler)
+        assert isinstance(app.logger.handlers[0].formatter, logging.Formatter)
+        assert isinstance(app.logger.handlers[1], logging.FileHandler)
+        assert isinstance(app.logger.handlers[1].formatter, JSONFormatter)


### PR DESCRIPTION
This adds a JSON log file when not in development. CloudWatch logs
supports much more sophisticated searching over JSON logs than it does
over plain text logs [1]. Most notably compound conditions (AND and OR).

The JSON log file path is the same as the line by line one with a
.json appended, as it seems simpler than having to explicitly
configure a separate JSON log path.

This uses python-json-logger [2]. I am pulling the v0.1.3 tag directly
from git because there is no v0.1.3 package file in PyPi. We need v0.1.3
for logging excecption track traces. There is an issue open for this
[3].

Some of the keys are rewritten to match the field names used in other
logs such as the apache and nginx access logs.

[1] http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/FilterAndPatternSyntax.html
[2] https://github.com/madzak/python-json-logger
[3] madzak/python-json-logger#30