### PR TITLE
Add dayformat filter, bump version

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -48,5 +48,6 @@ def init_app(
         return response
 
     application.add_template_filter(formats.timeformat)
+    application.add_template_filter(formats.dayformat)
     application.add_template_filter(formats.dateformat)
     application.add_template_filter(formats.datetimeformat)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '6.5.1'
+__version__ = '6.5.2'
 
 
 def init_app(

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -48,6 +48,6 @@ def init_app(
         return response
 
     application.add_template_filter(formats.timeformat)
-    application.add_template_filter(formats.dayformat)
+    application.add_template_filter(formats.shortdateformat)
     application.add_template_filter(formats.dateformat)
     application.add_template_filter(formats.datetimeformat)

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -4,7 +4,7 @@ import pytz
 
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_FORMAT = "%Y-%m-%d"
-DISPLAY_DAY_FORMAT = '%d %B'
+DISPLAY_SHORT_DATE_FORMAT = '%d %B'
 DISPLAY_DATE_FORMAT = '%A %d %B %Y'
 DISPLAY_TIME_FORMAT = '%H:%M:%S'
 DISPLAY_DATETIME_FORMAT = '%A %d %B %Y at %H:%M'
@@ -37,8 +37,8 @@ def timeformat(value, default_value=None):
     return _format_date(value, default_value, DISPLAY_TIME_FORMAT)
 
 
-def dayformat(value, default_value=None):
-    return _format_date(value, default_value, DISPLAY_DAY_FORMAT)
+def shortdateformat(value, default_value=None):
+    return _format_date(value, default_value, DISPLAY_SHORT_DATE_FORMAT)
 
 
 def dateformat(value, default_value=None):

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -2,7 +2,7 @@
 from dmutils.formats import (
     get_label_for_lot_param, lot_to_lot_case,
     format_price, format_service_price,
-    timeformat, dayformat, dateformat, datetimeformat
+    timeformat, shortdateformat, dateformat, datetimeformat
 )
 import pytz
 from datetime import datetime
@@ -105,7 +105,7 @@ def test_timeformat():
         yield check_timeformat, dt, formatted_time
 
 
-def test_dayformat():
+def test_shortdateformat():
     cases = [
         (datetime(2012, 11, 10, 9, 8, 7, 6), "10 November"),
         ("2012-11-10T09:08:07.0Z", "10 November"),
@@ -114,11 +114,11 @@ def test_dayformat():
         (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "10 August"),
     ]
 
-    def check_dayformat(dt, formatted_date):
-        assert dayformat(dt) == formatted_date
+    def check_shortdateformat(dt, formatted_date):
+        assert shortdateformat(dt) == formatted_date
 
     for dt, formatted_date in cases:
-        yield check_dayformat, dt, formatted_date
+        yield check_shortdateformat, dt, formatted_date
 
 
 def test_dateformat():


### PR DESCRIPTION
##### Add dayformat template filter
Forgot to do this earlier.  Gives the templates a 'DD Month' display date filter (for example '27 August').

and version bump to 6.5.2