### PR TITLE
Fingerprint unicode files without error

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '6.7.0'
+__version__ = '6.7.1'
 
 
 def init_app(

--- a/dmutils/asset_fingerprint.py
+++ b/dmutils/asset_fingerprint.py
@@ -1,4 +1,5 @@
 import hashlib
+import codecs
 
 
 class AssetFingerprinter():
@@ -40,6 +41,6 @@ class AssetFingerprinter():
         ).hexdigest()
 
     def get_asset_file_contents(self, asset_file_path):
-        with open(asset_file_path, 'r') as asset_file:
+        with codecs.open(asset_file_path, encoding='utf-8') as asset_file:
             contents = asset_file.read()
         return contents

--- a/tests/test_asset_fingerprint.py
+++ b/tests/test_asset_fingerprint.py
@@ -87,3 +87,9 @@ class TestAssetFingerprint(object):
         fingerprinter.get_asset_file_contents.assert_called_once_with(
             'app/static/application.css'
         )
+
+
+class TestAssetFingerprintWithUnicode(object):
+    def test_can_read_self(self):
+        string_with_unicode_character = 'Ralph’s apostrophe'
+        AssetFingerprinter(filesystem_path='tests/').get_url('test_asset_fingerprint.py')


### PR DESCRIPTION
When running in Python 2, the asset fingerprinter throws an exception if given a file with unicode contents.

The only way I found to replicate this error in a test was to read a file, rather than mocking. The one file that a) can reliably expect to exist and b) makes most sense to have an arbitrary unicode character in it is the test itself.

Fixing the error meant using the `codecs` module from the standard library to to match Python 3's unicode-by-default file reading.