### PR TITLE
[#102562916] Include orphaned assurances

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '6.8.0'
+__version__ = '6.8.1'
 
 
 def init_app(

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -190,6 +190,17 @@ class ContentSection(object):
                     "value": section_data[key],
                     "assurance": form_data.get(key + '--assurance'),
                 }
+
+        # Check for assurance answers in the form data with no associated question
+        for key in set(form_data):
+            if key.endswith('--assurance'):
+                root_key = key[:-11]
+                if root_key in set(self._get_fields()) and root_key not in section_data:
+                    section_data[root_key] = {
+                        "value": "",
+                        "assurance": form_data.get(key),
+                    }
+
         return section_data
 
     def unformat_data(self, data):


### PR DESCRIPTION
Part of the fix for this bug: https://www.pivotaltracker.com/story/show/102562916

When getting form data any assurance responses that do not have their associated question also included in the form data are lost by the content loader. This means that responses cannot be re-populated on the page in the case of a page validation error.

This adds a check for these orphaned assurance responses and includes them in the extracted form data.