### PR TITLE
Add string formatting to logging

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '6.8.2'
+__version__ = '6.9.0'
 
 
 def init_app(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,11 +1,17 @@
 from __future__ import absolute_import
 import tempfile
 import logging
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+import json
 
 from werkzeug.test import EnvironBuilder
 import mock
 
-from dmutils.logging import init_app, RequestIdFilter, CustomRequest, JSONFormatter
+from dmutils.logging import init_app, RequestIdFilter, CustomRequest, JSONFormatter, CustomLogFormatter
+from dmutils.logging import LOG_FORMAT, TIME_FORMAT
 
 
 def test_get_request_id_from_request_id_header():
@@ -96,6 +102,105 @@ def test_init_app_adds_file_handlers_in_non_debug(app):
 
         assert len(app.logger.handlers) == 2
         assert isinstance(app.logger.handlers[0], logging.FileHandler)
-        assert isinstance(app.logger.handlers[0].formatter, logging.Formatter)
+        assert isinstance(app.logger.handlers[0].formatter, CustomLogFormatter)
         assert isinstance(app.logger.handlers[1], logging.FileHandler)
         assert isinstance(app.logger.handlers[1].formatter, JSONFormatter)
+
+
+class TestJSONFormatter(object):
+    def _create_logger(self, name, formatter):
+        logger = logging.getLogger(name)
+        logger.setLevel(logging.DEBUG)
+        buffer = StringIO()
+        handler = logging.StreamHandler(buffer)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+        return logger, buffer
+
+    def setup(self):
+        self.formatter = JSONFormatter(LOG_FORMAT, TIME_FORMAT)
+        self.logger, self.buffer = self._create_logger('logging-test', self.formatter)
+        self.dmlogger, self.dmbuffer = self._create_logger('dmutils', self.formatter)
+
+    def teardown(self):
+        del self.logger.handlers[:]
+        del self.dmlogger.handlers[:]
+
+    def test_json_formatter_renames_fields(self):
+        self.logger.info("hello")
+        result = json.loads(self.buffer.getvalue())
+        self.dmbuffer.getvalue()
+
+        assert 'time' in result
+        assert 'asctime' not in result
+        assert 'requestId' in result
+        assert 'request_id' not in result
+        assert 'application' in result
+        assert 'app_name' not in result
+
+    def test_log_type_is_set_to_application(self):
+        self.logger.info("hello")
+        result = json.loads(self.buffer.getvalue())
+        self.dmbuffer.getvalue()
+
+        assert result['logType'] == 'application'
+
+    def test_log_message_gets_formatted(self):
+        self.logger.info("hello {foo}", extra={'foo': 'bar'})
+        result = json.loads(self.buffer.getvalue())
+        self.dmbuffer.getvalue()
+
+        assert result['message'] == "hello bar"
+
+    def test_log_message_is_unchanged_if_fields_are_not_found(self):
+        self.logger.info("hello {bar}")
+        result = json.loads(self.buffer.getvalue())
+
+        assert result['message'] == "hello {bar}"
+
+    def test_failed_log_message_formatting_logs_an_error(self):
+        self.logger.info("hello {barry}")
+        raw_result = self.dmbuffer.getvalue()
+        result = json.loads(raw_result)
+
+        assert result['message'] == "failed to format log message"
+
+
+class TestCustomLogFormatter(object):
+    def _create_logger(self, name, formatter):
+        logger = logging.getLogger(name)
+        logger.setLevel(logging.DEBUG)
+        buffer = StringIO()
+        handler = logging.StreamHandler(buffer)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+        return logger, buffer
+
+    def setup(self):
+        self.formatter = CustomLogFormatter(LOG_FORMAT, TIME_FORMAT)
+        self.logger, self.buffer = self._create_logger('logging-test', self.formatter)
+        self.dmlogger, self.dmbuffer = self._create_logger('dmutils', self.formatter)
+
+    def teardown(self):
+        del self.logger.handlers[:]
+        del self.dmlogger.handlers[:]
+
+    def test_log_message_gets_formatted(self):
+        self.logger.info("hello {foo}", extra={'foo': 'bar'})
+        result = self.buffer.getvalue()
+
+        assert '"hello bar"' in result
+
+    def test_log_message_is_unchanged_if_fields_are_not_found(self):
+        self.logger.info("hello {bar}")
+        result = self.buffer.getvalue()
+
+        assert '"hello {bar}"' in result
+
+    def test_failed_log_message_formatting_logs_an_error(self):
+        self.logger.info("hello {barry}")
+        result = self.dmbuffer.getvalue()
+
+        assert '"failed to format log message"' in result


### PR DESCRIPTION
Allow the log message to be passed in as a format string that is formatted with the log record. This allows additional parameters to be passed in once and used for both JSON log fields and the main log message. This has been implemented for both the JSON logs and the plain text logs.

This gives an overview of the Python logging architecture
https://docs.python.org/2/howto/logging.html#logging-flow