### PR TITLE
Log stack trace for failed logging

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '6.10.0'
+__version__ = '6.11.0'
 
 
 def init_app(

--- a/dmutils/email.py
+++ b/dmutils/email.py
@@ -1,3 +1,5 @@
+import hashlib
+import base64
 from flask import current_app
 from mandrill import Mandrill, Error
 from itsdangerous import URLSafeTimedSerializer
@@ -66,3 +68,10 @@ def decode_token(token, secret_key, salt, max_age_in_seconds=86400):
         return_timestamp=True
     )
     return decoded, timestamp
+
+
+def hash_email(email):
+    m = hashlib.sha256()
+    m.update(email.encode('utf-8'))
+
+    return base64.urlsafe_b64encode(m.digest())

--- a/dmutils/email.py
+++ b/dmutils/email.py
@@ -48,10 +48,14 @@ def send_email(
         )
     except Error as e:
         # Mandrill errors are thrown as exceptions
-        current_app.logger.error("A mandrill error occurred: %s", e)
+        current_app.logger.error("A mandrill error occurred: {error}",
+                                 extra={'error': e})
         raise MandrillException(e)
 
-    current_app.logger.info("Sent {} email: {}".format(tags, result))
+    current_app.logger.info("Sent {tags} response: id={id}, email={email_hash}",
+                            extra={'tags': tags,
+                                   'id': result[0]['_id'],
+                                   'email_hash': hash_email(result[0]['email'])})
 
 
 def generate_token(data, secret_key, salt):

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -137,8 +137,8 @@ class CustomLogFormatter(logging.Formatter):
         record = self.add_fields(record)
         try:
             record.msg = record.msg.format(**record.__dict__)
-        except KeyError:
-            logger.exception("failed to format log message")
+        except KeyError as e:
+            logger.exception("failed to format log message: {} not found".format(e))
         return super(CustomLogFormatter, self).format(record)
 
 
@@ -154,6 +154,6 @@ class JSONFormatter(BaseJSONFormatter):
         log_record['logType'] = "application"
         try:
             log_record['message'] = log_record['message'].format(**log_record)
-        except KeyError:
-            logger.exception("failed to format log message")
+        except KeyError as e:
+            logger.exception("failed to format log message: {} not found".format(e))
         return log_record

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -138,7 +138,7 @@ class CustomLogFormatter(logging.Formatter):
         try:
             record.msg = record.msg.format(**record.__dict__)
         except KeyError:
-            logger.error("failed to format log message")
+            logger.exception("failed to format log message")
         return super(CustomLogFormatter, self).format(record)
 
 
@@ -155,5 +155,5 @@ class JSONFormatter(BaseJSONFormatter):
         try:
             log_record['message'] = log_record['message'].format(**log_record)
         except KeyError:
-            logger.error("failed to format log message")
+            logger.exception("failed to format log message")
         return log_record

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,8 +1,10 @@
+# -*- coding: utf-8 -*-
 from dmutils.email import generate_token, decode_token, \
-    send_email, MandrillException
+    send_email, MandrillException, hash_email
 from itsdangerous import BadTimeSignature
 import pytest
 import mock
+import six
 from dmutils.config import init_app
 from mandrill import Error
 
@@ -120,3 +122,13 @@ def test_cant_decode_token_with_wrong_key():
     with pytest.raises(BadTimeSignature) as error:
         decode_token(token, "failed", "1234567890")
     assert "does not match" in str(error.value)
+
+
+def test_hash_email():
+    tests = [
+        (u'test@example.com', six.b('lz3-Rj7IV4X1-Vr1ujkG7tstkxwk5pgkqJ6mXbpOgTs=')),
+        (u'☃@example.com', six.b('jGgXle8WEBTTIFhP25dF8Ck-FxQSCZ_N0iWYBWve4Ps=')),
+    ]
+
+    for test, expected in tests:
+        assert hash_email(test) == expected

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -25,7 +25,8 @@ def email_app(app):
 def test_calls_send_email_with_correct_params(email_app, mandrill):
     with email_app.app_context():
 
-        mandrill.messages.send.return_value = True
+        mandrill.messages.send.return_value = [
+            {'_id': '123', 'email': '123'}]
 
         expected_call = {
             'html': "body",

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -164,7 +164,7 @@ class TestJSONFormatter(object):
         raw_result = self.dmbuffer.getvalue()
         result = json.loads(raw_result)
 
-        assert result['message'] == "failed to format log message"
+        assert result['message'].startswith("failed to format log message")
 
 
 class TestCustomLogFormatter(object):
@@ -203,4 +203,4 @@ class TestCustomLogFormatter(object):
         self.logger.info("hello {barry}")
         result = self.dmbuffer.getvalue()
 
-        assert '"failed to format log message"' in result
+        assert 'failed to format log message' in result


### PR DESCRIPTION
## Log stack traces for logging format error messages
When the logging message formatting fails it logs an error. This change uses the `exception` method to add a stack trace to the error so that we can more easily trace the root cause.

## Move hash_email function into dmutils
This was originally implemented in the supplier frontend to hash emails before putting them in logs to avoid logging raw email addresses but still retain the ability to search for them.

## 	Use formatted log messages for email
This was causing errors with the new logging style because `result` is a JSON object. This change pulls out the useful information and formats it into the message directly.