### PR TITLE
[#103779820] Fix user-update auditing

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '6.11.0'
+__version__ = '7.0.0'
 
 
 def init_app(

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-from flask_login import current_user
 from ..audit import AuditTypes
 from .base import BaseAPIClient, logger, make_iter_method
 from .errors import HTTPError
@@ -231,7 +230,8 @@ class DataAPIClient(BaseAPIClient):
                     locked=None,
                     active=None,
                     role=None,
-                    supplier_id=None):
+                    supplier_id=None,
+                    updater="no logged-in user"):
         fields = {}
         if locked is not None:
             fields.update({
@@ -252,11 +252,6 @@ class DataAPIClient(BaseAPIClient):
             fields.update({
                 'supplierId': supplier_id
             })
-
-        if current_user:
-            updater = current_user.email_address
-        else:
-            updater = "no logged-in user"
 
         params = {
             "users": fields,

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from flask_login import current_user
 from ..audit import AuditTypes
 from .base import BaseAPIClient, logger, make_iter_method
 from .errors import HTTPError
@@ -252,8 +253,16 @@ class DataAPIClient(BaseAPIClient):
                 'supplierId': supplier_id
             })
 
+        if current_user:
+            updater = current_user.email_address
+        else:
+            updater = "no logged-in user"
+
         params = {
-            "users": fields
+            "users": fields,
+            "update_details": {
+                "updated_by": updater
+            }
         }
 
         user = self._post(
@@ -290,8 +299,7 @@ class DataAPIClient(BaseAPIClient):
             "/draft-services/{}".format(draft_id),
             data={
                 "update_details": {
-                    "updated_by": user,
-                    "update_reason": "deprecated",
+                    "updated_by": user
                 },
             })
 
@@ -300,8 +308,7 @@ class DataAPIClient(BaseAPIClient):
             "/draft-services/copy-from/{}".format(service_id),
             data={
                 "update_details": {
-                    "updated_by": user,
-                    "update_reason": "deprecated",
+                    "updated_by": user
                 },
             })
 
@@ -317,8 +324,7 @@ class DataAPIClient(BaseAPIClient):
     def update_draft_service(self, draft_id, service, user, page_questions=None):
         data = {
             "update_details": {
-                "updated_by": user,
-                "update_reason": "deprecated",
+                "updated_by": user
             },
             "services": service,
         }
@@ -342,8 +348,7 @@ class DataAPIClient(BaseAPIClient):
             "/draft-services/{}/publish".format(draft_id),
             data={
                 "update_details": {
-                    "updated_by": user,
-                    "update_reason": "deprecated",
+                    "updated_by": user
                 },
             })
 
@@ -384,35 +389,32 @@ class DataAPIClient(BaseAPIClient):
 
     find_services_iter = make_iter_method('find_services', 'services', 'services')
 
-    def import_service(self, service_id, service, user, reason):
+    def import_service(self, service_id, service, user):
         return self._put(
             "/services/{}".format(service_id),
             data={
                 "update_details": {
-                    "updated_by": user,
-                    "update_reason": reason,
+                    "updated_by": user
                 },
                 "services": service,
             })
 
-    def update_service(self, service_id, service, user, reason):
+    def update_service(self, service_id, service, user):
         return self._post(
             "/services/{}".format(service_id),
             data={
                 "update_details": {
-                    "updated_by": user,
-                    "update_reason": reason,
+                    "updated_by": user
                 },
                 "services": service,
             })
 
-    def update_service_status(self, service_id, status, user, reason):
+    def update_service_status(self, service_id, status, user):
         return self._post(
             "/services/{}/status/{}".format(service_id, status),
             data={
                 "update_details": {
-                    "updated_by": user,
-                    "update_reason": reason,
+                    "updated_by": user
                 },
             })
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ backoff==1.0.7
 boto==2.38.0
 contextlib2==0.4.0
 Flask>=0.10
+Flask-Login==0.2.11
 six==1.9.0
 requests==2.7.0
 pyyaml==3.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ backoff==1.0.7
 boto==2.38.0
 contextlib2==0.4.0
 Flask>=0.10
-Flask-Login==0.2.11
 six==1.9.0
 requests==2.7.0
 pyyaml==3.11

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -406,7 +406,7 @@ class TestDataApiClient(object):
         )
 
         result = data_client.import_service(
-            123, {"foo": "bar"}, "person", "reason")
+            123, {"foo": "bar"}, "person")
 
         assert result == {"services": "result"}
         assert rmock.called
@@ -419,7 +419,7 @@ class TestDataApiClient(object):
         )
 
         result = data_client.update_service(
-            123, {"foo": "bar"}, "person", "reason")
+            123, {"foo": "bar"}, "person")
 
         assert result == {"services": "result"}
         assert rmock.called
@@ -432,7 +432,7 @@ class TestDataApiClient(object):
         )
 
         result = data_client.update_service_status(
-            123, "published", "person", "reason")
+            123, "published", "person")
 
         assert result == {"services": "result"}
         assert rmock.called
@@ -619,6 +619,7 @@ class TestDataApiClient(object):
         data_client.update_user(123, role='supplier')
         assert rmock.called
         assert rmock.last_request.json() == {
+            "update_details": {"updated_by": "no logged-in user"},
             "users": {"role": 'supplier'}
         }
 
@@ -630,6 +631,7 @@ class TestDataApiClient(object):
         data_client.update_user(123, supplier_id=123)
         assert rmock.called
         assert rmock.last_request.json() == {
+            "update_details": {"updated_by": "no logged-in user"},
             "users": {"supplierId": 123}
         }
 
@@ -641,6 +643,7 @@ class TestDataApiClient(object):
         data_client.update_user(123, supplier_id=123, role='supplier')
         assert rmock.called
         assert rmock.last_request.json() == {
+            "update_details": {"updated_by": "no logged-in user"},
             "users": {
                 "supplierId": 123,
                 "role": "supplier"
@@ -655,6 +658,7 @@ class TestDataApiClient(object):
         data_client.update_user(123, locked=False)
         assert rmock.called
         assert rmock.last_request.json() == {
+            "update_details": {"updated_by": "no logged-in user"},
             "users": {"locked": False}
         }
 
@@ -666,6 +670,7 @@ class TestDataApiClient(object):
         data_client.update_user(123, active=True)
         assert rmock.called
         assert rmock.last_request.json() == {
+            "update_details": {"updated_by": "no logged-in user"},
             "users": {"active": True}
         }
 
@@ -677,6 +682,7 @@ class TestDataApiClient(object):
         data_client.update_user(123, active=False)
         assert rmock.called
         assert rmock.last_request.json() == {
+            "update_details": {"updated_by": "no logged-in user"},
             "users": {"active": False}
         }
 
@@ -881,7 +887,7 @@ class TestDataApiClient(object):
         assert rmock.called
         assert rmock.request_history[0].json() == {
             'update_details': {
-                'update_reason': 'deprecated', 'updated_by': 'user'
+                'updated_by': 'user'
             }
         }
 
@@ -901,7 +907,7 @@ class TestDataApiClient(object):
         assert rmock.called
         assert rmock.request_history[0].json() == {
             'update_details': {
-                'update_reason': 'deprecated', 'updated_by': 'user'
+                'updated_by': 'user'
             }
         }
 
@@ -957,7 +963,7 @@ class TestDataApiClient(object):
                 "field": "value"
             },
             'update_details': {
-                'update_reason': 'deprecated', 'updated_by': 'user'
+                'updated_by': 'user'
             },
         }
 
@@ -979,7 +985,7 @@ class TestDataApiClient(object):
                 "field": "value"
             },
             'update_details': {
-                'update_reason': 'deprecated', 'updated_by': 'user'
+                'updated_by': 'user'
             },
             'page_questions': ['question1', 'question2']
         }
@@ -999,7 +1005,7 @@ class TestDataApiClient(object):
         assert rmock.called
         assert rmock.request_history[0].json() == {
             'update_details': {
-                'update_reason': 'deprecated', 'updated_by': 'user'
+                'updated_by': 'user'
             }
         }
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -603,9 +603,9 @@ class TestDataApiClient(object):
     def test_update_user_returns_false_on_non_200(self, data_client, rmock):
         for status_code in [400, 403, 404, 500]:
             rmock.post(
-                    "http://baseurl/users/123",
-                    json={},
-                    status_code=status_code)
+                "http://baseurl/users/123",
+                json={},
+                status_code=status_code)
             with pytest.raises(HTTPError) as e:
                 data_client.update_user(123)
 
@@ -616,10 +616,10 @@ class TestDataApiClient(object):
             "http://baseurl/users/123",
             json={},
             status_code=200)
-        data_client.update_user(123, role='supplier')
+        data_client.update_user(123, role='supplier', updater="test@example.com")
         assert rmock.called
         assert rmock.last_request.json() == {
-            "update_details": {"updated_by": "no logged-in user"},
+            "update_details": {"updated_by": "test@example.com"},
             "users": {"role": 'supplier'}
         }
 
@@ -628,10 +628,10 @@ class TestDataApiClient(object):
             "http://baseurl/users/123",
             json={},
             status_code=200)
-        data_client.update_user(123, supplier_id=123)
+        data_client.update_user(123, supplier_id=123, updater="test@example.com")
         assert rmock.called
         assert rmock.last_request.json() == {
-            "update_details": {"updated_by": "no logged-in user"},
+            "update_details": {"updated_by": "test@example.com"},
             "users": {"supplierId": 123}
         }
 
@@ -640,10 +640,10 @@ class TestDataApiClient(object):
             "http://baseurl/users/123",
             json={},
             status_code=200)
-        data_client.update_user(123, supplier_id=123, role='supplier')
+        data_client.update_user(123, supplier_id=123, role='supplier', updater="test@example.com")
         assert rmock.called
         assert rmock.last_request.json() == {
-            "update_details": {"updated_by": "no logged-in user"},
+            "update_details": {"updated_by": "test@example.com"},
             "users": {
                 "supplierId": 123,
                 "role": "supplier"
@@ -655,10 +655,10 @@ class TestDataApiClient(object):
             "http://baseurl/users/123",
             json={},
             status_code=200)
-        data_client.update_user(123, locked=False)
+        data_client.update_user(123, locked=False, updater="test@example.com")
         assert rmock.called
         assert rmock.last_request.json() == {
-            "update_details": {"updated_by": "no logged-in user"},
+            "update_details": {"updated_by": "test@example.com"},
             "users": {"locked": False}
         }
 
@@ -667,10 +667,10 @@ class TestDataApiClient(object):
             "http://baseurl/users/123",
             json={},
             status_code=200)
-        data_client.update_user(123, active=True)
+        data_client.update_user(123, active=True, updater="test@example.com")
         assert rmock.called
         assert rmock.last_request.json() == {
-            "update_details": {"updated_by": "no logged-in user"},
+            "update_details": {"updated_by": "test@example.com"},
             "users": {"active": True}
         }
 
@@ -679,10 +679,10 @@ class TestDataApiClient(object):
             "http://baseurl/users/123",
             json={},
             status_code=200)
-        data_client.update_user(123, active=False)
+        data_client.update_user(123, active=False, updater="test@example.com")
         assert rmock.called
         assert rmock.last_request.json() == {
-            "update_details": {"updated_by": "no logged-in user"},
+            "update_details": {"updated_by": "test@example.com"},
             "users": {"active": False}
         }
 


### PR DESCRIPTION
Part of this bug fix: https://www.pivotaltracker.com/story/show/103779820

Currently our auditing of user updates is broken because we only audit the user who was changed, not who made the change.  We need both to have a proper record of changes that have been made.

This commit also removes the long-deprecated `update reason` parameter from update details.