### PR TITLE
Add template filter for chunking the service ID

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -47,7 +47,4 @@ def init_app(
         response.headers['X-Frame-Options'] = 'DENY'
         return response
 
-    application.add_template_filter(formats.timeformat)
-    application.add_template_filter(formats.shortdateformat)
-    application.add_template_filter(formats.dateformat)
-    application.add_template_filter(formats.datetimeformat)
+    formats.init_app(application)

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -1,6 +1,16 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 import pytz
+import re
+
+
+def init_app(application):
+    application.add_template_filter(timeformat)
+    application.add_template_filter(shortdateformat)
+    application.add_template_filter(dateformat)
+    application.add_template_filter(datetimeformat)
+    application.add_template_filter(chunk_service_id)
+
 
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_FORMAT = "%Y-%m-%d"
@@ -102,3 +112,11 @@ def format_price(min_price, max_price, unit, interval):
     if interval:
         formatted_price += ' per ' + interval.lower()
     return formatted_price
+
+
+def chunk_service_id(service_id):
+    service_id = str(service_id)
+    if re.search(r'[a-zA-Z]', service_id):
+        return [service_id]
+    else:
+        return re.findall(r'....', service_id)

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -2,7 +2,8 @@
 from dmutils.formats import (
     get_label_for_lot_param, lot_to_lot_case,
     format_price, format_service_price,
-    timeformat, shortdateformat, dateformat, datetimeformat
+    timeformat, shortdateformat, dateformat, datetimeformat,
+    chunk_service_id
 )
 import pytz
 from datetime import datetime
@@ -151,3 +152,17 @@ def test_datetimeformat():
 
     for dt, formatted_datetime in cases:
         yield check_datetimeformat, dt, formatted_datetime
+
+
+def test_chunk_service_id():
+    cases = [
+        (12345678, ['1234', '5678']),
+        ('12345678', ['1234', '5678']),
+        ('A1234567', ['A1234567']),
+    ]
+
+    def check_chunked_service_id(service_id, chunked_service_id):
+        assert chunk_service_id(service_id) == chunked_service_id
+
+    for service_id, chunked_service_id in cases:
+        yield check_chunked_service_id, service_id, chunked_service_id


### PR DESCRIPTION
This adds a template filter for chunking the service ID for display. If a service ID is all numeric (ie. not G-Cloud 5) it will be split 4-digit chunks for display.

Currently this chunking is done in a couple of different places; in the buyer frontend it is done with service_presenters and in the admin app dmutils/presenters.

This does create a dependency between the frontend toolkit and dmutils but I can't see a better way around it. Any ideas would be gratefully received. 