### PR TITLE
[#103403706] Set Request ID header on error responses

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '8.0.0'
+__version__ = '8.1.0'
 
 
 def init_app(

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -1,4 +1,4 @@
-from . import logging, config, proxy_fix, formats
+from . import logging, config, proxy_fix, formats, request_id
 from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
@@ -25,6 +25,7 @@ def init_app(
     config.init_app(application)
     logging.init_app(application)
     proxy_fix.init_app(application)
+    request_id.init_app(application)
 
     if bootstrap:
         bootstrap.init_app(application)

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -1,12 +1,10 @@
 from __future__ import absolute_import
 import logging
-import uuid
 import sys
 import re
 from itertools import product
 
 from flask import request, current_app
-from flask.wrappers import Request
 from flask.ctx import has_request_context
 
 from pythonjsonlogger.jsonlogger import JsonFormatter as BaseJSONFormatter
@@ -22,16 +20,9 @@ def init_app(app):
     app.config.setdefault('DM_LOG_LEVEL', 'INFO')
     app.config.setdefault('DM_APP_NAME', 'none')
     app.config.setdefault('DM_LOG_PATH', './log/application.log')
-    app.config.setdefault('DM_REQUEST_ID_HEADER', 'DM-Request-ID')
-    app.config.setdefault('DM_DOWNSTREAM_REQUEST_ID_HEADER', '')
-
-    app.request_class = CustomRequest
 
     @app.after_request
     def after_request(response):
-        request_id_header = current_app.config['DM_REQUEST_ID_HEADER']
-        response.headers[request_id_header] = request.request_id
-
         current_app.logger.info('%s %s %s',
                                 request.method,
                                 request.url,
@@ -50,26 +41,6 @@ def init_app(app):
         logger.setLevel(loglevel)
 
     app.logger.info("Logging configured")
-
-
-class CustomRequest(Request):
-    _request_id = None
-
-    @property
-    def request_id(self):
-        if self._request_id is None:
-            self._request_id = self._get_request_id(
-                current_app.config['DM_REQUEST_ID_HEADER'],
-                current_app.config['DM_DOWNSTREAM_REQUEST_ID_HEADER'])
-        return self._request_id
-
-    def _get_request_id(self, request_id_header, downstream_header):
-        if request_id_header in self.headers:
-            return self.headers.get(request_id_header)
-        elif downstream_header and downstream_header in self.headers:
-            return self.headers.get(downstream_header)
-        else:
-            return str(uuid.uuid4())
 
 
 def configure_handler(handler, app, formatter):

--- a/dmutils/request_id.py
+++ b/dmutils/request_id.py
@@ -1,0 +1,50 @@
+import uuid
+
+from flask import request, current_app
+from flask.wrappers import Request
+
+
+class CustomRequest(Request):
+    _request_id = None
+
+    @property
+    def request_id(self):
+        if self._request_id is None:
+            self._request_id = self._get_request_id(
+                current_app.config['DM_REQUEST_ID_HEADER'],
+                current_app.config['DM_DOWNSTREAM_REQUEST_ID_HEADER'])
+        return self._request_id
+
+    def _get_request_id(self, request_id_header, downstream_header):
+        if request_id_header in self.headers:
+            return self.headers.get(request_id_header)
+        elif downstream_header and downstream_header in self.headers:
+            return self.headers.get(downstream_header)
+        else:
+            return str(uuid.uuid4())
+
+
+class ResponseHeaderMiddleware(object):
+    def __init__(self, app, request_id_header):
+        self.app = app
+        self.request_id_header = request_id_header
+
+    def __call__(self, environ, start_response):
+        def rewrite_response_headers(status, headers, exc_info=None):
+            if self.request_id_header not in dict(headers).keys():
+                headers = headers + [(
+                    self.request_id_header,
+                    request.request_id
+                )]
+
+            return start_response(status, headers, exc_info)
+
+        return self.app(environ, rewrite_response_headers)
+
+
+def init_app(app):
+    app.config.setdefault('DM_REQUEST_ID_HEADER', 'DM-Request-ID')
+    app.config.setdefault('DM_DOWNSTREAM_REQUEST_ID_HEADER', '')
+
+    app.request_class = CustomRequest
+    app.wsgi_app = ResponseHeaderMiddleware(app.wsgi_app, app.config['DM_REQUEST_ID_HEADER'])

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -13,6 +13,7 @@ from dmutils.apiclient import APIError, HTTPError, InvalidResponse
 from dmutils.apiclient.errors import REQUEST_ERROR_STATUS_CODE
 from dmutils.apiclient.errors import REQUEST_ERROR_MESSAGE
 from dmutils.audit import AuditTypes
+from dmutils import request_id
 
 
 @pytest.yield_fixture
@@ -278,6 +279,7 @@ class TestDataApiClient(object):
     def test_request_id_is_added_if_available(
             self, data_client, rmock, app_with_logging):
         headers = {'DM-Request-Id': 'generated'}
+        request_id.init_app(app_with_logging)
         with app_with_logging.test_request_context('/', headers=headers):
             rmock.get(
                 "http://baseurl/_status",

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -1,0 +1,77 @@
+import mock
+from werkzeug.test import EnvironBuilder
+
+from dmutils import request_id
+from dmutils.request_id import CustomRequest
+
+
+def test_get_request_id_from_request_id_header():
+    builder = EnvironBuilder()
+    builder.headers['DM-REQUEST-ID'] = 'from-header'
+    builder.headers['DOWNSTREAM-REQUEST-ID'] = 'from-downstream'
+    request = CustomRequest(builder.get_environ())
+
+    request_id = request._get_request_id('DM-REQUEST-ID',
+                                         'DOWNSTREAM-REQUEST-ID')
+
+    assert request_id == 'from-header'
+
+
+def test_get_request_id_from_downstream_header():
+    builder = EnvironBuilder()
+    builder.headers['DOWNSTREAM-REQUEST-ID'] = 'from-downstream'
+    request = CustomRequest(builder.get_environ())
+
+    request_id = request._get_request_id('DM-REQUEST-ID',
+                                         'DOWNSTREAM-REQUEST-ID')
+
+    assert request_id == 'from-downstream'
+
+
+@mock.patch('dmutils.request_id.uuid.uuid4')
+def test_get_request_id_with_no_downstream_header_configured(uuid4_mock):
+    builder = EnvironBuilder()
+    builder.headers[''] = 'from-downstream'
+    request = CustomRequest(builder.get_environ())
+    uuid4_mock.return_value = 'generated'
+
+    request_id = request._get_request_id('DM-REQUEST-ID', '')
+
+    uuid4_mock.assert_called_once()
+    assert request_id == 'generated'
+
+
+@mock.patch('dmutils.request_id.uuid.uuid4')
+def test_get_request_id_generates_id(uuid4_mock):
+    builder = EnvironBuilder()
+    request = CustomRequest(builder.get_environ())
+    uuid4_mock.return_value = 'generated'
+
+    request_id = request._get_request_id('DM-REQUEST-ID',
+                                         'DOWNSTREAM-REQUEST-ID')
+
+    uuid4_mock.assert_called_once()
+    assert request_id == 'generated'
+
+
+def test_request_id_is_set_on_response(app):
+    request_id.init_app(app)
+    client = app.test_client()
+
+    with app.app_context():
+        response = client.get('/', headers={'DM-REQUEST-ID': 'generated'})
+        assert response.headers['DM-Request-ID'] == 'generated'
+
+
+def test_request_id_is_set_on_error_response(app):
+    request_id.init_app(app)
+    client = app.test_client()
+
+    @app.route('/')
+    def error_route():
+        raise Exception()
+
+    with app.app_context():
+        response = client.get('/', headers={'DM-REQUEST-ID': 'generated'})
+        assert response.status_code == 500
+        assert response.headers['DM-Request-ID'] == 'generated'


### PR DESCRIPTION
[#103403706](https://www.pivotaltracker.com/story/show/103403706)

Replaces @after_request header setter with a WSGI middleware.
Unlike after_request, middleware is run on error responses, even if
they're caused by an uncaught exception.

Middleware is not executed when DEBUG is set to True, so development
servers won't have Request-ID headers set by default.

Request-ID related code, including the custom request class is moved
to the request_id module to remove implicit `app.config.setdefault`
dependency between logging and request_id modules.