### PR TITLE
𝐔𝐑𝐆𝐄𝐍𝐓: Fix update password

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '7.0.0'
+__version__ = '7.0.1'
 
 
 def init_app(

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -211,11 +211,16 @@ class DataAPIClient(BaseAPIClient):
                 raise
         return None
 
-    def update_user_password(self, user_id, new_password):
+    def update_user_password(self, user_id, new_password, updater="no logged-in user"):
         try:
             self._post(
                 '/users/{}'.format(user_id),
-                data={"users": {"password": new_password}}
+                data={
+                    "users": {"password": new_password},
+                    "update_details": {
+                        "updated_by": updater
+                    }
+                }
             )
 
             logger.info("Updated password for user %s", user_id)

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -588,7 +588,27 @@ class TestDataApiClient(object):
             status_code=200)
         assert data_client.update_user_password(123, "newpassword")
         assert rmock.last_request.json() == {
-            "users": {"password": "newpassword"}
+            "users": {
+                "password": "newpassword"
+            },
+            "update_details": {
+                "updated_by": "no logged-in user"
+            }
+        }
+
+    def test_update_user_password_by_logged_in_user(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/users/123",
+            json={},
+            status_code=200)
+        assert data_client.update_user_password(123, "newpassword", "test@example.com")
+        assert rmock.last_request.json() == {
+            "users": {
+                "password": "newpassword"
+            },
+            "update_details": {
+                "updated_by": "test@example.com"
+            }
         }
 
     def test_update_user_password_returns_false_on_non_200(


### PR DESCRIPTION
The API has changed to require who is updating a user: alphagov/digitalmarketplace-api@7f578ea

This change was reflected in utils for updating a user's information: 8a4bd48

…but wasn't changed for updating a user's password. This is currently causing a "Could not update password due to an error" error on production.

This commit allows the email address of the current user to be passed in, fixing the bug.

--

Addresses: https://www.pivotaltracker.com/story/show/104342384