### PR TITLE
Fix apiclient logging

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '8.1.0'
+__version__ = '8.1.1'
 
 
 def init_app(

--- a/dmutils/apiclient/base.py
+++ b/dmutils/apiclient/base.py
@@ -83,14 +83,27 @@ class BaseAPIClient(object):
             response.raise_for_status()
         except requests.RequestException as e:
             api_error = HTTPError.create(e)
+            elapsed_time = monotonic() - start_time
             logger.warning(
-                "API %s request on %s failed with %s '%s'",
-                method, url, api_error.status_code, api_error.message)
+                "API {api_method} request on {api_url} failed with {api_status} '{api_error}'",
+                extra={
+                    'api_method': method,
+                    'api_url': url,
+                    'api_status': api_error.status_code,
+                    'api_error': api_error.message,
+                    'api_time': elapsed_time
+                })
             raise api_error
-        finally:
+        else:
             elapsed_time = monotonic() - start_time
             logger.info(
-                "API %s request on %s finished in %s", method, url, elapsed_time)
+                "API {api_method} request on {api_url} finished in {api_time}",
+                extra={
+                    'api_method': method,
+                    'api_url': url,
+                    'api_status': response.status_code,
+                    'api_time': elapsed_time
+                })
         try:
             return response.json()
         except ValueError as e:


### PR DESCRIPTION
This updates the apiclient logging to use the formatted logging introduced with #160.

In addition this changes the logging so that we only get one message per
API request (either successful or unsucessful) and the elapsed time is
added to both.