### PR TITLE
Fix mod_wsgi error with header encoding

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '8.1.1'
+__version__ = '8.1.2'
 
 
 def init_app(

--- a/dmutils/request_id.py
+++ b/dmutils/request_id.py
@@ -34,7 +34,7 @@ class ResponseHeaderMiddleware(object):
             if self.request_id_header not in dict(headers).keys():
                 headers = headers + [(
                     self.request_id_header,
-                    request.request_id
+                    request.request_id.encode('utf-8')
                 )]
 
             return start_response(status, headers, exc_info)

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -60,7 +60,7 @@ def test_request_id_is_set_on_response(app):
 
     with app.app_context():
         response = client.get('/', headers={'DM-REQUEST-ID': 'generated'})
-        assert response.headers['DM-Request-ID'] == 'generated'
+        assert response.headers['DM-Request-ID'] == 'generated'.encode('utf-8')
 
 
 def test_request_id_is_set_on_error_response(app):
@@ -74,4 +74,4 @@ def test_request_id_is_set_on_error_response(app):
     with app.app_context():
         response = client.get('/', headers={'DM-REQUEST-ID': 'generated'})
         assert response.status_code == 500
-        assert response.headers['DM-Request-ID'] == 'generated'
+        assert response.headers['DM-Request-ID'] == 'generated'.encode('utf-8')


### PR DESCRIPTION
Request ID value taken from the incoming request header is a unicode
object instead of a string. Headers set on flask response objects
might be encoded by flask before being sent to the WSGI server, but
middleware headers are probably added after that step, which means
a unicode string ends up as header value, which makes Apache mod_wsgi
respond with internal error.