### PR TITLE
Add service update error management

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '8.1.2'
+__version__ = '8.2.0'
 
 
 def init_app(

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -95,9 +95,9 @@ def format_service_price(service):
 
 def format_price(min_price, max_price, unit, interval):
     """Format a price string"""
-    formatted_price = u'£' + min_price
+    formatted_price = u'£{}'.format(min_price)
     if max_price:
-        formatted_price += u' to £' + max_price
+        formatted_price += u' to £{}'.format(max_price)
     formatted_price += ' per ' + unit.lower()
     if interval:
         formatted_price += ' per ' + interval.lower()

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -66,6 +66,7 @@ def test_format_price():
         (('12', '13', 'Unit', None), u'£12 to £13 per unit'),
         (('12', '13', 'Unit', 'Second'), u'£12 to £13 per unit per second'),
         (('12', None, 'Unit', 'Second'), u'£12 per unit per second'),
+        ((12, 13, 'Unit', None), u'£12 to £13 per unit'),
     ]
 
     def check_price_formatting(args, formatted_price):


### PR DESCRIPTION
This adds service update error management to the content loader module.

These methods are copied over from the supplier frontend and will be used both from there and the admin frontend.