### PR TITLE
Move upload_documents to dmutils

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '8.2.0'
+__version__ = '8.3.0'
 
 
 def init_app(

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -156,8 +156,11 @@ class ContentSection(object):
     def _has_pricing_type(self):
         return any(self._is_pricing_type(q) for q in self.get_question_ids())
 
-    def get_question_ids(self):
-        return [question['id'] for question in self.questions]
+    def get_question_ids(self, type=None):
+        return [
+            question['id'] for question in self.questions
+            if type is None or question.get('type') == type
+        ]
 
     def get_data(self, form_data):
         """Extract data for a section from a submitted form

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -173,7 +173,7 @@ class ContentSection(object):
         to their type in the section data.
         """
         section_data = {}
-        for key in set(form_data) & set(self._get_fields()):
+        for key in set(form_data) & set(self.get_question_ids()):
             if self._is_list_type(key):
                 section_data[key] = form_data.getlist(key)
             elif self._is_boolean_type(key):
@@ -195,7 +195,7 @@ class ContentSection(object):
         for key in set(form_data):
             if key.endswith('--assurance'):
                 root_key = key[:-11]
-                if root_key in set(self._get_fields()) and root_key not in section_data:
+                if root_key in set(self.get_question_ids()) and root_key not in section_data:
                     section_data[root_key] = {
                         "assurance": form_data.get(key),
                     }
@@ -297,9 +297,6 @@ class ContentSection(object):
             else:
                 result[key] = data[key]
         return result
-
-    def _get_fields(self):
-        return [q['id'] for q in self.questions]
 
     def get_question(self, question_id):
         """Return a question dictionary by question ID"""

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -86,6 +86,30 @@ def upload_document(uploader, documents_url, service, field, file_contents, publ
     return full_url
 
 
+def upload_service_documents(uploader, documents_url, service, request_files, section):
+    files = {field: request_files[field] for field in section.get_question_ids(type="upload")
+             if field in request_files}
+    files = filter_empty_files(files)
+    errors = validate_documents(files)
+
+    if errors:
+        return None, errors
+
+    if len(files) == 0:
+        return {}, {}
+
+    for field, contents in files.items():
+        url = upload_document(
+            uploader, documents_url, service, field, contents)
+
+        if not url:
+            errors[field] = 'file_can_be_saved'
+        else:
+            files[field] = url
+
+    return files, errors
+
+
 def file_is_not_empty(file_contents):
     not_empty = len(file_contents.read(1)) > 0
     file_contents.seek(0)

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -383,6 +383,38 @@ class TestContentBuilder(object):
 
 
 class TestContentSection(object):
+    def test_get_question_ids(self):
+        section = ContentSection.create({
+            "id": "first_section",
+            "name": "First section",
+            "questions": [{
+                "id": "q1",
+                "question": "Boolean question",
+                "type": "boolean",
+            }, {
+                "id": "q2",
+                "question": "Text question",
+                "type": "text",
+            }]
+        })
+        assert section.get_question_ids() == ['q1', 'q2']
+
+    def test_get_question_ids_filtered_by_type(self):
+        section = ContentSection.create({
+            "id": "first_section",
+            "name": "First section",
+            "questions": [{
+                "id": "q1",
+                "question": "Boolean question",
+                "type": "boolean",
+            }, {
+                "id": "q2",
+                "question": "Text question",
+                "type": "text",
+            }]
+        })
+        assert section.get_question_ids('boolean') == ['q1']
+
     def test_get_data(self):
         section = ContentSection.create({
             "id": "first_section",


### PR DESCRIPTION
## Remove redundant _get_fields method
This is exactly the same as get_question_ids but without using the same language as the rest of the class.

## Allow question IDs to be filtered by question type
This is useful for doing actions on a questions of a particular type.

## Move upload_documents into dmutils
This was previously implemented in the supplier and admin frontends. This also introduces a couple of tests for it.