### PR TITLE
Add index name to SearchAPIClient init

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '8.4.0'
+__version__ = '8.5.0'
 
 
 def init_app(

--- a/dmutils/apiclient/errors.py
+++ b/dmutils/apiclient/errors.py
@@ -21,6 +21,9 @@ class APIError(Exception):
         except AttributeError:
             return REQUEST_ERROR_STATUS_CODE
 
+    def __str__(self):
+        return "{} (status: {})".format(self.message, self.status_code)
+
 
 class HTTPError(APIError):
     @staticmethod

--- a/dmutils/apiclient/search.py
+++ b/dmutils/apiclient/search.py
@@ -5,13 +5,17 @@ from .errors import HTTPError
 
 
 class SearchAPIClient(BaseAPIClient):
+    def __init__(self, *args, **kwargs):
+        self.index_name = kwargs.pop('index_name', 'g-cloud')
+        super(SearchAPIClient, self).__init__(*args, **kwargs)
+
     def init_app(self, app):
         self.base_url = app.config['DM_SEARCH_API_URL']
         self.auth_token = app.config['DM_SEARCH_API_AUTH_TOKEN']
         self.enabled = app.config['ES_ENABLED']
 
     def _url(self, path):
-        return u"/g-cloud/services{}".format(path)
+        return u"/{}/services{}".format(self.index_name, path)
 
     def index(self, service_id, service):
         url = self._url(u"/{}".format(service_id))

--- a/dmutils/apiclient/search.py
+++ b/dmutils/apiclient/search.py
@@ -17,6 +17,18 @@ class SearchAPIClient(BaseAPIClient):
     def _url(self, path):
         return u"/{}/services{}".format(self.index_name, path)
 
+    def create_index(self, index_name):
+        return self._put(
+            '/{}'.format(index_name),
+            data={'type': 'index'}
+        )
+
+    def set_alias(self, alias_name, target_index):
+        return self._put(
+            '/{}'.format(alias_name),
+            data={'type': 'alias', 'target': target_index}
+        )
+
     def index(self, service_id, service):
         url = self._url(u"/{}".format(service_id))
         return self._put(url, data={'service': service})

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -197,16 +197,45 @@ class TestSearchApiClient(object):
         assert rmock.called
         assert result == {'message': 'acknowledged'}
 
-    def test_get_status(self, data_client, rmock):
+    def test_get_status(self, search_client, rmock):
         rmock.get(
             "http://baseurl/_status",
             json={"status": "ok"},
             status_code=200)
 
-        result = data_client.get_status()
+        result = search_client.get_status()
 
         assert result['status'] == "ok"
         assert rmock.called
+
+    def test_create_index(self, search_client, rmock):
+        rmock.put(
+            "http://baseurl/new-index",
+            json={"status": "ok"},
+            status_code=200)
+
+        result = search_client.create_index('new-index')
+
+        assert rmock.called
+        assert result['status'] == "ok"
+        assert rmock.last_request.json() == {
+            "type": "index"
+        }
+
+    def test_set_alias(self, search_client, rmock):
+        rmock.put(
+            "http://baseurl/new-alias",
+            json={"status": "ok"},
+            status_code=200)
+
+        result = search_client.set_alias('new-alias', 'target')
+
+        assert rmock.called
+        assert result['status'] == "ok"
+        assert rmock.last_request.json() == {
+            "type": "alias",
+            "target": 'target'
+        }
 
     def test_post_to_index_with_type_and_service_id(
             self, search_client, rmock, service):

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -182,6 +182,21 @@ class TestSearchApiClient(object):
         assert search_client.auth_token == "example-token"
         assert not search_client.enabled
 
+    def test_client_with_index_name(self, rmock, service):
+        client = SearchAPIClient(
+            'http://baseurl', 'auth-token', True,
+            index_name='not-g-cloud'
+        )
+
+        rmock.put(
+            'http://baseurl/not-g-cloud/services/12345',
+            json={'message': 'acknowledged'},
+            status_code=200)
+
+        result = client.index("12345", service)
+        assert rmock.called
+        assert result == {'message': 'acknowledged'}
+
     def test_get_status(self, data_client, rmock):
         rmock.get(
             "http://baseurl/_status",


### PR DESCRIPTION
Allows creating SearchAPIClient instance for a given index.

#### Add SearchAPIClient index creation methods
Adds methods for index and alias creation.

#### Set __str__ on APIError instances
Fixes the empty error output in Python shell and logged tracebacks.