### PR TITLE
Allow service document uploads to be private

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '8.3.0'
+__version__ = '8.4.0'
 
 
 def init_app(

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -86,7 +86,7 @@ def upload_document(uploader, documents_url, service, field, file_contents, publ
     return full_url
 
 
-def upload_service_documents(uploader, documents_url, service, request_files, section):
+def upload_service_documents(uploader, documents_url, service, request_files, section, public=True):
     files = {field: request_files[field] for field in section.get_question_ids(type="upload")
              if field in request_files}
     files = filter_empty_files(files)
@@ -100,7 +100,8 @@ def upload_service_documents(uploader, documents_url, service, request_files, se
 
     for field, contents in files.items():
         url = upload_document(
-            uploader, documents_url, service, field, contents)
+            uploader, documents_url, service, field, contents,
+            public=public)
 
         if not url:
             errors[field] = 'file_can_be_saved'

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -183,9 +183,28 @@ class TestUploadServiceDocuments(object):
     def test_upload_service_documents(self):
         request_files = {'pricingDocumentURL': mock_file('q1.pdf', 100)}
 
-        files, errors = upload_service_documents(
-            self.uploader, self.documents_url, self.service,
-            request_files, self.section)
+        with freeze_time('2015-10-04 14:36:05'):
+            files, errors = upload_service_documents(
+                self.uploader, self.documents_url, self.service,
+                request_files, self.section)
+
+        self.uploader.save.assert_called_with(
+            'g-cloud-7/12345/654321-pricing-document-2015-10-04-1436.pdf', mock.ANY, acl='public-read')
+
+        assert 'pricingDocumentURL' in files
+        assert len(errors) == 0
+
+    def test_upload_private_service_documents(self):
+        request_files = {'pricingDocumentURL': mock_file('q1.pdf', 100)}
+
+        with freeze_time('2015-10-04 14:36:05'):
+            files, errors = upload_service_documents(
+                self.uploader, self.documents_url, self.service,
+                request_files, self.section,
+                public=False)
+
+        self.uploader.save.assert_called_with(
+            'g-cloud-7/12345/654321-pricing-document-2015-10-04-1436.pdf', mock.ANY, acl='private')
 
         assert 'pricingDocumentURL' in files
         assert len(errors) == 0


### PR DESCRIPTION
The supplier frontend needs draft document uploads to be private until the framework goes live. This just passes the `public` down from `upload_service_documents` to the `upload_document` call.