### PR TITLE
[#103325898] Strip whitespace from submitted form values

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '8.4.0'
+__version__ = '8.5.0'
 
 
 def init_app(

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -176,7 +176,7 @@ class ContentSection(object):
         to their type in the section data.
         """
         # strip trailing and leading whitespace from form values
-        form_data = ImmutableMultiDict(_strip_values(form_data.to_dict(flat=False)))
+        form_data = ImmutableMultiDict((k, v.strip()) for k, v in form_data.items(multi=True))
 
         section_data = {}
         for key in set(form_data) & set(self.get_question_ids()):
@@ -410,44 +410,3 @@ def read_yaml(yaml_file):
         return {}
     with open(yaml_file, "r") as file:
         return yaml.load(file)
-
-
-def _strip_values(val):
-    """
-    Recursively strip whitespace values.
-
-    >> { ' key1 ': ' val1 ', 'key2': [' val21 ', ' val22 ' ] }
-    << { ' key1 ': 'val1', 'key2': ['val21', 'val22' ] }
-
-    :param val: a string or simple data structure with values to strip
-    :return: input with stripped value(s)
-    """
-
-    def _strip_str(s):
-        if hasattr(s, 'decode'):
-            s = s.decode('utf-8')
-        if hasattr(s, 'strip'):
-            s = s.strip()
-
-        return s
-
-    def _strip_list(l):
-        return [_strip_values(v) for v in l]
-
-    def _strip_tuple(t):
-        return _strip_list(t)
-
-    def _strip_dict(d):
-        return {k: _strip_values(v) for k, v in d.items()}
-
-    strip_func = {
-        '_strip_str': _strip_str,
-        '_strip_list': _strip_list,
-        '_strip_tuple': _strip_tuple,
-        '_strip_dict': _strip_dict
-    }
-
-    try:
-        return strip_func['_strip_{}'.format(type(val).__name__)](val)
-    except KeyError:
-        return val

--- a/dmutils/forms.py
+++ b/dmutils/forms.py
@@ -1,0 +1,14 @@
+from wtforms import StringField
+
+
+class StripWhitespaceStringField(StringField):
+    def __init__(self, label=None, **kwargs):
+
+        kwargs['filters'] = kwargs.get('filters', []) + [strip_whitespace]
+        super(StringField, self).__init__(label, **kwargs)
+
+
+def strip_whitespace(value):
+    if value is not None and hasattr(value, 'strip'):
+        return value.strip()
+    return value

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ enum34==1.0.4
 mandrill==1.0.57
 monotonic==0.3
 pytz==2015.4
+Flask-WTF==0.12

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -6,7 +6,7 @@ import pytest
 
 import io
 
-from dmutils.content_loader import ContentLoader, ContentSection, ContentBuilder, read_yaml
+from dmutils.content_loader import ContentLoader, ContentSection, ContentBuilder, read_yaml, _strip_values
 
 from sys import version_info
 if version_info.major == 2:
@@ -366,12 +366,22 @@ class TestContentBuilder(object):
                     "question": "Question two",
                     "type": "text",
                 }]
+            },
+            {
+                "id": "third_section",
+                "name": "Third section",
+                "questions": [{
+                    "id": "q3",
+                    "question": "Question three",
+                    "type": "text",
+                }]
             }
         ])
 
         form = ImmutableMultiDict([
             ('q1', 'some text'),
             ('q2', 'other text'),
+            ('q3', '  lots of      whitespace     \t\n'),
         ])
 
         data = content.get_all_data(form)
@@ -379,6 +389,7 @@ class TestContentBuilder(object):
         assert data == {
             'q1': 'some text',
             'q2': 'other text',
+            'q3': 'lots of      whitespace',
         }
 
 
@@ -872,3 +883,67 @@ class TestContentLoader(object):
         builder2 = yaml_loader.get_builder()
 
         assert builder1 != builder2
+
+
+class TestStripWhiteSpace(object):
+
+    class Paul(object):
+        def __init__(self):
+            self.name = ' Paul '
+
+    def test_strip_string(self):
+        assert _strip_values(' test\t ') == 'test'
+
+    def test_strip_list(self):
+        assert _strip_values([' test\n ', ' me ']) == ['test', 'me']
+
+    def test_strip_tuple(self):
+        assert _strip_values((' test ', ' me ')) == ['test', 'me']
+
+    def test_strip_dict(self):
+        assert _strip_values({' test ': ' me '}) == {' test ': 'me'}
+
+    def test_strip_object(self):
+        paul = self.Paul()
+        assert _strip_values(paul) == paul
+
+    def test_strip_int(self):
+        assert _strip_values(1) == 1
+
+    def test_strip_multi_dict(self):
+        val = {
+            'fruits ': [
+                ' banana ',
+                'apricot    ',
+                # em space after gala
+                {'apples ': [' spartan', 'gala ', '  honeycrisp ']},
+                # non-breaking space after 'pear'
+                ' pear ',
+                ' goji berry  '
+                ],
+            'teams ': [
+                (' hockey', ' Maple Leafs '),
+                (' basketball ', ' Raptors '),
+                (' baseball ', ' Blue Jays '),
+            ],
+            'numbers': [1, '  2 ', 3.4, ' 5.55 '],
+            'empty': [{}, [], '', 0, None, False]
+        }
+        stripped_val = {
+            'fruits ': [
+                'banana',
+                'apricot',
+                {'apples ': ['spartan', 'gala', 'honeycrisp']},
+                'pear',
+                'goji berry'
+                ],
+            'teams ': [
+                ['hockey', 'Maple Leafs'],
+                ['basketball', 'Raptors'],
+                ['baseball', 'Blue Jays'],
+            ],
+            'numbers': [1, '2', 3.4, '5.55'],
+            'empty': [{}, [], '', 0, None, False]
+        }
+
+        assert _strip_values(val) == stripped_val

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -6,7 +6,7 @@ import pytest
 
 import io
 
-from dmutils.content_loader import ContentLoader, ContentSection, ContentBuilder, read_yaml, _strip_values
+from dmutils.content_loader import ContentLoader, ContentSection, ContentBuilder, read_yaml
 
 from sys import version_info
 if version_info.major == 2:
@@ -883,67 +883,3 @@ class TestContentLoader(object):
         builder2 = yaml_loader.get_builder()
 
         assert builder1 != builder2
-
-
-class TestStripWhiteSpace(object):
-
-    class Paul(object):
-        def __init__(self):
-            self.name = ' Paul '
-
-    def test_strip_string(self):
-        assert _strip_values(' test\t ') == 'test'
-
-    def test_strip_list(self):
-        assert _strip_values([' test\n ', ' me ']) == ['test', 'me']
-
-    def test_strip_tuple(self):
-        assert _strip_values((' test ', ' me ')) == ['test', 'me']
-
-    def test_strip_dict(self):
-        assert _strip_values({' test ': ' me '}) == {' test ': 'me'}
-
-    def test_strip_object(self):
-        paul = self.Paul()
-        assert _strip_values(paul) == paul
-
-    def test_strip_int(self):
-        assert _strip_values(1) == 1
-
-    def test_strip_multi_dict(self):
-        val = {
-            'fruits ': [
-                ' banana ',
-                'apricot    ',
-                # em space after gala
-                {'apples ': [' spartan', 'gala ', '  honeycrisp ']},
-                # non-breaking space after 'pear'
-                ' pear ',
-                ' goji berry  '
-                ],
-            'teams ': [
-                (' hockey', ' Maple Leafs '),
-                (' basketball ', ' Raptors '),
-                (' baseball ', ' Blue Jays '),
-            ],
-            'numbers': [1, '  2 ', 3.4, ' 5.55 '],
-            'empty': [{}, [], '', 0, None, False]
-        }
-        stripped_val = {
-            'fruits ': [
-                'banana',
-                'apricot',
-                {'apples ': ['spartan', 'gala', 'honeycrisp']},
-                'pear',
-                'goji berry'
-                ],
-            'teams ': [
-                ['hockey', 'Maple Leafs'],
-                ['basketball', 'Raptors'],
-                ['baseball', 'Blue Jays'],
-            ],
-            'numbers': [1, '2', 3.4, '5.55'],
-            'empty': [{}, [], '', 0, None, False]
-        }
-
-        assert _strip_values(val) == stripped_val


### PR DESCRIPTION
This pull request adds a whitespace-stripping WTF Field that we can use instead of a string field, and it strips surrounding whitespace from input submitted through our content-built forms.

[>> Story in Pivotal](https://www.pivotaltracker.com/story/show/103325898)

***

### Content Builder Data

[`ImmutableMultiDict`](http://werkzeug.pocoo.org/docs/0.10/datastructures/#werkzeug.datastructures.ImmutableMultiDict)s can be converted into a regular dict (with duplicate keys), as well as created from them.
So I've written a leading/trailing whitespace-stripping function to recursively `strip()` all values of a `dict`, ( or `list` or `tuple`, or `str`).  Not sure if this is the best solution, but it looks cool.

It addresses the problem of suppliers in their declaration copy+pasting emails with surrounding whitespace that then fail to validate with an unhelpful error message, [as pointed out](https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/297#issuecomment-144679574) by @quis.

### WTF Field

<sub>Most of the explanation I've just cribbed from my other open pull request [in the supplier app](https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/297#issuecomment-144679574).</sub>

I've subclassed the WTF `StringField` class with one that preprocesses all user-inputted values.  Specifically, all submitted values will be stripped of leading and trailing whitespace.

What happens if I'm trying to login with my valid email and password:

Submitted values | Processed values | Result
------------ | ------------ | -------------
`'email@email.com'`, `'password'` | `'email@email.com'`, `'password'` | :white_check_mark:
`' email@email.com '`, `'password'` | `'email@email.com'`, `'password'` | :white_check_mark:
`'email@email.com'`, `' password '` | `'email@email.com'`, `' password '` | :x:
`' email@email.com '`, `' password '` | `'email@email.com'`, `' password '` | :x:
