### PR TITLE
Rename selection answers to supplier declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Digital marketplace utils changelog
+
+Records breaking changes from major version bumps
+
+## 9.0.0
+
+PR: [#178](https://github.com/alphagov/digitalmarketplace-utils/pull/178)
+
+#### What changed
+
+1. `dmutils.apiclient.DataAPIClient.get_selection_answers` was renamed to `dmutils.apiclient.DataAPIClient.get_supplier_declaration`
+2. `dmutils.apiclient.DataAPIClient.answer_selection_questions` was renamed to `dmutils.apiclient.DataAPIClient.set_supplier_declaration`
+3. The response format for `get_supplier_declaration` is different from that of `get_selection_answers`:
+   `{"selectionAnswers": {"questionAnswers": { ... }}}` was replaced with `{"declaration": { ... }}`
+
+#### Example app change
+
+Old
+```python
+answers = data_api_client.get_selection_answers(
+   current_user.supplier_id, 'g-cloud-7'
+)['selectionAnswers']['questionAnswers']
+```
+
+New
+```python
+declaration = data_api_client.get_supplier_declaration(
+  current_user.supplier_id, 'g-cloud-7'
+)['declaration']
+```

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '8.7.0'
+__version__ = '9.0.0'
 
 
 def init_app(

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -132,22 +132,19 @@ class DataAPIClient(BaseAPIClient):
             },
         )
 
-    def get_selection_answers(self, supplier_id, framework_slug):
+    def get_supplier_declaration(self, supplier_id, framework_slug):
         return self._get(
-            "/suppliers/{}/selection-answers/{}".format(
-                supplier_id, framework_slug))
+            "/suppliers/{}/frameworks/{}/declaration".format(supplier_id, framework_slug)
+        )
 
-    def answer_selection_questions(self, supplier_id, framework_slug,
-                                   answers, user):
+    def set_supplier_declaration(self, supplier_id, framework_slug, declaration, user):
         return self._put(
-            "/suppliers/{}/selection-answers/{}".format(
-                supplier_id, framework_slug),
+            "/suppliers/{}/frameworks/{}/declaration".format(supplier_id, framework_slug),
             data={
                 "updated_by": user,
-                "selectionAnswers": {
-                    "questionAnswers": answers
-                }
-            })
+                "declaration": declaration
+            }
+        )
 
     # Users
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -931,6 +931,31 @@ class TestDataApiClient(object):
             'contactInformation': {'foo': 'bar'}, 'updated_by': 'supplier'
         }
 
+    def test_get_supplier_declaration(self, data_client, rmock):
+        rmock.get(
+            "http://baseurl/suppliers/123/frameworks/g-cloud-7/declaration",
+            json={"declaration": {"question": "answer"}},
+            status_code=200)
+
+        result = data_client.get_supplier_declaration(123, 'g-cloud-7')
+
+        assert result == {'declaration': {'question': 'answer'}}
+        assert rmock.called
+
+    def test_set_supplier_declaration(self, data_client, rmock):
+        rmock.put(
+            "http://baseurl/suppliers/123/frameworks/g-cloud-7/declaration",
+            json={"declaration": {"question": "answer"}},
+            status_code=200)
+
+        result = data_client.set_supplier_declaration(123, 'g-cloud-7', {"question": "answer"}, "user")
+
+        assert result == {'declaration': {'question': 'answer'}}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'updated_by': 'user',
+            'declaration': {'question': 'answer'}}
+
     def test_find_draft_services(self, data_client, rmock):
         rmock.get(
             "http://baseurl/draft-services?supplier_id=2",


### PR DESCRIPTION
The language we have settled on for this is supplier declaration. This reflects the changes in alphagov/digitalmarketplace-api#262

## Depends on
- [x] alphagov/digitalmarketplace-api#262