### PR TITLE
Add user has_any_role method

### DIFF
--- a/dmutils/user.py
+++ b/dmutils/user.py
@@ -32,6 +32,9 @@ class User():
     def has_role(self, role):
         return self.role == role
 
+    def has_any_role(self, *roles):
+        return any(self.has_role(role) for role in roles)
+
     def get_id(self):
         try:
             return unicode(self.id)  # python 2

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -87,6 +87,13 @@ def test_User_has_role(user_json):
     assert not user.has_role('admin')
 
 
+def test_User_has_any_role(user_json):
+    user = User.from_json(user_json)
+    assert user.has_any_role('supplier', 'other')
+    assert user.has_any_role('other', 'supplier')
+    assert not user.has_any_role('other', 'admin')
+
+
 def test_User_load_user(user_json):
     data_api_client = mock.Mock()
     data_api_client.get_user.return_value = user_json


### PR DESCRIPTION
Add a method to check if a user has any one of a list of roles.
This is particularly useful in the admin app where sections are available to multiple user roles.