### PR TITLE
Convert config ints to ints

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '8.6.0'
+__version__ = '8.7.0'
 
 
 def init_app(

--- a/dmutils/config.py
+++ b/dmutils/config.py
@@ -6,9 +6,21 @@ from flask._compat import string_types
 def init_app(app):
     for key, value in app.config.items():
         if key in os.environ:
-            app.config[key] = convert_to_boolean(os.environ[key])
+            if isinstance(value, bool):
+                app.config[key] = _convert_to_boolean_or_fail(key, os.environ[key])
+            elif isinstance(value, int):
+                app.config[key] = _convert_to_int_or_fail(key, os.environ[key])
+            else:
+                app.config[key] = os.environ[key]
     app.config['DM_ENVIRONMENT'] = os.environ.get('DM_ENVIRONMENT',
                                                   'development')
+
+
+def _convert_to_boolean_or_fail(key, value):
+    result = convert_to_boolean(value)
+    if not isinstance(result, bool):
+        raise ValueError("{} must be boolean".format(key))
+    return result
 
 
 def convert_to_boolean(value):
@@ -33,6 +45,13 @@ def convert_to_boolean(value):
             return False
 
     return value
+
+
+def _convert_to_int_or_fail(key, value):
+    result = convert_to_number(value)
+    if not isinstance(result, int):
+        raise ValueError("{} must be an integer".format(key))
+    return result
 
 
 def convert_to_number(value):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,4 @@
+import pytest
 from dmutils.config import init_app
 
 
@@ -28,3 +29,31 @@ def test_init_app_converts_truthy_to_bool(app, os_environ):
         init_app(app)
 
         assert app.config['MY_SETTING'] is False
+
+
+def test_init_app_fails_if_boolean_field_is_not_truthy(app, os_environ):
+    with app.app_context():
+        app.config['MY_SETTING'] = True
+        os_environ.update({'MY_SETTING': 'not truthy'})
+
+        with pytest.raises(ValueError):
+            init_app(app)
+
+
+def test_init_app_converts_inty_to_integers(app, os_environ):
+    with app.app_context():
+        app.config['MY_SETTING'] = 123
+        os_environ.update({'MY_SETTING': "312"})
+
+        init_app(app)
+
+        assert app.config['MY_SETTING'] == 312
+
+
+def test_init_app_fails_if_integer_field_is_not_inty(app, os_environ):
+    with app.app_context():
+        app.config['MY_SETTING'] = 123
+        os_environ.update({'MY_SETTING': 'not-numeric'})
+
+        with pytest.raises(ValueError):
+            init_app(app)


### PR DESCRIPTION
When a configuration option is defined as an integer it should be converted to an integer when passed in from the environment. If an invalid value is passed on the environment then it should fail.

This change also makes boolean configuration options fail if passed a non-truthy value on the environment.