### PR TITLE
More logging fixes

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '8.5.0'
+__version__ = '8.6.0'
 
 
 def init_app(

--- a/dmutils/apiclient/base.py
+++ b/dmutils/apiclient/base.py
@@ -67,7 +67,11 @@ class BaseAPIClient(object):
 
         url = urlparse.urljoin(self.base_url, url)
 
-        logger.debug("API request %s %s", method, url)
+        logger.debug("API request {method} {url}",
+                     extra={
+                        'method': method,
+                        'url': url
+                     })
         headers = {
             "Content-type": "application/json",
             "Authorization": "Bearer {}".format(self.auth_token),

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -222,12 +222,8 @@ class DataAPIClient(BaseAPIClient):
                     }
                 }
             )
-
-            logger.info("Updated password for user %s", user_id)
             return True
         except HTTPError as e:
-            logger.info("Password update failed for user %s: %s",
-                        user_id, e.status_code)
             return False
 
     def update_user(self,
@@ -270,7 +266,8 @@ class DataAPIClient(BaseAPIClient):
             data=params
         )
 
-        logger.info("Updated user %s fields %s", user_id, params)
+        logger.info("Updated user {user_id} fields {params}",
+                    extra={"user_id": user_id, "params": params})
         return user
 
     # Services

--- a/dmutils/deprecation.py
+++ b/dmutils/deprecation.py
@@ -13,12 +13,13 @@ def deprecated(dies_at):
     def decorator(view):
         @wraps(view)
         def func(*args, **kwargs):
-            message = "Calling deprecated view '%s'. Dies in %s."
+            message = "Calling deprecated view '{view_name}'. Dies in {time_left}."
             time_left = dies_at - datetime.utcnow()
+            extra = {'view_name': view.__name__, 'time_left': time_left}
             if time_left < timedelta(days=7):
-                current_app.logger.error(message, view.__name__, time_left)
+                current_app.logger.error(message, extra=extra)
             else:
-                current_app.logger.warning(message, view.__name__, time_left)
+                current_app.logger.warning(message, extra=extra)
             response = view(*args, **kwargs)
             response.headers['DM-Deprecated'] = "Dies in {}".format(time_left)
             return response

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -23,10 +23,12 @@ def init_app(app):
 
     @app.after_request
     def after_request(response):
-        current_app.logger.info('%s %s %s',
-                                request.method,
-                                request.url,
-                                response.status_code)
+        current_app.logger.info('{method} {url} {status}',
+                                extra={
+                                    'method': request.method,
+                                    'url': request.url,
+                                    'status': response.status_code
+                                })
         return response
 
     logging.getLogger().addHandler(logging.NullHandler())


### PR DESCRIPTION
The correct way of logging is now to provide a format string and then the arguments in the `extra` parameter so that they get picked up and added as distinct JSON fields.