### PR TITLE
Support frameworks and manifests in ContentLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,8 @@ declaration_content = ContentLoader(
 New
 ```python
 content_loader = ContentLoader('app/content')
-content_loader.load_manifest('g-cloud-6', 'edit_service', 'services')
-content_loader.load_manifest('g-cloud-7', 'edit_submission', 'services')
+content_loader.load_manifest('g-cloud-6', 'services', 'edit_service')
+content_loader.load_manifest('g-cloud-7', 'services', 'edit_submission')
 content_loader.load_manifest('g-cloud-7', 'declaration', 'declaration')
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 Records breaking changes from major version bumps
 
+## 10.0.0
+
+PR: [#182](https://github.com/alphagov/digitalmarketplace-utils/pull/182)
+
+### What changed
+
+1. `dmutils.content_loader.ContentLoader` changed to support loading content from multiple frameworks.
+
+### Example app change
+
+#### At application startup
+
+Old
+```python
+existing_service_content = ContentLoader(
+    'app/content/frameworks/g-cloud-6/manifests/edit_service.yml',
+    'app/content/frameworks/g-cloud-6/questions/services/'
+)
+new_service_content = ContentLoader(
+    'app/content/frameworks/g-cloud-7/manifests/edit_submission.yml',
+    'app/content/frameworks/g-cloud-7/questions/services/'
+)
+declaration_content = ContentLoader(
+    'app/content/frameworks/g-cloud-7/manifests/declaration.yml',
+    'app/content/frameworks/g-cloud-7/questions/declaration/'
+)
+```
+
+New
+```python
+content_loader = ContentLoader('app/content')
+content_loader.load_manifest('g-cloud-6', 'edit_service', 'services')
+content_loader.load_manifest('g-cloud-7', 'edit_submission', 'services')
+content_loader.load_manifest('g-cloud-7', 'declaration', 'declaration')
+```
+
+#### In the views
+
+Old
+```python
+content = declaration_content.get_builder()
+```
+
+New
+```python
+content = content_loader.get_builder(framework_slug, 'declaration')
+```
+
 ## 9.0.0
 
 PR: [#178](https://github.com/alphagov/digitalmarketplace-utils/pull/178)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '9.1.0'
+__version__ = '10.0.0'
 
 
 def init_app(

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -370,6 +370,8 @@ class ContentLoader(object):
 
     def get_builder(self, framework_slug, manifest):
         try:
+            if framework_slug not in self._content:
+                raise KeyError
             return ContentBuilder(self._content[framework_slug][manifest])
         except KeyError:
             raise ContentNotFoundError("Content not found for {} and {}".format(framework_slug, manifest))
@@ -388,8 +390,16 @@ class ContentLoader(object):
 
         return self._content[framework_slug][manifest]
 
+    def _has_question(self, framework_slug, question_set, question):
+        if framework_slug not in self._questions:
+            return False
+        if question_set not in self._questions[framework_slug]:
+            return False
+
+        return question in self._questions[framework_slug][question_set]
+
     def get_question(self, framework_slug, question_set, question):
-        if question not in self._questions[framework_slug][question_set]:
+        if not self._has_question(framework_slug, question_set, question):
             try:
                 questions_path = self._questions_path(framework_slug, question_set)
                 self._questions[framework_slug][question_set][question] = _load_question(question, questions_path)

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -376,7 +376,7 @@ class ContentLoader(object):
         except KeyError:
             raise ContentNotFoundError("Content not found for {} and {}".format(framework_slug, manifest))
 
-    def load_manifest(self, framework_slug, manifest, question_set):
+    def load_manifest(self, framework_slug, question_set, manifest):
         if manifest not in self._content[framework_slug]:
             try:
                 manifest_path = self._manifest_path(framework_slug, manifest)

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -829,7 +829,7 @@ class TestContentLoader(object):
 
         yaml_loader = ContentLoader('content/')
 
-        sections = yaml_loader.load_manifest('framework-slug', 'my-manifest', 'question-set')
+        sections = yaml_loader.load_manifest('framework-slug', 'question-set', 'my-manifest')
 
         assert sections == [
             {'name': 'section1',
@@ -852,7 +852,7 @@ class TestContentLoader(object):
         yaml_loader = ContentLoader('content/')
 
         with pytest.raises(ContentNotFoundError):
-            yaml_loader.load_manifest('framework-slug', 'my-manifest', 'question-set')
+            yaml_loader.load_manifest('framework-slug', 'question-set', 'my-manifest')
 
     def test_manifest_loading_fails_if_question_cannot_be_read(self, read_yaml_mock):
         read_yaml_mock.side_effect = [
@@ -863,7 +863,7 @@ class TestContentLoader(object):
         yaml_loader = ContentLoader('content')
 
         with pytest.raises(ContentNotFoundError):
-            yaml_loader.load_manifest('framework-slug', 'my-manifest', 'question-set')
+            yaml_loader.load_manifest('framework-slug', 'question-set', 'my-manifest')
 
     def test_get_question(self, read_yaml_mock):
         read_yaml_mock.return_value = self.question1()
@@ -928,7 +928,7 @@ class TestContentLoader(object):
         self.set_read_yaml_mock_response(read_yaml_mock)
 
         yaml_loader = ContentLoader('content/')
-        yaml_loader.load_manifest('framework-slug', 'manifest', 'question-set')
+        yaml_loader.load_manifest('framework-slug', 'question-set', 'manifest')
 
         builder = yaml_loader.get_builder('framework-slug', 'manifest')
         assert isinstance(builder, ContentBuilder)
@@ -941,7 +941,7 @@ class TestContentLoader(object):
         self.set_read_yaml_mock_response(read_yaml_mock)
 
         yaml_loader = ContentLoader('content/')
-        yaml_loader.load_manifest('framework-slug', 'manifest', 'question-set')
+        yaml_loader.load_manifest('framework-slug', 'question-set', 'manifest')
 
         builder1 = yaml_loader.get_builder('framework-slug', 'manifest')
         builder2 = yaml_loader.get_builder('framework-slug', 'manifest')


### PR DESCRIPTION
As we move to handling multiple frameworks the `ContentLoader` needs to be able to support this. This commit changes the `ContentLoader`'s role so that it is responsible for managing multiple manifests across multiple frameworks. Rather than creating multiple `ContentLoader` instances we create one, pointing it at the root content directory (`digitalmarketplace-frameworks`). On application startup we load the manifests we need and then get builders by framework slug and manifest name. If a manifest is not found either when loading or when getting a buidler we error with a `ContentNotFound` error and should fail fast.

Note that this changes `read_yaml` so that it raises an error if the file is not found. `read_yaml` only seems to be used by the content loader so this should not cause errors.
### Example app change

#### At application startup

Old
```python
existing_service_content = ContentLoader(
    'app/content/frameworks/g-cloud-6/manifests/edit_service.yml',
    'app/content/frameworks/g-cloud-6/questions/services/'
)
new_service_content = ContentLoader(
    'app/content/frameworks/g-cloud-7/manifests/edit_submission.yml',
    'app/content/frameworks/g-cloud-7/questions/services/'
)
declaration_content = ContentLoader(
    'app/content/frameworks/g-cloud-7/manifests/declaration.yml',
    'app/content/frameworks/g-cloud-7/questions/declaration/'
)
```

New
```python
content_loader = ContentLoader('app/content')
content_loader.load_manifest('g-cloud-6', 'edit_service', 'services')
content_loader.load_manifest('g-cloud-7', 'edit_submission', 'services')
content_loader.load_manifest('g-cloud-7', 'declaration', 'declaration')
```

#### In the views

Old
```python
content = declaration_content.get_builder()
```

New
```python
content = content_loader.get_builder(framework_slug, 'declaration')
```