### PR TITLE
Framework and status params in find_services

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '10.1.0'
+__version__ = '10.2.0'
 
 
 def init_app(

--- a/dmutils/apiclient/base.py
+++ b/dmutils/apiclient/base.py
@@ -88,7 +88,8 @@ class BaseAPIClient(object):
         except requests.RequestException as e:
             api_error = HTTPError.create(e)
             elapsed_time = monotonic() - start_time
-            logger.warning(
+            logger.log(
+                logging.INFO if api_error.status_code == 404 else logging.WARNING,
                 "API {api_method} request on {api_url} failed with {api_status} '{api_error}'",
                 extra={
                     'api_method': method,

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -372,12 +372,13 @@ class DataAPIClient(BaseAPIClient):
                 raise
         return None
 
-    def find_services(self, supplier_id=None, page=None):
-        params = {}
-        if supplier_id is not None:
-            params['supplier_id'] = supplier_id
-        if page is not None:
-            params['page'] = page
+    def find_services(self, supplier_id=None, framework=None, status=None, page=None):
+        params = {
+            'supplier_id': supplier_id,
+            'framework': framework,
+            'status': status,
+            'page': page,
+        }
 
         return self._get("/services", params=params)
 


### PR DESCRIPTION
#### Add framework and status parameters to apiclient .find_services
Adds support for the framework and status parameters from
alphagov/digitalmarketplace-api#266

`framework` and `status` should contain comma-separated strings of
values, but similar to OR filters in search API the formatting is
left to the caller of the method.

#### Log apiclient 404 responses with INFO level
Data and search APIs return 404 for a lot of common requests:

* Requesting a missing service ID by user request
* Removing a service that was never published from the search index

Logging them as INFO to make more important log messages more visible
and reduce the logging output of scripts.