### PR TITLE
Add question numbers automatically

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '10.0.1'
+__version__ = '10.1.0'
 
 
 def init_app(

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -111,6 +111,14 @@ class ContentBuilder(object):
             if question:
                 return question
 
+    def get_question_number(self, question_id):
+        index = 0
+        for section in self.sections:
+            for question in section.questions:
+                index += 1
+                if question['id'] == question_id:
+                    return index
+
 
 class ContentSection(object):
     @classmethod

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -22,6 +22,9 @@ class ContentBuilder(object):
     """
     def __init__(self, sections):
         self.sections = [ContentSection.create(section) for section in sections]
+        for section in self.sections:
+            for question in section.questions:
+                self._add_question_number(question)
 
     def __iter__(self):
         return self.sections.__iter__()
@@ -83,7 +86,7 @@ class ContentBuilder(object):
         section = section.copy()
 
         filtered_questions = [
-            question for question in section.questions
+            self._add_question_number(question) for question in section.questions
             if self._question_should_be_shown(
                 question.get("depends"), service_data
             )
@@ -118,6 +121,11 @@ class ContentBuilder(object):
                 index += 1
                 if question['id'] == question_id:
                     return index
+        return None
+
+    def _add_question_number(self, question):
+        question['number'] = self.get_question_number(question['id'])
+        return question
 
 
 class ContentSection(object):

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -22,9 +22,11 @@ class ContentBuilder(object):
     """
     def __init__(self, sections):
         self.sections = [ContentSection.create(section) for section in sections]
+        question_index = 0
         for section in self.sections:
             for question in section.questions:
-                self._add_question_number(question)
+                question_index += 1
+                question['number'] = question_index
 
     def __iter__(self):
         return self.sections.__iter__()
@@ -86,7 +88,7 @@ class ContentBuilder(object):
         section = section.copy()
 
         filtered_questions = [
-            self._add_question_number(question) for question in section.questions
+            question for question in section.questions
             if self._question_should_be_shown(
                 question.get("depends"), service_data
             )
@@ -113,19 +115,6 @@ class ContentBuilder(object):
             question = section.get_question(question_id)
             if question:
                 return question
-
-    def get_question_number(self, question_id):
-        index = 0
-        for section in self.sections:
-            for question in section.questions:
-                index += 1
-                if question['id'] == question_id:
-                    return index
-        return None
-
-    def _add_question_number(self, question):
-        question['number'] = self.get_question_number(question['id'])
-        return question
 
 
 class ContentSection(object):

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -423,45 +423,9 @@ class TestContentBuilder(object):
             }
         ])
 
-        assert content.get_question_number("q1") == 1
-        assert content.get_question_number("q2") == 2
-        assert content.get_question_number("q3") == 3
-        assert content.get_question_number("qX") == None
-
-    def test_questions_get_numbers(self):
-        content = ContentBuilder([
-            {
-                "id": "first_section",
-                "name": "First section",
-                "questions": [
-                    {
-                        "id": "q1",
-                        "question": "Question one",
-                        "type": "text",
-                    },
-                    {
-                        "id": "q2",
-                        "question": "Question one",
-                        "type": "text",
-                    }
-                ]
-            },
-            {
-                "id": "second_section",
-                "name": "Second section",
-                "questions": [
-                    {
-                        "id": "q3",
-                        "question": "Question three",
-                        "type": "text",
-                    }
-                ]
-            }
-        ])
-
-        assert content.sections[0].questions[0]['number'] == 1
-        assert content.sections[0].questions[1]['number'] == 2
-        assert content.sections[1].questions[0]['number'] == 3
+        assert content.get_question("q1")['number'] == 1
+        assert content.get_question("q2")['number'] == 2
+        assert content.get_question("q3")['number'] == 3
 
     def test_question_numbers_respect_filtering(self):
         content = ContentBuilder([
@@ -501,10 +465,8 @@ class TestContentBuilder(object):
             }
         ]).filter({"lot": "SCS"})
 
-        assert content.get_question_number('q1') == None
-        assert content.get_question_number('q2') == 1
-
         assert content.sections[0].questions[0]['id'] == 'q2'
+        assert content.get_question('q2')['number'] == 1
         assert content.sections[0].questions[0]['number'] == 1
 
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -428,6 +428,85 @@ class TestContentBuilder(object):
         assert content.get_question_number("q3") == 3
         assert content.get_question_number("qX") == None
 
+    def test_questions_get_numbers(self):
+        content = ContentBuilder([
+            {
+                "id": "first_section",
+                "name": "First section",
+                "questions": [
+                    {
+                        "id": "q1",
+                        "question": "Question one",
+                        "type": "text",
+                    },
+                    {
+                        "id": "q2",
+                        "question": "Question one",
+                        "type": "text",
+                    }
+                ]
+            },
+            {
+                "id": "second_section",
+                "name": "Second section",
+                "questions": [
+                    {
+                        "id": "q3",
+                        "question": "Question three",
+                        "type": "text",
+                    }
+                ]
+            }
+        ])
+
+        assert content.sections[0].questions[0]['number'] == 1
+        assert content.sections[0].questions[1]['number'] == 2
+        assert content.sections[1].questions[0]['number'] == 3
+
+    def test_question_numbers_respect_filtering(self):
+        content = ContentBuilder([
+            {
+                "id": "first_section",
+                "name": "First section",
+                "questions": [{
+                    "id": "q1",
+                    "question": 'First question',
+                    "depends": [{
+                        "on": "lot",
+                        "being": ["SaaS"]
+                    }]
+                }]
+            },
+            {
+                "id": "second_section",
+                "name": "Second section",
+                "questions": [
+                    {
+                        "id": "q2",
+                        "question": 'Second question',
+                        "depends": [{
+                            "on": "lot",
+                            "being": ["SCS"]
+                        }]
+                    },
+                    {
+                        "id": "q3",
+                        "question": 'Third question',
+                        "depends": [{
+                            "on": "lot",
+                            "being": ["SCS"]
+                        }]
+                    },
+                ]
+            }
+        ]).filter({"lot": "SCS"})
+
+        assert content.get_question_number('q1') == None
+        assert content.get_question_number('q2') == 1
+
+        assert content.sections[0].questions[0]['id'] == 'q2'
+        assert content.sections[0].questions[0]['number'] == 1
+
 
 class TestContentSection(object):
     def test_get_question_ids(self):

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -392,6 +392,42 @@ class TestContentBuilder(object):
             'q3': 'lots of      whitespace',
         }
 
+    def test_question_numbering(self):
+        content = ContentBuilder([
+            {
+                "id": "first_section",
+                "name": "First section",
+                "questions": [
+                    {
+                        "id": "q1",
+                        "question": "Question one",
+                        "type": "text",
+                    },
+                    {
+                        "id": "q2",
+                        "question": "Question one",
+                        "type": "text",
+                    }
+                ]
+            },
+            {
+                "id": "second_section",
+                "name": "Second section",
+                "questions": [
+                    {
+                        "id": "q3",
+                        "question": "Question three",
+                        "type": "text",
+                    }
+                ]
+            }
+        ])
+
+        assert content.get_question_number("q1") == 1
+        assert content.get_question_number("q2") == 2
+        assert content.get_question_number("q3") == 3
+        assert content.get_question_number("qX") == None
+
 
 class TestContentSection(object):
     def test_get_question_ids(self):


### PR DESCRIPTION
## Add question numbering method to content builder

This will be useful for:
- numbering the questions in the declaration, rather than doing it in Jinja
- looking up a question's number when it's referred to from another question, eg "if you answered 'no' to question 23…"

## Add question number as a property of each question

This extends the above to be more immediately useful, eg in a template:

``` Jinja
<label>
  {{question.number}}. {{question.question}}
</label>
```

It preserves the numbering after any filtering.