### PR TITLE
Allow each content section to have a description

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import flask_featureflags
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 
-__version__ = '10.1.0'
+__version__ = '10.2.0'
 
 
 def init_app(

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -127,13 +127,15 @@ class ContentSection(object):
                 id=section['id'],
                 name=section['name'],
                 editable=section.get('editable'),
-                questions=section['questions'])
+                questions=section['questions'],
+                description=section.get('description'))
 
-    def __init__(self, id, name, editable, questions):
+    def __init__(self, id, name, editable, questions, description=None):
         self.id = id
         self.name = name
         self.editable = editable
         self.questions = questions
+        self.description = description
 
     def __getitem__(self, key):
         return getattr(self, key)
@@ -143,7 +145,8 @@ class ContentSection(object):
             id=self.id,
             name=self.name,
             editable=self.editable,
-            questions=self.questions[:])
+            questions=self.questions[:],
+            description=self.description)
 
     def get_field_names(self):
         """Return a list of field names that this section returns

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -865,6 +865,18 @@ class TestContentSection(object):
         assert result['q3--assurance']['message'] == "There there, it'll be ok."
         assert result['serviceTypeSCS']['message'] == "This is the error message"
 
+    def test_section_description(self):
+        section = ContentSection.create({
+            "id": "first_section",
+            "name": "First section",
+            "questions": [],
+            "description": "This is the first section"
+        })
+        assert section.description == "This is the first section"
+
+        copy_of_section = section.copy()
+        assert copy_of_section.description == "This is the first section"
+
 
 class TestReadYaml(object):
     @mock.patch.object(builtins, 'open', return_value=io.StringIO(u'foo: bar'))


### PR DESCRIPTION
This will be useful for the declaration, where in the guidance each page has an introductory paragraph. Being able to have this in the interface might mean we don't have to publish the documentation.

Suggested usage, `manifest.yml`:
```YAML
-
  name: Grounds for mandatory exclusion
  description: You must be able to answer all of these questions
  questions:
    - …
```