### PR TITLE
Have content loader manage framework messages

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '10.3.0'
+__version__ = '10.4.0'

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1013,6 +1013,69 @@ class TestContentLoader(object):
 
         assert yaml_loader.get_question('framework-slug', 'question-set', 'question1') != q1
 
+    def test_message_key_format(self, mock_read_yaml):
+        messages = ContentLoader('content/')
+
+        assert messages._message_key(
+            'coming', 'submitted'
+        ) == 'coming-submitted'
+
+        assert messages._message_key(
+            'coming', None
+        ) == 'coming'
+
+        # frameworks must have a state
+        with pytest.raises(TypeError):
+            messages._message_key()
+
+    def test_get_message(self, mock_read_yaml):
+
+        mock_read_yaml.return_value = {
+            'coming': {
+                'heading': 'G-Cloud 7 is coming',
+                'message': 'Get ready'
+            }
+        }
+        messages = ContentLoader('content/')
+
+        assert messages.get_message('g-cloud-7', 'index', 'coming') == {
+            'heading': 'G-Cloud 7 is coming',
+            'message': 'Get ready'
+        }
+        mock_read_yaml.assert_called_with('content/frameworks/g-cloud-7/messages/index.yml')
+
+    def test_get_message_with_supplier_status(self, mock_read_yaml):
+
+        mock_read_yaml.return_value = {
+            'open-registered_interest': {
+                'heading': 'G-Cloud 8 is open',
+                'message': 'You have registered interest'
+            }
+        }
+        messages = ContentLoader('content/')
+
+        assert messages.get_message('g-cloud-8', 'index', 'open', 'registered_interest') == {
+            'heading': 'G-Cloud 8 is open',
+            'message': 'You have registered interest'
+        }
+        mock_read_yaml.assert_called_with('content/frameworks/g-cloud-8/messages/index.yml')
+
+    def test_caching_of_messages(self, mock_read_yaml):
+
+        messages = ContentLoader('content/')
+        messages.get_message('g-cloud-7', 'index', 'coming')
+        messages.get_message('g-cloud-7', 'index', 'coming')
+
+        mock_read_yaml.assert_called_once_with('content/frameworks/g-cloud-7/messages/index.yml')
+
+    def test_non_existant_file_raises(self, mock_read_yaml):
+
+        mock_read_yaml.side_effect = IOError
+        messages = ContentLoader('content/')
+
+        with pytest.raises(ContentNotFoundError):
+            messages.get_message('g-cloud-7', 'index', 'not_a_state')
+
     def test_get_builder(self, read_yaml_mock):
         self.set_read_yaml_mock_response(read_yaml_mock)
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1037,12 +1037,34 @@ class TestContentLoader(object):
             }
         }
         messages = ContentLoader('content/')
+        messages.load_messages('g-cloud-7', ['index'])
 
         assert messages.get_message('g-cloud-7', 'index', 'coming') == {
             'heading': 'G-Cloud 7 is coming',
             'message': 'Get ready'
         }
         mock_read_yaml.assert_called_with('content/frameworks/g-cloud-7/messages/index.yml')
+
+    def test_load_message_argument_types(self, mock_read_yaml):
+
+        mock_read_yaml.return_value = {}
+        messages = ContentLoader('content/')
+
+        with pytest.raises(TypeError):
+            messages.load_messages('g-cloud-7', 'index')  # blocks argument must be a list
+
+    def test_get_message_non_existant_state(self, mock_read_yaml):
+
+        mock_read_yaml.return_value = {
+            'coming': {
+                'heading': 'G-Cloud 7 is coming',
+                'message': 'This message won’t be looked for'
+            }
+        }
+        messages = ContentLoader('content/')
+        messages.load_messages('g-cloud-7', ['index'])
+
+        assert messages.get_message('g-cloud-7', 'index', 'open') == None
 
     def test_get_message_with_supplier_status(self, mock_read_yaml):
 
@@ -1053,12 +1075,23 @@ class TestContentLoader(object):
             }
         }
         messages = ContentLoader('content/')
+        messages.load_messages('g-cloud-8', ['index'])
 
         assert messages.get_message('g-cloud-8', 'index', 'open', 'registered_interest') == {
             'heading': 'G-Cloud 8 is open',
             'message': 'You have registered interest'
         }
         mock_read_yaml.assert_called_with('content/frameworks/g-cloud-8/messages/index.yml')
+
+    def test_get_message_must_preload(self, mock_read_yaml):
+
+        mock_read_yaml.return_value = {}
+        messages = ContentLoader('content/')
+        messages.load_messages('g-cloud-8', ['index'])
+
+        with pytest.raises(ContentNotFoundError):
+            messages.get_message('g-cloud-8', 'dashboard', 'open')
+            mock_read_yaml.assert_not_called()
 
     def test_caching_of_messages(self, mock_read_yaml):
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1063,18 +1063,19 @@ class TestContentLoader(object):
     def test_caching_of_messages(self, mock_read_yaml):
 
         messages = ContentLoader('content/')
+        messages.load_messages('g-cloud-7', ['index'])
         messages.get_message('g-cloud-7', 'index', 'coming')
         messages.get_message('g-cloud-7', 'index', 'coming')
 
         mock_read_yaml.assert_called_once_with('content/frameworks/g-cloud-7/messages/index.yml')
 
-    def test_non_existant_file_raises(self, mock_read_yaml):
+    def test_load_message_raises(self, mock_read_yaml):
 
         mock_read_yaml.side_effect = IOError
         messages = ContentLoader('content/')
 
         with pytest.raises(ContentNotFoundError):
-            messages.get_message('g-cloud-7', 'index', 'not_a_state')
+            messages.load_messages('not-a-framework', ['index'])
 
     def test_get_builder(self, read_yaml_mock):
         self.set_read_yaml_mock_response(read_yaml_mock)


### PR DESCRIPTION
This is to let us manage pieces of content which are specific to a combination
of:
- a place on a page
- a framework
- the status of that framework
- the status of a supplier‘s application to a framework

eg, on the supplier dashboard there is a block telling you about your,
declaration which has different content through different stages of the process.
Currently we manage this with lots of {% if %} statements in the templates,
which is:
- hacky
- not scaleable

These pieces of content will be stored in the frameworks repo, in a directory
called 'messages', eg
`./frameworks/g-cloud-7/messages/index.yml`

These file will contain a dictionary of statuses, eg
```
g-cloud-7/messages/index.yml
---
- open-not_interested:
    message: please register interest
- open-registered_interest:
    message: please complete your application
- pending-registered_interest:
    message: you only did the registering interest bit
```

The format of the filename is:
`<block>.yml`