### PR TITLE
Add 'markdown' jinja2 filter. 

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '10.5.0'
+__version__ = '10.6.0'

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -1,0 +1,5 @@
+from markdown import markdown
+
+
+def markdown_filter(text, *args, **kwargs):
+    return markdown(text, *args, **kwargs)

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -1,5 +1,6 @@
 from flask_featureflags.contrib.inline import InlineFeatureFlag
-from . import config, logging, proxy_fix, request_id, formats
+from . import config, logging, proxy_fix, request_id, formats, filters
+from flask import Markup
 
 
 def init_app(
@@ -43,6 +44,10 @@ def init_app(
     def add_header(response):
         response.headers['X-Frame-Options'] = 'DENY'
         return response
+
+    @application.template_filter('markdown')
+    def markdown_filter_flask(data):
+        return Markup(filters.markdown_filter(data))
 
     application.add_template_filter(formats.timeformat)
     application.add_template_filter(formats.shortdateformat)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ mandrill==1.0.57
 monotonic==0.3
 pytz==2015.4
 Flask-WTF==0.12
+markdown==2.6.2

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,24 @@
+from dmutils.filters import markdown_filter
+
+
+def test_markdown_filter_produces_markup():
+
+    markdown_string = """## H2 title
+
+- List item 1
+- List item 2
+
+Paragraph
+**Bold**
+*Emphasis*"""
+
+    html_string = """<h2>H2 title</h2>
+<ul>
+<li>List item 1</li>
+<li>List item 2</li>
+</ul>
+<p>Paragraph
+<strong>Bold</strong>
+<em>Emphasis</em></p>"""
+
+    assert markdown_filter(markdown_string) == html_string


### PR DESCRIPTION
Added a markdown filter converts markdown-formatted (which we [occasionally store in .yml files](https://github.com/alphagov/digitalmarketplace-frameworks/blob/master/frameworks/digital-outcomes-and-specialists/questions/declaration/environmentalSocialLabourLaw.yml)) strings to HTML.

Flask apps which make use of dmutils' `init_app` method will have the `markdown` filter added to their jinja templates.  

Other apps which want access to a `markdown` filter (the frontend toolkit, for example) can manually include it.