### PR TITLE
Add extra files to watch for reloading

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '10.6.0'
+__version__ = '10.7.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ monotonic==0.3
 pytz==2015.4
 Flask-WTF==0.12
 markdown==2.6.2
+Flask-Script==2.0.5


### PR DESCRIPTION
In the same way that changing a .py file causes the app to restart, this gives each app the ability to specify what other files should cause it to restart.

For example:
- when you `npm install` you don't need to restart the app
- you can quickly try out content changes locally and see the changes with just a refresh of the page
- you can modify schemas and search API mappings and see the implications on the APIs straight away

This uses the `init_manager` added in https://github.com/alphagov/digitalmarketplace-utils/commit/27b0756ee734e15d29b41768db7cae998fa84325

So implementing this in an app means changing to use `init_manager` and passing a list of directories to watch, eg

``` Python
from dmutils import init_manager

init_manager(manager, 5003, ['./app/content/frameworks'])
```