### PR TITLE
Have flask.init init the Manager

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '10.7.0'
+__version__ = '11.0.0'

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -2,7 +2,7 @@ import os
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 from . import config, logging, proxy_fix, request_id, formats, filters
 from flask import Markup
-from flask.ext.script import Server
+from flask.ext.script import Manager, Server
 
 
 def init_app(
@@ -66,7 +66,9 @@ def get_extra_files(paths):
                     yield filename
 
 
-def init_manager(manager, port, extra_directories=()):
+def init_manager(application, port, extra_directories=()):
+
+    manager = Manager(application)
 
     extra_files = list(get_extra_files(extra_directories))
 


### PR DESCRIPTION
The code that does this is currently repeated across all apps, and mean that the apps have Flask script as an extra dependency.

This brings the code and the dependency into utils, so the usage will look like:

## Before

``` Python
from flask.ext.script import Manager

manager = Manager(application)
init_manager(manager, 5003, ['./app/content/frameworks'])
```

## After

``` Python
init_manager(application, 5003, ['./app/content/frameworks'])


## Bump version to 11.0.0

Breaking changes because the expected arguments to Flask init have changed.