### PR TITLE
Use new /draft-service POST endpoint for creating drafts

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '11.0.0'
+__version__ = '11.1.0'

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -364,12 +364,13 @@ class DataAPIClient(BaseAPIClient):
 
     def create_new_draft_service(self, framework_slug, supplier_id, user, lot):
         return self._post(
-            "/draft-services/{}/create".format(framework_slug),
+            "/draft-services",
             data={
                 "update_details": {
                     "updated_by": user
                 },
                 "services": {
+                    "frameworkSlug": framework_slug,
                     "supplierId": supplier_id,
                     "lot": lot
                 }

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1143,13 +1143,13 @@ class TestDataApiClient(object):
 
     def test_create_new_draft_service(self, data_client, rmock):
         rmock.post(
-            "http://baseurl/draft-services/g-cloud-7/create",
+            "http://baseurl/draft-services",
             json={"done": "it"},
             status_code=201,
         )
 
         result = data_client.create_new_draft_service(
-            'g-cloud-7', 2, 'user', 'IaaS'
+            'g-cloud-7', 2, 'user', 'iaas'
         )
 
         assert result == {"done": "it"}
@@ -1159,8 +1159,9 @@ class TestDataApiClient(object):
                 'updated_by': 'user'
             },
             'services': {
+                'frameworkSlug': 'g-cloud-7',
                 'supplierId': 2,
-                'lot': 'IaaS'
+                'lot': 'iaas'
             }
         }
 


### PR DESCRIPTION
`/draft-service/<framework-slug>/create` is deprecated in favour of
using /draft-service and passing frameworkSlug in the payload, similar
to lot and supplierId

(https://github.com/alphagov/digitalmarketplace-api/commit/dd2ed8)