### PR TITLE
Add changes to init_manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ PR: [#195](https://github.com/alphagov/digitalmarketplace-utils/pull/195)
 
 ### Example app change
 
-#### In application's `__init__.py`
+#### In application's `application.py`
 
 Old
 ```python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 Records breaking changes from major version bumps
 
+## 11.0.0
+
+PR: [#195](https://github.com/alphagov/digitalmarketplace-utils/pull/195)
+
+### What changed
+
+1. Moved the creation of the `manager` instance into `init_manager`.
+
+### Example app change
+
+#### In application's `__init__.py`
+
+Old
+```python
+from flask.ext.script import Manager
+
+manager = Manager(application)
+init_manager(manager, 5003, ['./app/content/frameworks'])
+```
+
+New
+```python
+from dmutils.flask_init import init_manager
+
+manager = init_manager(application, 5003, ['./app/content/frameworks'])
+```
+
 ## 10.0.0
 
 PR: [#182](https://github.com/alphagov/digitalmarketplace-utils/pull/182)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '11.1.0'
+__version__ = '11.1.1'

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -84,3 +84,5 @@ def init_manager(application, port, extra_directories=()):
         """List URLs of all application routes."""
         for rule in sorted(manager.app.url_map.iter_rules(), key=lambda r: r.rule):
             print("{:10} {}".format(", ".join(rule.methods - set(['OPTIONS', 'HEAD'])), rule.rule))
+
+    return manager


### PR DESCRIPTION
Make `init_manager` return a `Manager` instance and log changes to it in CHANGELOG.md.

As requested in:

https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/315#discussion_r43144869

and

https://github.com/alphagov/digitalmarketplace-utils/pull/195#issuecomment-151555892