### PR TITLE
Add `path_exists` method to S3

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '11.1.2'
+__version__ = '11.2.0'

--- a/dmutils/s3.py
+++ b/dmutils/s3.py
@@ -27,6 +27,9 @@ class S3(object):
         key.set_acl(acl)
         return key
 
+    def path_exists(self, path):
+        return bool(self.bucket.get_key(path))
+
     def get_signed_url(self, path, expires_in=30):
         """Create a signed S3 document URL
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -22,6 +22,18 @@ class TestS3Uploader(unittest.TestCase):
         S3('test-bucket')
         self.s3_mock.get_bucket.assert_called_with('test-bucket')
 
+    def test_path_exists(self):
+        mock_bucket = FakeBucket()
+        self.s3_mock.get_bucket.return_value = mock_bucket
+
+        assert S3('test-bucket').path_exists('foo') is False
+
+    def test_path_exists_nonexistent_path(self):
+        mock_bucket = FakeBucket(['foo'])
+        self.s3_mock.get_bucket.return_value = mock_bucket
+
+        assert S3('test-bucket').path_exists('foo') is True
+
     def test_get_signed_url(self):
         mock_bucket = FakeBucket(['documents/file.pdf'])
         self.s3_mock.get_bucket.return_value = mock_bucket


### PR DESCRIPTION
Add a method that returns true if the provided path exists in the bucket and false otherwise. This is useful in the supplier app for when a link to a file should be shown only if it exists but that link is to a proxy route in the supplier app, eg. agreement documents.