### PR TITLE
Agreements documents

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '11.3.0'
+__version__ = '11.4.0'

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -169,3 +169,7 @@ def get_signed_url(bucket, path, base_url):
             base_url = urlparse.urlparse(base_url)
             url = url._replace(netloc=base_url.netloc, scheme=base_url.scheme).geturl()
         return url
+
+
+def get_agreement_document_path(framework_slug, supplier_id, document_name):
+    return '{0}/agreements/{1}/{1}-{2}'.format(framework_slug, supplier_id, document_name)

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -159,3 +159,13 @@ def default_file_suffix():
 def get_extension(filename):
     file_name, file_extension = os.path.splitext(filename)
     return file_extension.lower()
+
+
+def get_signed_url(bucket, path, base_url):
+    url = bucket.get_signed_url(path)
+    if url is not None:
+        if base_url is not None:
+            url = urlparse.urlparse(url)
+            base_url = urlparse.urlparse(base_url)
+            url = url._replace(netloc=base_url.netloc, scheme=base_url.scheme).geturl()
+        return url

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,6 +1,7 @@
 import unittest
 
 import mock
+import pytest
 from freezegun import freeze_time
 
 from dmutils.s3 import S3ResponseError
@@ -12,7 +13,8 @@ from dmutils.documents import (
     file_is_less_than_5mb,
     file_is_open_document_format,
     validate_documents,
-    upload_document, upload_service_documents
+    upload_document, upload_service_documents,
+    get_signed_url
 )
 
 
@@ -238,6 +240,22 @@ class TestUploadServiceDocuments(object):
 
         assert files is None
         assert 'pricingDocumentURL' in errors
+
+
+@pytest.mark.parametrize('base_url,expected', [
+    ('http://other', 'http://other/foo?after'),
+    (None, 'http://example/foo?after'),
+    ('https://other', 'https://other/foo?after'),
+    ('https://other:1234', 'https://other:1234/foo?after'),
+    ('https://other/again', 'https://other/foo?after'),
+])
+def test_get_signed_url(base_url, expected):
+    mock_bucket = mock.Mock()
+    mock_bucket.get_signed_url.return_value = "http://example/foo?after"
+
+    url = get_signed_url(mock_bucket, 'foo', base_url)
+
+    assert url == expected
 
 
 def mock_file(filename, length, name=None):

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -14,7 +14,7 @@ from dmutils.documents import (
     file_is_open_document_format,
     validate_documents,
     upload_document, upload_service_documents,
-    get_signed_url
+    get_signed_url, get_agreement_document_path
 )
 
 
@@ -256,6 +256,10 @@ def test_get_signed_url(base_url, expected):
     url = get_signed_url(mock_bucket, 'foo', base_url)
 
     assert url == expected
+
+
+def test_get_agreement_document_path():
+    assert get_agreement_document_path('g-cloud-7', 1234, 'foo.pdf') == 'g-cloud-7/agreements/1234/1234-foo.pdf'
 
 
 def mock_file(filename, length, name=None):


### PR DESCRIPTION
## Add method to get signed document URL
This is a wrapper around the S3 get_signed_url method that replicates the behaviour of get_draft_document_url in the supplier frontend for replacing the S3 URL with our assets URL.

This has been moved to utils so that it can be used in the admin app.

## Add method to get agreement document path
This is copied over from the supplier frontend so that it can be used in the admin app as well. It has been added the the documents module as this is where other utility functions relating to documents have been added.