### PR TITLE
Create new draft page questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 Records breaking changes from major version bumps
 
+## 12.0.0
+
+PR: [#202](https://github.com/alphagov/digitalmarketplace-utils/pull/202)
+
+### What changed
+
+1. Two new parameters were added to `dmutils.apiclient.DataAPIClient.create_new_draft_service`:
+   `data` and `page_questions`
+2. Parameter order for `dmutils.apiclient.DataAPIClient.create_new_draft_service` was changed to:
+   `create_new_draft_service(self, framework_slug, lot, supplier_id, data, user, page_questions=None)`
+3. `dmutils.apiclient.DataAPIClient.get_framework_status` method was removed, use `.get_framework`
+   instead
+
+### Example app change
+
+Old
+```python
+draft_service = data_api_client.create_new_draft_service(
+    framework_slug, supplier_id, user, lot
+)
+```
+
+New
+```python
+draft_service = data_api_client.create_new_draft_service(
+    framework_slug, lot, supplier_id, {},
+    user, page_questions=None
+)
+```
+
 ## 11.0.0
 
 PR: [#195](https://github.com/alphagov/digitalmarketplace-utils/pull/195)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '11.4.0'
+__version__ = '12.0.0'

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -392,19 +392,23 @@ class DataAPIClient(BaseAPIClient):
                 },
             })
 
-    def create_new_draft_service(self, framework_slug, supplier_id, user, lot):
+    def create_new_draft_service(self, framework_slug, lot, supplier_id, data, user, page_questions=None):
+        service_data = data.copy()
+        service_data.update({
+            "frameworkSlug": framework_slug,
+            "lot": lot,
+            "supplierId": supplier_id,
+        })
+
         return self._post(
             "/draft-services",
             data={
                 "update_details": {
                     "updated_by": user
                 },
-                "services": {
-                    "frameworkSlug": framework_slug,
-                    "supplierId": supplier_id,
-                    "lot": lot
-                }
 
+                "services": service_data,
+                "page_questions": page_questions or [],
             })
 
     def get_archived_service(self, archived_service_id):

--- a/dmutils/apiclient/data.py
+++ b/dmutils/apiclient/data.py
@@ -476,8 +476,3 @@ class DataAPIClient(BaseAPIClient):
     def get_framework_stats(self, framework_slug):
         return self._get(
             "/frameworks/{}/stats".format(framework_slug))
-
-    def get_framework_status(self, framework_slug):
-        return self._get(
-            "/frameworks/{}/status".format(framework_slug)
-        )

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1186,19 +1186,21 @@ class TestDataApiClient(object):
         )
 
         result = data_client.create_new_draft_service(
-            'g-cloud-7', 2, 'user', 'iaas'
+            'g-cloud-7', 'iaas', 2, {'serviceName': 'name'}, 'user',
         )
 
         assert result == {"done": "it"}
         assert rmock.called
         assert rmock.request_history[0].json() == {
+            'page_questions': [],
             'update_details': {
                 'updated_by': 'user'
             },
             'services': {
                 'frameworkSlug': 'g-cloud-7',
                 'supplierId': 2,
-                'lot': 'iaas'
+                'lot': 'iaas',
+                'serviceName': 'name',
             }
         }
 

--- a/tests/test_apiclient.py
+++ b/tests/test_apiclient.py
@@ -1428,26 +1428,6 @@ class TestDataApiClient(object):
 
             data_client.get_framework_stats('g-cloud-11')
 
-    def test_get_framework_status(self, data_client, rmock):
-        rmock.get(
-            'http://baseurl/frameworks/g-cloud-11/status',
-            json={'status': 'pending'},
-            status_code=200)
-
-        result = data_client.get_framework_status('g-cloud-11')
-
-        assert result == {'status': 'pending'}
-        assert rmock.called
-
-    def test_get_framework_status_raises_on_error(self, data_client, rmock):
-        with pytest.raises(APIError):
-            rmock.get(
-                'http://baseurl/frameworks/g-cloud-11/status',
-                json={'error': 'It broke'},
-                status_code=400)
-
-            data_client.get_framework_status('g-cloud-11')
-
 
 class TestDataAPIClientIterMethods(object):
     def _test_find_iter(self, data_client, rmock, method_name, model_name, url_path):


### PR DESCRIPTION
### Remove get_framework_status apiclient method
Framework status is returned as part of the get_framework response,
so there's no need for a separate apiclient method and API endpoint.

Method isn't currently used by any of the apps.

### Add service data and page_questions arguments to create_new_draft_service

Allows creating a draft with initial service data and validating the
required page_questions fields in the API.

This changes the argument order for create_new_draft_service, which is
used by the supplier-frontend.