### PR TITLE
Include sanitised supplier name in agreement document filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 Records breaking changes from major version bumps
 
+## 13.0.0
+
+PR: [#203](https://github.com/alphagov/digitalmarketplace-utils/pull/203)
+
+### What changed
+
+The method `get_agreement_document_path` in `documents.py` now has supplier name as an additional parameter.
+
+### Example app change
+Old
+```
+path = get_agreement_document_path(framework_slug, supplier_id, document_name)
+```
+
+New
+```
+path = get_agreement_document_path(framework_slug, supplier_id, supplier_name, document_name)
+```
+
 ## 12.0.0
 
 PR: [#202](https://github.com/alphagov/digitalmarketplace-utils/pull/202)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '12.0.0'
+__version__ = '13.0.0'

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -179,12 +179,12 @@ def get_agreement_document_path(framework_slug, supplier_id, supplier_name, docu
     return '{0}/agreements/{1}/{2}-{1}-{3}'.format(
         framework_slug,
         supplier_id,
-        _sanitise_supplier_name(supplier_name),
+        sanitise_supplier_name(supplier_name),
         document_name
     )
 
 
-def _sanitise_supplier_name(supplier_name):
+def sanitise_supplier_name(supplier_name):
     sanitised_supplier_name = supplier_name.strip().replace(' ', '_').replace('&', 'and')
     for bad_char in BAD_SUPPLIER_NAME_CHARACTERS:
         sanitised_supplier_name = sanitised_supplier_name.replace(bad_char, '')

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -9,6 +9,10 @@ except ImportError:
 from .s3 import S3ResponseError
 
 
+BAD_SUPPLIER_NAME_CHARACTERS = ['#', '%', '&', '{', '}', '\\', '<', '>', '*', '?', '/', '$',
+                                '!', "'", '"', ':', '@', '+', '`', '|', '=', ',', '.']
+
+
 def filter_empty_files(files):
     """Remove any empty files from the list.
 
@@ -171,5 +175,19 @@ def get_signed_url(bucket, path, base_url):
         return url
 
 
-def get_agreement_document_path(framework_slug, supplier_id, document_name):
-    return '{0}/agreements/{1}/{1}-{2}'.format(framework_slug, supplier_id, document_name)
+def get_agreement_document_path(framework_slug, supplier_id, supplier_name, document_name):
+    return '{0}/agreements/{1}/{2}-{1}-{3}'.format(
+        framework_slug,
+        supplier_id,
+        _sanitise_supplier_name(supplier_name),
+        document_name
+    )
+
+
+def _sanitise_supplier_name(supplier_name):
+    sanitised_supplier_name = supplier_name.strip().replace(' ', '_').replace('&', 'and')
+    for bad_char in BAD_SUPPLIER_NAME_CHARACTERS:
+        sanitised_supplier_name = sanitised_supplier_name.replace(bad_char, '')
+    while '__' in sanitised_supplier_name:
+        sanitised_supplier_name = sanitised_supplier_name.replace('__', '_')
+    return sanitised_supplier_name

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -15,7 +15,7 @@ from dmutils.documents import (
     validate_documents,
     upload_document, upload_service_documents,
     get_signed_url, get_agreement_document_path,
-    _sanitise_supplier_name)
+    sanitise_supplier_name)
 
 
 class TestGenerateFilename(unittest.TestCase):
@@ -264,11 +264,11 @@ def test_get_agreement_document_path():
 
 
 def test_sanitise_supplier_name():
-    assert _sanitise_supplier_name('Kev\'s Butties') == 'Kevs_Butties'
-    assert _sanitise_supplier_name('   Supplier A   ') == 'Supplier_A'
-    assert _sanitise_supplier_name('Kev & Sons. | Ltd') == 'Kev_and_Sons_Ltd'
-    assert _sanitise_supplier_name('\ / : * ? \' " < > |') == '_'
-    assert _sanitise_supplier_name('kev@the*agency') == 'kevtheagency'
+    assert sanitise_supplier_name('Kev\'s Butties') == 'Kevs_Butties'
+    assert sanitise_supplier_name('   Supplier A   ') == 'Supplier_A'
+    assert sanitise_supplier_name('Kev & Sons. | Ltd') == 'Kev_and_Sons_Ltd'
+    assert sanitise_supplier_name('\ / : * ? \' " < > |') == '_'
+    assert sanitise_supplier_name('kev@the*agency') == 'kevtheagency'
 
 
 def mock_file(filename, length, name=None):

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -14,8 +14,8 @@ from dmutils.documents import (
     file_is_open_document_format,
     validate_documents,
     upload_document, upload_service_documents,
-    get_signed_url, get_agreement_document_path
-)
+    get_signed_url, get_agreement_document_path,
+    _sanitise_supplier_name)
 
 
 class TestGenerateFilename(unittest.TestCase):
@@ -259,7 +259,16 @@ def test_get_signed_url(base_url, expected):
 
 
 def test_get_agreement_document_path():
-    assert get_agreement_document_path('g-cloud-7', 1234, 'foo.pdf') == 'g-cloud-7/agreements/1234/1234-foo.pdf'
+    assert get_agreement_document_path('g-cloud-7', 1234, 'supplier name', 'foo.pdf') == \
+        'g-cloud-7/agreements/1234/supplier_name-1234-foo.pdf'
+
+
+def test_sanitise_supplier_name():
+    assert _sanitise_supplier_name('Kev\'s Butties') == 'Kevs_Butties'
+    assert _sanitise_supplier_name('   Supplier A   ') == 'Supplier_A'
+    assert _sanitise_supplier_name('Kev & Sons. | Ltd') == 'Kev_and_Sons_Ltd'
+    assert _sanitise_supplier_name('\ / : * ? \' " < > |') == '_'
+    assert _sanitise_supplier_name('kev@the*agency') == 'kevtheagency'
 
 
 def mock_file(filename, length, name=None):


### PR DESCRIPTION
CCS use supplier name to organise their work, so they need it to be included in the filename for the returned agreement documents.

This is exactly the same method used in the script to generate the framework agreement data.

I have confirmed with Chris at CCS that the filename format generated here is good for them to work with.