### PR TITLE
Update document url generation

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '13.2.0'
+__version__ = '13.3.0'

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -146,7 +146,7 @@ def generate_file_name(framework_slug, supplier_id, service_id, field, filename,
         'pricingDocumentURL': 'pricing-document',
     }
 
-    return '{}/{}/{}-{}-{}{}'.format(
+    return '{}/documents/{}/{}-{}-{}{}'.format(
         framework_slug,
         supplier_id,
         service_id,

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -21,7 +21,7 @@ from dmutils.documents import (
 class TestGenerateFilename(unittest.TestCase):
     def test_filename_format(self):
         self.assertEquals(
-            'slug/2/1-pricing-document-123.pdf',
+            'slug/documents/2/1-pricing-document-123.pdf',
             generate_file_name(
                 'slug', 2, 1,
                 'pricingDocumentURL', 'test.pdf',
@@ -31,7 +31,7 @@ class TestGenerateFilename(unittest.TestCase):
     def test_default_suffix_is_datetime(self):
         with freeze_time('2015-01-02 03:04:05'):
             self.assertEquals(
-                'slug/2/1-pricing-document-2015-01-02-0304.pdf',
+                'slug/documents/2/1-pricing-document-2015-01-02-0304.pdf',
                 generate_file_name(
                     'slug', 2, 1,
                     'pricingDocumentURL', 'test.pdf',
@@ -116,11 +116,11 @@ class TestUploadDocument(unittest.TestCase):
                     "pricingDocumentURL",
                     mock_file('file.pdf', 1)
                 ),
-                'http://assets/g-cloud-6/5/123-pricing-document-2015-01-02-0405.pdf'
+                'http://assets/g-cloud-6/documents/5/123-pricing-document-2015-01-02-0405.pdf'
             )
 
         uploader.save.assert_called_once_with(
-            'g-cloud-6/5/123-pricing-document-2015-01-02-0405.pdf',
+            'g-cloud-6/documents/5/123-pricing-document-2015-01-02-0405.pdf',
             mock.ANY,
             acl='public-read'
         )
@@ -137,11 +137,11 @@ class TestUploadDocument(unittest.TestCase):
                     mock_file('file.pdf', 1),
                     public=False
                 ),
-                'http://assets/g-cloud-6/5/123-pricing-document-2015-01-02-0405.pdf'
+                'http://assets/g-cloud-6/documents/5/123-pricing-document-2015-01-02-0405.pdf'
             )
 
         uploader.save.assert_called_once_with(
-            'g-cloud-6/5/123-pricing-document-2015-01-02-0405.pdf',
+            'g-cloud-6/documents/5/123-pricing-document-2015-01-02-0405.pdf',
             mock.ANY,
             acl='private'
         )
@@ -191,7 +191,7 @@ class TestUploadServiceDocuments(object):
                 request_files, self.section)
 
         self.uploader.save.assert_called_with(
-            'g-cloud-7/12345/654321-pricing-document-2015-10-04-1436.pdf', mock.ANY, acl='public-read')
+            'g-cloud-7/documents/12345/654321-pricing-document-2015-10-04-1436.pdf', mock.ANY, acl='public-read')
 
         assert 'pricingDocumentURL' in files
         assert len(errors) == 0
@@ -206,7 +206,7 @@ class TestUploadServiceDocuments(object):
                 public=False)
 
         self.uploader.save.assert_called_with(
-            'g-cloud-7/12345/654321-pricing-document-2015-10-04-1436.pdf', mock.ANY, acl='private')
+            'g-cloud-7/documents/12345/654321-pricing-document-2015-10-04-1436.pdf', mock.ANY, acl='private')
 
         assert 'pricingDocumentURL' in files
         assert len(errors) == 0

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -265,13 +265,13 @@ class TestValidate(unittest.TestCase):
         self.assertEquals(self.validate.errors, {})
 
         self.uploader.save.assert_called_once_with(
-            'g-cloud-6/2/1-pricing-document-2015-01-01-1200.pdf',
+            'g-cloud-6/documents/2/1-pricing-document-2015-01-01-1200.pdf',
             self.data['pricingDocumentURL'],
             acl='public-read'
         )
 
         self.assertEquals(self.validate.clean_data, {
-            'pricingDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/g-cloud-6/2/1-pricing-document-2015-01-01-1200.pdf',  # noqa
+            'pricingDocumentURL': 'https://assets.test.digitalmarketplace.service.gov.uk/g-cloud-6/documents/2/1-pricing-document-2015-01-01-1200.pdf',  # noqa
         })
 
     def test_failed_file_upload(self):


### PR DESCRIPTION
This updates document URL generation to include /documents/ after the framework slug as per the discussion about URL naming. The document can be found in Google Drive with the title Digital Marketplace URLs.