### PR TITLE
Documents and S3 updates

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '13.3.0'
+__version__ = '13.4.0'

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     import urllib.parse as urlparse
 
-from .s3 import S3ResponseError
+from .s3 import S3ResponseError, get_file_size_up_to_maximum, FILE_SIZE_LIMIT
 
 
 BAD_SUPPLIER_NAME_CHARACTERS = ['#', '%', '&', '{', '}', '\\', '<', '>', '*', '?', '/', '$',
@@ -122,11 +122,7 @@ def file_is_not_empty(file_contents):
 
 
 def file_is_less_than_5mb(file_contents):
-    size_limit = 5400000
-    below_size_limit = len(file_contents.read(size_limit)) < size_limit
-    file_contents.seek(0)
-
-    return below_size_limit
+    return get_file_size_up_to_maximum(file_contents) < FILE_SIZE_LIMIT
 
 
 def file_is_open_document_format(file_object):

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -116,9 +116,13 @@ def upload_service_documents(uploader, documents_url, service, request_files, se
 
 
 def file_is_not_empty(file_contents):
-    not_empty = len(file_contents.read(1)) > 0
+    return not file_is_empty(file_contents)
+
+
+def file_is_empty(file_contents):
+    empty = len(file_contents.read(1)) == 0
     file_contents.seek(0)
-    return not_empty
+    return empty
 
 
 def file_is_less_than_5mb(file_contents):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,16 @@
 from datetime import datetime
+import mock
 
 
 class IsDatetime(object):
     def __eq__(self, other):
         return isinstance(other, datetime)
+
+
+def mock_file(filename, length, name=None):
+    mock_file = mock.MagicMock()
+    mock_file.read.return_value = '*' * length
+    mock_file.filename = filename
+    mock_file.name = name
+
+    return mock_file

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -4,6 +4,7 @@ import mock
 import pytest
 from freezegun import freeze_time
 
+from .helpers import mock_file
 from dmutils.s3 import S3ResponseError
 
 from dmutils.content_loader import ContentSection
@@ -269,12 +270,3 @@ def test_sanitise_supplier_name():
     assert sanitise_supplier_name('Kev & Sons. | Ltd') == 'Kev_and_Sons_Ltd'
     assert sanitise_supplier_name('\ / : * ? \' " < > |') == '_'
     assert sanitise_supplier_name('kev@the*agency') == 'kevtheagency'
-
-
-def mock_file(filename, length, name=None):
-    mock_file = mock.MagicMock()
-    mock_file.read.return_value = '*' * length
-    mock_file.filename = filename
-    mock_file.name = name
-
-    return mock_file

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -10,7 +10,7 @@ from dmutils.s3 import S3ResponseError
 from dmutils.content_loader import ContentSection
 from dmutils.documents import (
     generate_file_name,
-    file_is_not_empty, filter_empty_files,
+    file_is_not_empty, file_is_empty, filter_empty_files,
     file_is_less_than_5mb,
     file_is_open_document_format,
     validate_documents,
@@ -41,10 +41,14 @@ class TestGenerateFilename(unittest.TestCase):
 
 class TestValidateDocuments(unittest.TestCase):
     def test_file_is_not_empty(self):
-        self.assertTrue(file_is_not_empty(mock_file('file1', 1)))
+        non_empty_file = mock_file('file1', 1)
+        assert file_is_not_empty(non_empty_file)
+        assert not file_is_empty(non_empty_file)
 
     def test_file_is_empty(self):
-        self.assertFalse(file_is_not_empty(mock_file('file1', 0)))
+        empty_file = mock_file('file1', 0)
+        assert not file_is_not_empty(empty_file)
+        assert file_is_empty(empty_file)
 
     def test_filter_empty_files(self):
         file1 = mock_file('file1', 1)


### PR DESCRIPTION
## Log file size on S3 upload

We have been having some problems with unexpected files being uploaded. This change logs the path, size and ACL of a saved file.

## Add file_is_empty function

In cases where we want to test if a file is empty using the double negative form (`if not file_is_not_empty`) is confusing.