### PR TITLE
New pricing fields functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Records breaking changes from major version bumps
 
+## 15.0.0
+
+PR: [#210](https://github.com/alphagov/digitalmarketplace-utils/pull/210)
+
+### What changed
+
+Breaking changes:
+* `content_builder` module no longer does special handling of pricing fields. The content
+  repository must therefore be upgraded along with this change.
+
+### Example app change
+
+Upgrade digitalmarketplace-frameworks to `0.5.0` in `bower.json`
+
 ## 14.0.0
 
 PR: [#211](https://github.com/alphagov/digitalmarketplace-utils/pull/211)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '14.1.0'
+__version__ = '15.0.0'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -206,8 +206,6 @@ class ContentSection(object):
         This list of field names corresponds to the keys of the data returned
         by :func:`ContentSection.get_data`.
         """
-        return list(self.get_valid_params())
-
         return [
             form_field for question in self.questions for form_field in question.form_fields
         ]
@@ -217,15 +215,6 @@ class ContentSection(object):
         return [
             form_field for question in self.questions for form_field in question.get_question_ids(type)
         ]
-
-    def get_valid_params(self):
-        valid_params = set(self.get_question_ids())
-        for question in self.questions:
-            # if the question has fields, swap the id out for them as a valid param
-            if question.get('fields'):
-                valid_params.update(question.get('fields').values())
-                valid_params.remove(question.get('id'))
-        return valid_params
 
     def get_data(self, form_data):
         """Extract data for a section from a submitted form

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -486,6 +486,9 @@ class ContentQuestionSummary(ContentQuestion):
             self.questions = [q.summary(service_data) for q in self.questions]
         self.fields = question.fields
 
+    def _default_for_field(self, field_key):
+        return self.get('field_defaults', {}).get(field_key)
+
     @property
     def value(self):
         if self.questions:
@@ -494,8 +497,8 @@ class ContentQuestionSummary(ContentQuestion):
             return format_price(
                 self._service_data.get(self.fields.get('minimum_price')),
                 self._service_data.get(self.fields.get('maximum_price')),
-                self._service_data.get(self.fields.get('price_unit')),
-                self._service_data.get(self.fields.get('price_interval')),
+                self._service_data.get(self.fields.get('price_unit'), self._default_for_field('price_unit')),
+                self._service_data.get(self.fields.get('price_interval'), self._default_for_field('price_interval')),
             )
         return self._service_data.get(self.id, '')
 

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -266,9 +266,6 @@ class ContentSection(object):
         """
         errors_map = {}
         for field_name, message_key in errors.items():
-            if field_name == 'serviceTypes':
-                field_name = 'serviceType{}'.format(lot)
-
             question = self.get_question(field_name)
             validation_message = question.get_error_message(message_key, field_name)
 

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -426,12 +426,14 @@ class ContentQuestion(object):
     def form_fields(self):
         if self.fields:
             return self.fields.values()
+        elif self.questions:
+            return list(chain.from_iterable(question.form_fields for question in self.questions))
         else:
             # pricing fields should have fields.
             # throw an assertion error if they don't.
             # TODO: maybe we can check this elsewhere?
             assert self.type != "pricing"
-            return self.get_question_ids()
+            return [self.id]
 
     @property
     def required_form_fields(self):

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -280,7 +280,7 @@ class ContentSection(object):
                 field_name = 'serviceType{}'.format(lot)
 
             question = self.get_question(field_name)
-            validation_message = self.get_error_message(field_name, message_key)
+            validation_message = question.get_error_message(message_key, field_name)
 
             error_key = question.id
             if message_key == 'assurance_required':
@@ -292,18 +292,6 @@ class ContentSection(object):
                 'message': validation_message,
             }
         return errors_map
-
-    def get_error_message(self, field_name, message_key):
-        """Return a single error message
-
-        :param field_name:
-        :param message_key: error message key as returned by the data API
-        """
-        for validation in self.get_question(field_name)['validations']:
-            if validation['name'] == message_key:
-                if validation.get('field', field_name) == field_name:
-                    return validation['message']
-        return 'There was a problem with the answer to this question'
 
     def unformat_data(self, data):
         """Unpack assurance information to be used in a form
@@ -420,6 +408,20 @@ class ContentQuestion(object):
             }
 
         return {self.id: value}
+
+    def get_error_message(self, message_key, field_name=None):
+        """Return a single error message.
+
+        :param message_key: error message key as returned by the data API
+        :param field_name:
+        """
+        if field_name is None:
+            field_name = self.id
+        for validation in self.get_question(field_name).get('validations', []):
+            if validation['name'] == message_key:
+                if validation.get('field', field_name) == field_name:
+                    return validation['message']
+        return 'There was a problem with the answer to this question'
 
     @property
     def label(self):

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -472,7 +472,7 @@ class ContentQuestion(object):
         return getattr(self, key)
 
     def __repr__(self):
-        return '<ContentQuestion: number={0.number}, data={0._data}>'.format(self)
+        return '<{0.__class__.__name__}: number={0.number}, data={0._data}>'.format(self)
 
 
 class ContentQuestionSummary(ContentQuestion):

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -359,11 +359,11 @@ class ContentQuestion(object):
 
     def get_data(self, form_data):
         if self.get('fields'):
-            fields = self.get('fields')
-            questions_data = {}
-            for key in set(fields.values()) & set(form_data):
-                questions_data[key] = form_data[key]
-            return questions_data
+            return {
+                key: form_data[key]
+                for key in self['fields'].values()
+                if key in form_data
+            }
         elif self.questions:
             questions_data = {}
             for question in self.questions:

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -10,6 +10,7 @@ from itertools import chain
 from werkzeug.datastructures import ImmutableMultiDict
 
 from .config import convert_to_boolean, convert_to_number
+from .formats import format_price
 
 
 class ContentNotFoundError(Exception):
@@ -489,6 +490,13 @@ class ContentQuestionSummary(ContentQuestion):
     def value(self):
         if self.questions:
             return self.questions
+        if self.type == "pricing":
+            return format_price(
+                self._service_data.get(self.fields.get('minimum_price')),
+                self._service_data.get(self.fields.get('maximum_price')),
+                self._service_data.get(self.fields.get('price_unit')),
+                self._service_data.get(self.fields.get('price_interval')),
+            )
         return self._service_data.get(self.id, '')
 
     @property

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -211,9 +211,8 @@ class ContentSection(object):
         ]
 
     def get_question_ids(self, type=None):
-        # TODO: variable name reconsider?
         return [
-            form_field for question in self.questions for form_field in question.get_question_ids(type)
+            question_id for question in self.questions for question_id in question.get_question_ids(type)
         ]
 
     def get_data(self, form_data):

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -422,7 +422,7 @@ class ContentQuestion(object):
     @property
     def form_fields(self):
         if self.fields:
-            return self.fields.values()
+            return sorted(self.fields.values())
         elif self.questions:
             return list(chain.from_iterable(question.form_fields for question in self.questions))
         else:

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -6,7 +6,6 @@ import re
 import os
 from collections import defaultdict
 from functools import partial
-from itertools import chain
 from werkzeug.datastructures import ImmutableMultiDict
 
 from .config import convert_to_boolean, convert_to_number
@@ -424,7 +423,7 @@ class ContentQuestion(object):
         if self.fields:
             return sorted(self.fields.values())
         elif self.questions:
-            return list(chain.from_iterable(question.form_fields for question in self.questions))
+            return [form_field for question in self.questions for form_field in question.form_fields]
         else:
             # pricing fields should have fields.
             # throw an assertion error if they don't.
@@ -442,12 +441,10 @@ class ContentQuestion(object):
             return self.form_fields
         elif self.get('optional_fields'):
             return [self.fields[key] for key in self['optional_fields']]
+        elif self.questions:
+            return [form_field for question in self.questions for form_field in question._optional_form_fields]
         else:
-            if self.questions:
-                return list(chain.from_iterable(
-                    question._optional_form_fields for question in self.questions))
-            else:
-                return []
+            return []
 
     def get_question_ids(self, type=None):
         if self.questions:

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -6,6 +6,7 @@ import re
 import os
 from collections import defaultdict
 from functools import partial
+from itertools import chain
 from werkzeug.datastructures import ImmutableMultiDict
 
 from .config import convert_to_boolean, convert_to_number
@@ -437,6 +438,23 @@ class ContentQuestion(object):
             # TODO: maybe we can check this elsewhere?
             assert self.type != "pricing"
             return self.get_question_ids()
+
+    @property
+    def required_form_fields(self):
+        return list(set(self.form_fields) - set(self._optional_form_fields))
+
+    @property
+    def _optional_form_fields(self):
+        if self.get('optional'):
+            return self.form_fields
+        elif self.get('optional_fields'):
+            return [self['fields'][key] for key in self['optional_fields']]
+        else:
+            if self.questions:
+                return list(chain.from_iterable(
+                    question._optional_form_fields for question in self.questions))
+            else:
+                return []
 
     def get_question_ids(self, type=None):
         if self.questions:

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -483,6 +483,7 @@ class ContentQuestionSummary(ContentQuestion):
         self.questions = question.questions
         if self.questions:
             self.questions = [q.summary(service_data) for q in self.questions]
+        self.fields = question.fields
 
     @property
     def value(self):
@@ -494,7 +495,11 @@ class ContentQuestionSummary(ContentQuestion):
     def answer_required(self):
         if self.questions:
             return any(question.answer_required for question in self.questions)
-        if self.value in ['', [], None]:
+        elif self.fields:
+            return any(
+                self._service_data.get(field_name) in ['', [], None]
+                for field_name in self.required_form_fields)
+        elif self.value in ['', [], None]:
             if not self.get('optional'):
                 return True
         else:

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -490,22 +490,23 @@ class ContentQuestionSummary(ContentQuestion):
         if self.questions:
             return self.questions
         if self.type == "pricing":
-            return format_price(
-                self._service_data.get(self.fields.get('minimum_price')),
-                self._service_data.get(self.fields.get('maximum_price')),
-                self._service_data.get(self.fields.get('price_unit'), self._default_for_field('price_unit')),
-                self._service_data.get(self.fields.get('price_interval'), self._default_for_field('price_interval')),
-            )
+            minimum_price = self._service_data.get(self.fields.get('minimum_price'))
+            maximum_price = self._service_data.get(self.fields.get('maximum_price'))
+            price_unit = self._service_data.get(self.fields.get('price_unit'),
+                                                self._default_for_field('price_unit'))
+            price_interval = self._service_data.get(self.fields.get('price_interval'),
+                                                    self._default_for_field('price_interval'))
+
+            if minimum_price and price_unit:
+                return format_price(minimum_price, maximum_price, price_unit, price_interval)
+            else:
+                return ''
         return self._service_data.get(self.id, '')
 
     @property
     def answer_required(self):
         if self.questions:
             return any(question.answer_required for question in self.questions)
-        elif self.fields:
-            return any(
-                self._service_data.get(field_name) in ['', [], None]
-                for field_name in self.required_form_fields)
         elif self.value in ['', [], None]:
             if not self.get('optional'):
                 return True

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -341,13 +341,18 @@ class ContentQuestion(object):
         else:
             self.questions = None
 
+        if 'fields' in data:
+            self.fields = data['fields']
+        else:
+            self.fields = {}
+
     def summary(self, service_data):
         return ContentQuestionSummary(
             self, service_data
         )
 
     def get_question(self, field_name):
-        if field_name in self.get('fields', {}).values():
+        if field_name in self.fields.values():
             return self
         if self.id == field_name:
             return self
@@ -358,10 +363,10 @@ class ContentQuestion(object):
             )
 
     def get_data(self, form_data):
-        if self.get('fields'):
+        if self.fields:
             return {
                 key: form_data[key]
-                for key in self['fields'].values()
+                for key in self.fields.values()
                 if key in form_data
             }
         elif self.questions:
@@ -418,8 +423,8 @@ class ContentQuestion(object):
 
     @property
     def form_fields(self):
-        if self.get('fields', False):
-            return self.get('fields').values()
+        if self.fields:
+            return self.fields.values()
         else:
             # pricing fields should have fields.
             # throw an assertion error if they don't.
@@ -436,7 +441,7 @@ class ContentQuestion(object):
         if self.get('optional'):
             return self.form_fields
         elif self.get('optional_fields'):
-            return [self['fields'][key] for key in self['optional_fields']]
+            return [self.fields[key] for key in self['optional_fields']]
         else:
             if self.questions:
                 return list(chain.from_iterable(

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -76,10 +76,44 @@ def get_label_for_lot_param(lot_to_check):
     return None
 
 
+def format_field_based_price(service, question):
+    """Format a price string from a service using field mappings
+    provided in the question definition.
+
+    :param service: a service dictionary, returned from data API
+
+    :param question: dictionary describing the question containing
+                     `fields`.
+
+    :return: a formatted price string if the required
+             fields are set in the service dictionary.
+    """
+    if 'fields' in question:
+        fields = question['fields']
+        min_price_f = fields.get('minimum_price', None)
+        max_price_f = fields.get('maximum_price', None)
+        price_unit_f = fields.get('price_unit', None)
+        price_interval_f = fields.get('price_interval', None)
+
+        min_price = service.get(min_price_f, None)
+        max_price = service.get(max_price_f, None)
+        price_unit = service.get(price_unit_f, None)
+        price_interval = service.get(price_interval_f, None)
+
+        if min_price_f and price_interval_f and min_price and max_price:
+            return format_price(
+                min_price, max_price, price_unit, price_interval
+            )
+        else:
+            return u''
+    else:
+        return u''
+
+
 def format_service_price(service):
     """Format a price string from a service dictionary
 
-    :param service: a service dictionary as would be returned from the data API
+    :param service: a service dictionary, returned from data API
 
     :return: a formatted price string if the required
              fields are set in the service dictionary.

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -76,35 +76,6 @@ def get_label_for_lot_param(lot_to_check):
     return None
 
 
-def format_field_based_price(service, question):
-    """Format a price string from a service using field mappings
-    provided in the question definition.
-
-    :param service: a service dictionary, returned from data API
-
-    :param question: dictionary describing the question containing
-                     `fields`.
-
-    :return: a formatted price string if the required
-             fields are set in the service dictionary.
-    """
-    if 'fields' in question:
-        fields = question['fields']
-        min_price = service.get(fields.get('minimum_price'))
-        max_price = service.get(fields.get('maximum_price'))
-        price_unit = service.get(fields.get('price_unit'))
-        price_interval = service.get(fields.get('price_interval'))
-
-        if min_price and price_unit:
-            return format_price(
-                min_price, max_price, price_unit, price_interval
-            )
-        else:
-            return u''
-    else:
-        return u''
-
-
 def format_service_price(service):
     """Format a price string from a service dictionary
 

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -90,17 +90,12 @@ def format_field_based_price(service, question):
     """
     if 'fields' in question:
         fields = question['fields']
-        min_price_f = fields.get('minimum_price', None)
-        max_price_f = fields.get('maximum_price', None)
-        price_unit_f = fields.get('price_unit', None)
-        price_interval_f = fields.get('price_interval', None)
+        min_price = service.get(fields.get('minimum_price'))
+        max_price = service.get(fields.get('maximum_price'))
+        price_unit = service.get(fields.get('price_unit'))
+        price_interval = service.get(fields.get('price_interval'))
 
-        min_price = service.get(min_price_f, None)
-        max_price = service.get(max_price_f, None)
-        price_unit = service.get(price_unit_f, None)
-        price_interval = service.get(price_interval_f, None)
-
-        if min_price_f and price_interval_f and min_price and max_price:
+        if min_price and price_unit:
             return format_price(
                 min_price, max_price, price_unit, price_interval
             )

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -276,6 +276,7 @@ class TestContentManifest(object):
                     "fields": {
                         "minimum_price": "q7.min",
                         "maximum_price": "q7.max",
+                        "price_unit": "q7.unit",
                     },
                     "optional_fields": [
                         "maximum_price"
@@ -295,7 +296,11 @@ class TestContentManifest(object):
             ]
         }])
 
-        summary = content.summary({'q2': 'some value', 'q6': 'another value', 'q7.min': '10'})
+        summary = content.summary({
+            'q2': 'some value',
+            'q6': 'another value',
+            'q7.min': '10',
+            'q7.unit': 'day'})
         assert summary.get_question('q1').value == [
             summary.get_question('q2'), summary.get_question('q3')
         ]
@@ -307,6 +312,7 @@ class TestContentManifest(object):
         assert not summary.get_question('q4').answer_required
         assert summary.get_question('q5').answer_required
         assert not summary.get_question('q6').answer_required
+        assert summary.get_question('q7').value == u'£10 per day'
         assert not summary.get_question('q7').answer_required
         assert summary.get_question('q8').answer_required
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -6,7 +6,10 @@ import pytest
 
 import io
 
-from dmutils.content_loader import ContentLoader, ContentSection, ContentManifest, read_yaml, ContentNotFoundError
+from dmutils.content_loader import (
+    ContentLoader, ContentSection, ContentQuestion, ContentManifest,
+    read_yaml, ContentNotFoundError
+)
 
 from sys import version_info
 if version_info.major == 2:
@@ -1056,6 +1059,98 @@ class TestContentSection(object):
         copy_of_section = section.copy()
         assert copy_of_section.description == "This is the first section"
 
+
+class TestContentQuestion(object):
+    def test_form_fields_property(self):
+        question = ContentQuestion({
+            "id": "example",
+            "type": "text"
+        })
+        assert question.form_fields == ['example']
+
+    def test_form_fields_property_with_pricing_field(self):
+        question = ContentQuestion({
+            "id": "example",
+            "type": "pricing",
+            "fields": {
+                "minimum_price": "priceMin",
+                "maximum_price": "priceMax",
+            }
+        })
+        assert sorted(question.form_fields) == sorted(['priceMin', 'priceMax'])
+
+    def test_form_fields_property_with_multiquestion(self):
+        question = ContentQuestion({
+            "id": "example",
+            "type": "multiquestion",
+            "questions": [
+                {
+                    "id": "example2",
+                    "type": "text",
+                },
+                {
+                    "id": "example3",
+                    "type": "text",
+                }
+            ]
+        })
+        assert question.form_fields == ['example2', 'example3']
+
+    def test_required_form_fields_property(self):
+        question = ContentQuestion({
+            "id": "example",
+            "type": "pricing",
+            "fields": {
+                "minimum_price": "priceMin",
+                "maximum_price": "priceMax",
+            }
+        })
+        assert sorted(question.required_form_fields) == sorted(['priceMin', 'priceMax'])
+
+    def test_required_form_fields_property_when_optional(self):
+        question = ContentQuestion({
+            "id": "example",
+            "type": "pricing",
+            "optional": True,
+            "fields": {
+                "minimum_price": "priceMin",
+                "maximum_price": "priceMax",
+            }
+        })
+        assert question.required_form_fields == []
+
+    def test_required_form_fields_property_with_optional_fields(self):
+        question = ContentQuestion({
+            "id": "example",
+            "type": "pricing",
+            "fields": {
+                "minimum_price": "priceMin",
+                "maximum_price": "priceMax",
+            },
+            "optional_fields": [
+                "minimum_price"
+            ]
+        })
+        assert question.required_form_fields == ['priceMax']
+
+    def test_required_form_fields_with_multiquestion(self):
+        question = ContentQuestion({
+            "id": "example",
+            "type": "multiquestion",
+            "questions": [
+                {
+                    "id": "example2",
+                    "type": "text",
+                    "optional": False,
+                },
+                {
+                    "id": "example3",
+                    "type": "text",
+                    "optional": True,
+                }
+            ]
+        })
+        assert question.required_form_fields == ['example2']
 
 class TestReadYaml(object):
     @mock.patch.object(builtins, 'open', return_value=io.StringIO(u'foo: bar'))

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -968,7 +968,8 @@ class TestContentSection(object):
             }]
         })
 
-        assert section.get_error_message('q2', 'the_error') == "This is the error message"
+        expected = "This is the error message"
+        assert section.get_question('q2').get_error_message('the_error') == expected
 
     def test_get_error_message_returns_default(self):
         section = ContentSection.create({
@@ -984,7 +985,8 @@ class TestContentSection(object):
             }]
         })
 
-        assert section.get_error_message('q2', 'other_error') == "There was a problem with the answer to this question"
+        expected = "There was a problem with the answer to this question"
+        assert section.get_question('q2').get_error_message('other_error') == expected
 
     def test_get_error_messages(self):
         section = ContentSection.create({

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1153,6 +1153,7 @@ class TestContentQuestion(object):
         })
         assert question.required_form_fields == ['example2']
 
+
 class TestReadYaml(object):
     @mock.patch.object(builtins, 'open', return_value=io.StringIO(u'foo: bar'))
     def test_loading_existant_file(self, mocked_open):

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1034,7 +1034,7 @@ class TestContentSection(object):
                     {'name': 'the_error', 'message': 'This is the error message'},
                 ],
             }, {
-                "id": "serviceTypeSCS",
+                "id": "serviceTypes",
                 "question": "Third question",
                 "type": "text",
                 "validations": [
@@ -1076,7 +1076,7 @@ class TestContentSection(object):
         assert result['priceString']['message'] == "No min price"
         assert result['q2']['message'] == "This is the error message"
         assert result['q3--assurance']['message'] == "There there, it'll be ok."
-        assert result['serviceTypeSCS']['message'] == "This is the error message"
+        assert result['serviceTypes']['message'] == "This is the error message"
 
     def test_section_description(self):
         section = ContentSection.create({

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -270,10 +270,32 @@ class TestContentManifest(object):
                 {"id": "q4", "type": "text", "optional": True},
                 {"id": "q5", "type": "text", "optional": False},
                 {"id": "q6", "type": "text", "optional": False},
+                {
+                    "id": "q7",
+                    "type": "pricing",
+                    "fields": {
+                        "minimum_price": "q7.min",
+                        "maximum_price": "q7.max",
+                    },
+                    "optional_fields": [
+                        "maximum_price"
+                    ]
+                },
+                {
+                    "id": "q8",
+                    "type": "pricing",
+                    "fields": {
+                        "minimum_price": "q8.min",
+                        "maximum_price": "q8.max",
+                    },
+                    "optional_fields": [
+                        "maximum_price"
+                    ]
+                }
             ]
         }])
 
-        summary = content.summary({'q2': 'some value', 'q6': 'another value'})
+        summary = content.summary({'q2': 'some value', 'q6': 'another value', 'q7.min': '10'})
         assert summary.get_question('q1').value == [
             summary.get_question('q2'), summary.get_question('q3')
         ]
@@ -285,6 +307,8 @@ class TestContentManifest(object):
         assert not summary.get_question('q4').answer_required
         assert summary.get_question('q5').answer_required
         assert not summary.get_question('q6').answer_required
+        assert not summary.get_question('q7').answer_required
+        assert summary.get_question('q8').answer_required
 
     def test_get_question(self):
         content = ContentManifest([

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -887,7 +887,8 @@ class TestContentSection(object):
                 "type": "pricing",
             }]
         })
-        assert section.get_field_names() == ["q1"]
+        with pytest.raises(AssertionError):
+            section.get_field_names()
 
     def test_get_field_names_with_good_pricing_question(self):
         section = ContentSection.create({

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from dmutils.formats import (
     get_label_for_lot_param, lot_to_lot_case,
-    format_price, format_service_price, format_field_based_price,
+    format_price, format_service_price,
     timeformat, shortdateformat, dateformat, datetimeformat
 )
 import pytz
@@ -36,52 +36,6 @@ class TestFormats(object):
 
         for example, expected in cases:
             assert get_label_for_lot_param(example) == expected
-
-
-def test_format_field_based_price():
-    draft = {
-        u'priceString-minimum': u'50',
-        u'priceString-maximum': u'100',
-        u'priceString-interval': u'',
-        u'priceString-unit': u'Unit',
-    }
-    q = {
-        'question': 'Service price',
-        'fields': {
-            'maximum_price': 'priceString-maximum',
-            'minimum_price': 'priceString-minimum',
-            'price_unit': 'priceString-unit',
-            'price_interval': 'priceString-interval'},
-        'validations': [],
-        'type': 'pricing',
-        'id': 'priceString'
-    }
-    assert format_field_based_price(draft, q) == u"£50 to £100 per unit"
-
-
-def test_format_field_based_price_fail():
-    q = {
-        'question': 'Service price',
-        'fields': {
-            'maximum_price': 'priceString-maximum',
-            'minimum_price': 'priceString-minimum',
-            'price_unit': 'priceString-unit',
-            'price_interval': 'priceString-interval'},
-        'validations': [],
-        'type': 'pricing',
-        'id': 'priceString'
-    }
-
-    drafts = [
-        {},
-        {'priceString-minimum': None},
-        {'priceString-minimum': None, 'priceString-maximum': None},
-        {'priceString-unit': None},
-        {'priceString-interval': None}
-    ]
-
-    for draft in drafts:
-        assert format_field_based_price(draft, q) == u''
 
 
 def test_format_service_price():

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from dmutils.formats import (
     get_label_for_lot_param, lot_to_lot_case,
-    format_price, format_service_price,
+    format_price, format_service_price, format_field_based_price,
     timeformat, shortdateformat, dateformat, datetimeformat
 )
 import pytz
@@ -36,6 +36,52 @@ class TestFormats(object):
 
         for example, expected in cases:
             assert get_label_for_lot_param(example) == expected
+
+
+def test_format_field_based_price():
+    draft = {
+        u'priceString-minimum': u'50',
+        u'priceString-maximum': u'100',
+        u'priceString-interval': u'',
+        u'priceString-unit': u'Unit',
+    }
+    q = {
+        'question': 'Service price',
+        'fields': {
+            'maximum_price': 'priceString-maximum',
+            'minimum_price': 'priceString-minimum',
+            'price_unit': 'priceString-unit',
+            'price_interval': 'priceString-interval'},
+        'validations': [],
+        'type': 'pricing',
+        'id': 'priceString'
+    }
+    assert format_field_based_price(draft, q) == u"£50 to £100 per unit"
+
+
+def test_format_field_based_price_fail():
+    q = {
+        'question': 'Service price',
+        'fields': {
+            'maximum_price': 'priceString-maximum',
+            'minimum_price': 'priceString-minimum',
+            'price_unit': 'priceString-unit',
+            'price_interval': 'priceString-interval'},
+        'validations': [],
+        'type': 'pricing',
+        'id': 'priceString'
+    }
+
+    drafts = [
+        {},
+        {'priceString-minimum': None},
+        {'priceString-minimum': None, 'priceString-maximum': None},
+        {'priceString-unit': None},
+        {'priceString-interval': None}
+    ]
+
+    for draft in drafts:
+        assert format_field_based_price(draft, q) == u''
 
 
 def test_format_service_price():


### PR DESCRIPTION
In Content Loader, instead of using `get_question`, a new method (`get_question_by_form_field_name`) provides a fields-compatible equivalent.

In the formatting code, a new function has been created to format pricing fields.

Existing methods have been retained until we are sure they are no longer needed.