### PR TITLE
Multiquestion questions support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ install:
   - pip install -r requirements_for_test.txt
   - pip install -e .
 script:
-  - ./scripts/run_tests.sh
+  - ./scripts/run_tests.sh --cov=dmutils --cov-report=term-missing
+after_success:
+  - coveralls
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 Records breaking changes from major version bumps
 
+## 14.0.0
+
+PR: [#211](https://github.com/alphagov/digitalmarketplace-utils/pull/211)
+
+### What changed
+
+Breaking changes:
+* `ContentSection.id` used in edit section URLs now uses dashes instead of underscores.
+
+Non-breaking changes:
+* `ContentBuilder` class renamed to `ContentManifest`
+* `.get_builder` is renamed to `.get_manifest`, but the old name is kept as an alias to give
+  frontend apps time to update
+* Question fields can be now accessed as attributes of `ContentQuestion`
+* `service_attribute` is being replaced by `ContetManifest.summary` and `ContentQuestionSummary`
+
+### Example app change
+
+Test URLs referencing section IDs need to be updated:
+
+Old
+```
+res = self.client.get('/suppliers/frameworks/g-cloud-7/declaration/g_cloud_7_essentials')
+```
+
+New
+```
+res = self.client.get('/suppliers/frameworks/g-cloud-7/declaration/g-cloud-7-essentials')
+```
+
 ## 13.0.0
 
 PR: [#203](https://github.com/alphagov/digitalmarketplace-utils/pull/203)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Digital Marketplace utils
 =========================
 
+[![Coverage Status](https://coveralls.io/repos/alphagov/digitalmarketplace-utils/badge.svg?branch=multiquestion-questions&service=github)](https://coveralls.io/github/alphagov/digitalmarketplace-utils?branch=multiquestion-questions)
+
 ## What's in here?
 
 * Digital Marketplace API clients

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Digital Marketplace utils
 =========================
 
 [![Coverage Status](https://coveralls.io/repos/alphagov/digitalmarketplace-utils/badge.svg?branch=multiquestion-questions&service=github)](https://coveralls.io/github/alphagov/digitalmarketplace-utils?branch=multiquestion-questions)
+[![Requirements Status](https://requires.io/github/alphagov/digitalmarketplace-utils/requirements.svg?branch=multiquestion-questions)](https://requires.io/github/alphagov/digitalmarketplace-utils/requirements/?branch=multiquestion-questions)
 
 ## What's in here?
 

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '13.5.0'
+__version__ = '14.0.0'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -114,9 +114,9 @@ class ContentManifest(object):
                 return False
         return True
 
-    def get_question(self, question_id):
+    def get_question(self, field_name):
         for section in self.sections:
-            question = section.get_question(question_id)
+            question = section.get_question(field_name)
             if question:
                 return question
 
@@ -317,12 +317,13 @@ class ContentSection(object):
                 result[key] = data[key]
         return result
 
-    def get_question(self, question_id):
+    def get_question(self, field_name):
         """Return a question dictionary by question ID"""
-        # TODO: investigate how this would work as get by form field name
+
         for question in self.questions:
-            if question['id'] == question_id:
-                return question
+            field_question = question.get_question(field_name)
+            if field_question:
+                return field_question
 
     # Type checking
 
@@ -367,6 +368,15 @@ class ContentQuestion(object):
             self.questions = None
         self.number = number
         self.data = data
+
+    def get_question(self, field_name):
+        if self.id == field_name:
+            return self
+        elif self.questions:
+            return next(
+                (question for question in self.questions if question.id == field_name),
+                None
+            )
 
     def fields(self, type=None):
         if self.questions:

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -13,12 +13,12 @@ class ContentNotFoundError(Exception):
     pass
 
 
-class ContentBuilder(object):
+class ContentManifest(object):
     """An ordered set of sections each made up of one or more questions.
 
     Example::
         # Get hold of a section
-        content = ContentBuilder(sections)
+        content = ContentManifest(sections)
         section = content.get_section(section_id)
 
         # Extract data from form data
@@ -76,7 +76,7 @@ class ContentBuilder(object):
         return self.get_next_section_id(section_id, True)
 
     def filter(self, service_data):
-        """Return a new :class:`ContentBuilder` filtered by service data
+        """Return a new :class:`ContentManifest` filtered by service data
 
         Only includes the questions that should be shown for the provided
         service data. This is calculated by resolving the dependencies
@@ -86,7 +86,7 @@ class ContentBuilder(object):
             for section in self.sections
         ])
 
-        return ContentBuilder(sections)
+        return ContentManifest(sections)
 
     def _get_section_filtered_by(self, section, service_data):
         section = section.copy()
@@ -390,7 +390,7 @@ class ContentLoader(object):
         try:
             if framework_slug not in self._content:
                 raise KeyError
-            return ContentBuilder(self._content[framework_slug][manifest])
+            return ContentManifest(self._content[framework_slug][manifest])
         except KeyError:
             raise ContentNotFoundError("Content not found for {} and {}".format(framework_slug, manifest))
 

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -144,15 +144,16 @@ class ContentSection(object):
             return section.copy()
         else:
             return ContentSection(
-                id=section['slug'],
+                slug=section['slug'],
                 name=section['name'],
                 editable=section.get('editable'),
                 edit_questions=section.get('edit_questions'),
                 questions=[ContentQuestion(question) for question in section['questions']],
                 description=section.get('description'))
 
-    def __init__(self, id, name, editable, edit_questions, questions, description=None):
-        self.id = id
+    def __init__(self, slug, name, editable, edit_questions, questions, description=None):
+        self.id = slug  # TODO deprecated, use `.slug` instead
+        self.slug = slug
         self.name = name
         self.editable = editable
         self.edit_questions = edit_questions
@@ -164,7 +165,7 @@ class ContentSection(object):
 
     def copy(self):
         return ContentSection(
-            id=self.id,
+            slug=self.slug,
             name=self.name,
             editable=self.editable,
             edit_questions=self.edit_questions,
@@ -182,7 +183,7 @@ class ContentSection(object):
         if not question:
             return None
         return ContentSection(
-            id=question['slug'],
+            slug=question['slug'],
             name=question['question'],
             editable=self.edit_questions,
             edit_questions=False,

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -429,10 +429,14 @@ class ContentQuestionSummary(ContentQuestion):
 
     @property
     def value(self):
-        return self.service_data.get(self.id)
+        if self.questions:
+            return self.questions
+        return self.service_data.get(self.id, '')
 
     @property
     def answer_required(self):
+        if self.questions:
+            return any(question.answer_required for question in self.questions)
         if self.value in ['', [], None]:
             if not self.get('optional'):
                 return True

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -30,7 +30,7 @@ class ContentManifest(object):
         for section in self.sections:
             for question in section.questions:
                 question_index += 1
-                question['number'] = question_index
+                question.number = question_index
 
     def __iter__(self):
         return self.sections.__iter__()
@@ -131,7 +131,7 @@ class ContentSection(object):
                 id=section['slug'],
                 name=section['name'],
                 editable=section.get('editable'),
-                questions=section['questions'],
+                questions=[ContentQuestion(question) for question in section['questions']],
                 description=section.get('description'))
 
     def __init__(self, id, name, editable, questions, description=None):
@@ -356,6 +356,24 @@ class ContentSection(object):
         """Return True if a question has an assurance component"""
         question = self.get_question(key)
         return bool(question) and question.get('assuranceApproach', False)
+
+
+class ContentQuestion(object):
+    def __init__(self, data, number=None):
+        self.number = number
+        self.data = data
+
+    def get(self, key, default=None):
+        try:
+            return self.__getitem__(key)
+        except KeyError:
+            return default
+
+    def __getitem__(self, key):
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            return self.data[key]
 
 
 class ContentLoader(object):

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -172,8 +172,7 @@ class ContentSection(object):
 
     def get_question_ids(self, type=None):
         return [
-            question['id'] for question in self.questions
-            if type is None or question.get('type') == type
+            field for question in self.questions for field in question.fields(type)
         ]
 
     def get_data(self, form_data):
@@ -360,8 +359,20 @@ class ContentSection(object):
 
 class ContentQuestion(object):
     def __init__(self, data, number=None):
+        self.id = data['id']
+        self.type = data.get('type')
+        if 'questions' in data:
+            self.questions = [ContentQuestion(question) for question in data['questions']]
+        else:
+            self.questions = None
         self.number = number
         self.data = data
+
+    def fields(self, type=None):
+        if self.questions:
+            return [question['id'] for question in self.questions if type in [question.type, None]]
+        else:
+            return [self.id] if type in [self.type, None] else []
 
     def get(self, key, default=None):
         try:

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -488,8 +488,8 @@ class ContentLoader(object):
     >>> # preload messages
     >>> loader.load_messages('framework-1', ['homepage_sidebar', 'dashboard'])
     >>>
-    >>> # get a builder
-    >>> loader.get_builder('framework-1', 'manifest-1')
+    >>> # get a manifest
+    >>> loader.get_manifest('framework-1', 'manifest-1')
     >>>
     >>> # get a message
     >>> loader.get_message('framework-1', 'homepage_sidebar', 'in_review')
@@ -502,7 +502,7 @@ class ContentLoader(object):
         # A defaultdict that defaults to a defaultdict of dicts
         self._questions = defaultdict(partial(defaultdict, dict))
 
-    def get_builder(self, framework_slug, manifest):
+    def get_manifest(self, framework_slug, manifest):
         try:
             if framework_slug not in self._content:
                 raise KeyError
@@ -511,6 +511,8 @@ class ContentLoader(object):
             raise ContentNotFoundError("Content not found for {} and {}".format(framework_slug, manifest))
 
         return ContentManifest(manifest)
+
+    get_builder = get_manifest  # TODO remove once apps have switched to .get_manifest
 
     def load_manifest(self, framework_slug, question_set, manifest):
         if manifest not in self._content[framework_slug]:

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -9,6 +9,10 @@ from werkzeug.datastructures import ImmutableMultiDict
 from .config import convert_to_boolean, convert_to_number
 
 
+class ContentNotFoundError(Exception):
+    pass
+
+
 class ContentBuilder(object):
     """An ordered set of sections each made up of one or more questions.
 
@@ -354,19 +358,16 @@ class ContentSection(object):
         return bool(question) and question.get('assuranceApproach', False)
 
 
-class ContentNotFoundError(Exception):
-    pass
-
-
 class ContentLoader(object):
-    """
+    """Load the frameworks content files
+
     Usage:
     >>> loader = ContentLoader('path/to/digitalmarketplace-frameworks')
     >>> # pre-load manifests
-    >>> loader.load_manifest('framework-1', 'manifest-1', 'question-set-1')
-    >>> loader.load_manifest('framework-1', 'manifest-2', 'question-set-1')
-    >>> loader.load_manifest('framework-1', 'manifest-3', 'question-set-2')
-    >>> loader.load_manifest('framework-2', 'manifest-1', 'question-set-1')
+    >>> loader.load_manifest('framework-1', 'question-set-1', 'manifest-1')
+    >>> loader.load_manifest('framework-1', 'question-set-1', 'manifest-2')
+    >>> loader.load_manifest('framework-1', 'question-set-2', 'manifest-3')
+    >>> loader.load_manifest('framework-2', 'question-set-1', 'manifest-1')
     >>>
     >>> # preload messages
     >>> loader.load_messages('framework-1', ['homepage_sidebar', 'dashboard'])
@@ -376,6 +377,7 @@ class ContentLoader(object):
     >>>
     >>> # get a message
     >>> loader.get_message('framework-1', 'homepage_sidebar', 'in_review')
+
     """
     def __init__(self, content_path):
         self.content_path = content_path
@@ -424,9 +426,7 @@ class ContentLoader(object):
 
         return self._questions[framework_slug][question_set][question].copy()
 
-    def get_message(
-        self, framework_slug, block, framework_status, supplier_status=None
-    ):
+    def get_message(self, framework_slug, block, framework_status, supplier_status=None):
         if block not in self._messages[framework_slug]:
             raise ContentNotFoundError(
                 "Message file at {} not loaded".format(self._message_path(framework_slug, block))
@@ -436,9 +436,7 @@ class ContentLoader(object):
             self._message_key(framework_status, supplier_status), None
         )
 
-    def load_messages(
-        self, framework_slug, blocks
-    ):
+    def load_messages(self, framework_slug, blocks):
         if not isinstance(blocks, list):
             raise TypeError('Content blocks must be a list')
 
@@ -471,9 +469,7 @@ class ContentLoader(object):
         ]
         return section
 
-    def _message_key(
-        self, framework_status, supplier_status
-    ):
+    def _message_key(self, framework_status, supplier_status):
         return '{}{}'.format(
             framework_status,
             '-{}'.format(supplier_status) if supplier_status else ''

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -177,6 +177,19 @@ class ContentSection(object):
 
         return summary_section
 
+    def get_question_as_section(self, question_slug):
+        question = self.get_question_by_slug(question_slug)
+        if not question:
+            return None
+        return ContentSection(
+            id=question['slug'],
+            name=question['question'],
+            editable=self.edit_questions,
+            edit_questions=False,
+            questions=question.questions,
+            description=question.get('description')
+        )
+
     def get_field_names(self):
         """Return a list of field names that this section returns
 
@@ -319,6 +332,11 @@ class ContentSection(object):
             field_question = question.get_question(field_name)
             if field_question:
                 return field_question
+
+    def get_question_by_slug(self, question_slug):
+        for question in self.questions:
+            if question['slug'] == question_slug:
+                return question
 
     # Type checking
 

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -147,13 +147,15 @@ class ContentSection(object):
                 id=section['slug'],
                 name=section['name'],
                 editable=section.get('editable'),
+                edit_questions=section.get('edit_questions'),
                 questions=[ContentQuestion(question) for question in section['questions']],
                 description=section.get('description'))
 
-    def __init__(self, id, name, editable, questions, description=None):
+    def __init__(self, id, name, editable, edit_questions, questions, description=None):
         self.id = id
         self.name = name
         self.editable = editable
+        self.edit_questions = edit_questions
         self.questions = questions
         self.description = description
 
@@ -165,6 +167,7 @@ class ContentSection(object):
             id=self.id,
             name=self.name,
             editable=self.editable,
+            edit_questions=self.edit_questions,
             questions=self.questions[:],
             description=self.description)
 

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -184,7 +184,7 @@ class ContentSection(object):
             return None
         return ContentSection(
             slug=question.slug,
-            name=question.question,
+            name=question.label,
             editable=self.edit_questions,
             edit_questions=False,
             questions=question.questions,
@@ -409,6 +409,10 @@ class ContentQuestion(object):
         return {self.id: value}
 
     @property
+    def label(self):
+        return self.get('name') or self.question
+
+    @property
     def fields(self):
         if self.type == 'pricing':
             return PRICE_FIELDS
@@ -449,10 +453,6 @@ class ContentQuestionSummary(ContentQuestion):
         self.questions = question.questions
         if self.questions:
             self.questions = [q.summary(service_data) for q in self.questions]
-
-    @property
-    def label(self):
-        return self['question']
 
     @property
     def value(self):

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -353,7 +353,10 @@ class ContentQuestion(object):
         self._data = data.copy()
 
         if 'questions' in data:
-            self.questions = [ContentQuestion(question) for question in data['questions']]
+            self.questions = [
+                question if isinstance(question, ContentQuestion) else ContentQuestion(question)
+                for question in data['questions']
+            ]
         else:
             self.questions = None
 

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -4,3 +4,6 @@ mock==1.0.1
 requests-mock==0.6.0
 pep8==1.6.2
 freezegun==0.3.4
+coverage==3.7.1
+pytest-cov==2.2.0
+python-coveralls==2.5.0

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -17,5 +17,5 @@ function display_result {
 pep8 .
 display_result $? 1 "Code style check"
 
-py.test
+py.test $@
 display_result $? 2 "Unit tests"

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -487,6 +487,28 @@ class TestContentSection(object):
         })
         assert section.get_question_ids() == ['q1', 'q2']
 
+    def test_get_multiquestion_ids(self):
+        section = ContentSection.create({
+            "slug": "first_section",
+            "name": "First section",
+            "questions": [{
+                "id": "q0",
+                "question": "Boolean question",
+                "type": "Boolean question",
+                "questions": [
+                    {
+                        "id": "q2",
+                        "type": "text"
+                    },
+                    {
+                        "id": "q3",
+                        "type": "text"
+                    }
+                ]
+            }]
+        })
+        assert section.get_question_ids() == ['q2', 'q3']
+
     def test_get_question_ids_filtered_by_type(self):
         section = ContentSection.create({
             "slug": "first_section",

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -6,7 +6,7 @@ import pytest
 
 import io
 
-from dmutils.content_loader import ContentLoader, ContentSection, ContentBuilder, read_yaml, ContentNotFoundError
+from dmutils.content_loader import ContentLoader, ContentSection, ContentManifest, read_yaml, ContentNotFoundError
 
 from sys import version_info
 if version_info.major == 2:
@@ -15,15 +15,15 @@ else:
     import builtins
 
 
-class TestContentBuilder(object):
+class TestContentManifest(object):
     def test_content_builder_init(self):
-        content = ContentBuilder([])
+        content = ContentManifest([])
 
         assert content.sections == []
 
     def test_content_builder_init_copies_section_list(self):
         sections = []
-        content = ContentBuilder(sections)
+        content = ContentManifest(sections)
 
         sections.append('new')
         assert content.sections == []
@@ -36,12 +36,12 @@ class TestContentBuilder(object):
                 'questions': []
             }
 
-        content = ContentBuilder([section(1), section(2), section(3)])
+        content = ContentManifest([section(1), section(2), section(3)])
 
         assert [section.id for section in content] == [1, 2, 3]
 
     def test_a_question_with_a_dependency(self):
-        content = ContentBuilder([{
+        content = ContentManifest([{
             "id": "first_section",
             "name": "First section",
             "questions": [{
@@ -57,7 +57,7 @@ class TestContentBuilder(object):
         assert len(content.sections) == 1
 
     def test_missing_depends_key_filter(self):
-        content = ContentBuilder([{
+        content = ContentManifest([{
             "id": "first_section",
             "name": "First section",
             "questions": [{
@@ -73,7 +73,7 @@ class TestContentBuilder(object):
         assert len(content.sections) == 0
 
     def test_question_without_dependencies(self):
-        content = ContentBuilder([{
+        content = ContentManifest([{
             "id": "first_section",
             "name": "First section",
             "questions": [{
@@ -85,7 +85,7 @@ class TestContentBuilder(object):
         assert len(content.sections) == 1
 
     def test_a_question_with_a_dependency_that_doesnt_match(self):
-        content = ContentBuilder([{
+        content = ContentManifest([{
             "id": "first_section",
             "name": "First section",
             "questions": [{
@@ -101,7 +101,7 @@ class TestContentBuilder(object):
         assert len(content.sections) == 0
 
     def test_a_question_which_depends_on_one_of_several_answers(self):
-        content = ContentBuilder([{
+        content = ContentManifest([{
             "id": "first_section",
             "name": "First section",
             "questions": [{
@@ -119,7 +119,7 @@ class TestContentBuilder(object):
         assert len(content.filter({"lot": "SCS"}).sections) == 1
 
     def test_a_question_which_shouldnt_be_shown(self):
-        content = ContentBuilder([{
+        content = ContentManifest([{
             "id": "first_section",
             "name": "First section",
             "questions": [{
@@ -135,7 +135,7 @@ class TestContentBuilder(object):
         assert len(content.filter({"lot": "IaaS"}).sections) == 0
 
     def test_a_section_which_has_a_mixture_of_dependencies(self):
-        content = ContentBuilder([{
+        content = ContentManifest([{
             "id": "first_section",
             "name": "First section",
             "questions": [
@@ -161,7 +161,7 @@ class TestContentBuilder(object):
         assert len(content.sections) == 1
 
     def test_section_modification(self):
-        content = ContentBuilder([{
+        content = ContentManifest([{
             "id": "first_section",
             "name": "First section",
             "questions": [
@@ -190,7 +190,7 @@ class TestContentBuilder(object):
         assert len(content2.sections[0]["questions"]) == 1
 
     def test_that_filtering_is_cumulative(self):
-        content = ContentBuilder([{
+        content = ContentManifest([{
             "id": "first_section",
             "name": "First section",
             "questions": [
@@ -231,7 +231,7 @@ class TestContentBuilder(object):
         assert len(content.sections) == 0
 
     def test_get_section(self):
-        content = ContentBuilder([{
+        content = ContentManifest([{
             "id": "first_section",
             "name": "First section",
             "questions": [
@@ -252,7 +252,7 @@ class TestContentBuilder(object):
         assert content.get_section("first_section") is None
 
     def test_get_question(self):
-        content = ContentBuilder([
+        content = ContentManifest([
             {
                 "id": "first_section",
                 "name": "First section",
@@ -298,7 +298,7 @@ class TestContentBuilder(object):
         assert content.get_question('q1') is None
 
     def test_get_next_section(self):
-        content = ContentBuilder([
+        content = ContentManifest([
             {
                 "id": "first_section",
                 "name": "First section",
@@ -348,7 +348,7 @@ class TestContentBuilder(object):
             "second_section") == "third_section"
 
     def test_get_all_data(self):
-        content = ContentBuilder([
+        content = ContentManifest([
             {
                 "id": "first_section",
                 "name": "First section",
@@ -393,7 +393,7 @@ class TestContentBuilder(object):
         }
 
     def test_question_numbering(self):
-        content = ContentBuilder([
+        content = ContentManifest([
             {
                 "id": "first_section",
                 "name": "First section",
@@ -428,7 +428,7 @@ class TestContentBuilder(object):
         assert content.get_question("q3")['number'] == 3
 
     def test_question_numbers_respect_filtering(self):
-        content = ContentBuilder([
+        content = ContentManifest([
             {
                 "id": "first_section",
                 "name": "First section",
@@ -1117,7 +1117,7 @@ class TestContentLoader(object):
         yaml_loader.load_manifest('framework-slug', 'question-set', 'manifest')
 
         builder = yaml_loader.get_builder('framework-slug', 'manifest')
-        assert isinstance(builder, ContentBuilder)
+        assert isinstance(builder, ContentManifest)
 
         assert [
             section.id for section in builder.sections

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -966,6 +966,23 @@ class TestContentLoader(object):
         read_yaml_mock.assert_called_with(
             'content/frameworks/framework-slug/questions/question-set/question1.yml')
 
+    def test_get_question_loads_nested_questions(self, read_yaml_mock):
+        read_yaml_mock.side_effect = [
+            {"name": "question1", "type": "multiquestion", "questions": ["question10", "question20"]},
+            {"name": "question10", "type": "text"},
+            {"name": "question20", "type": "checkboxes"},
+        ]
+
+        yaml_loader = ContentLoader('content/')
+
+        assert yaml_loader.get_question('framework-slug', 'question-set', 'question1')
+
+        read_yaml_mock.assert_has_calls([
+            mock.call('content/frameworks/framework-slug/questions/question-set/question1.yml'),
+            mock.call('content/frameworks/framework-slug/questions/question-set/question10.yml'),
+            mock.call('content/frameworks/framework-slug/questions/question-set/question20.yml'),
+        ])
+
     def test_get_question_fails_if_question_cannot_be_read(self, read_yaml_mock):
         read_yaml_mock.side_effect = IOError
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -31,7 +31,7 @@ class TestContentManifest(object):
     def test_content_builder_iteration(self):
         def section(id):
             return {
-                'id': id,
+                'slug': id,
                 'name': 'name',
                 'questions': []
             }
@@ -42,7 +42,7 @@ class TestContentManifest(object):
 
     def test_a_question_with_a_dependency(self):
         content = ContentManifest([{
-            "id": "first_section",
+            "slug": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "q1",
@@ -58,7 +58,7 @@ class TestContentManifest(object):
 
     def test_missing_depends_key_filter(self):
         content = ContentManifest([{
-            "id": "first_section",
+            "slug": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "q1",
@@ -74,7 +74,7 @@ class TestContentManifest(object):
 
     def test_question_without_dependencies(self):
         content = ContentManifest([{
-            "id": "first_section",
+            "slug": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "q1",
@@ -86,7 +86,7 @@ class TestContentManifest(object):
 
     def test_a_question_with_a_dependency_that_doesnt_match(self):
         content = ContentManifest([{
-            "id": "first_section",
+            "slug": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "q1",
@@ -102,7 +102,7 @@ class TestContentManifest(object):
 
     def test_a_question_which_depends_on_one_of_several_answers(self):
         content = ContentManifest([{
-            "id": "first_section",
+            "slug": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "q1",
@@ -120,7 +120,7 @@ class TestContentManifest(object):
 
     def test_a_question_which_shouldnt_be_shown(self):
         content = ContentManifest([{
-            "id": "first_section",
+            "slug": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "q1",
@@ -136,7 +136,7 @@ class TestContentManifest(object):
 
     def test_a_section_which_has_a_mixture_of_dependencies(self):
         content = ContentManifest([{
-            "id": "first_section",
+            "slug": "first_section",
             "name": "First section",
             "questions": [
                 {
@@ -162,7 +162,7 @@ class TestContentManifest(object):
 
     def test_section_modification(self):
         content = ContentManifest([{
-            "id": "first_section",
+            "slug": "first_section",
             "name": "First section",
             "questions": [
                 {
@@ -191,7 +191,7 @@ class TestContentManifest(object):
 
     def test_that_filtering_is_cumulative(self):
         content = ContentManifest([{
-            "id": "first_section",
+            "slug": "first_section",
             "name": "First section",
             "questions": [
                 {
@@ -232,7 +232,7 @@ class TestContentManifest(object):
 
     def test_get_section(self):
         content = ContentManifest([{
-            "id": "first_section",
+            "slug": "first_section",
             "name": "First section",
             "questions": [
                 {
@@ -254,7 +254,7 @@ class TestContentManifest(object):
     def test_get_question(self):
         content = ContentManifest([
             {
-                "id": "first_section",
+                "slug": "first_section",
                 "name": "First section",
                 "questions": [{
                     "id": "q1",
@@ -266,7 +266,7 @@ class TestContentManifest(object):
                 }]
             },
             {
-                "id": "second_section",
+                "slug": "second_section",
                 "name": "Second section",
                 "questions": [{
                     "id": "q2",
@@ -278,7 +278,7 @@ class TestContentManifest(object):
                 }]
             },
             {
-                "id": "third_section",
+                "slug": "third_section",
                 "name": "Third section",
                 "editable": True,
                 "questions": [{
@@ -300,7 +300,7 @@ class TestContentManifest(object):
     def test_get_next_section(self):
         content = ContentManifest([
             {
-                "id": "first_section",
+                "slug": "first_section",
                 "name": "First section",
                 "questions": [{
                     "id": "q1",
@@ -312,7 +312,7 @@ class TestContentManifest(object):
                 }]
             },
             {
-                "id": "second_section",
+                "slug": "second_section",
                 "name": "Second section",
                 "questions": [{
                     "id": "q2",
@@ -324,7 +324,7 @@ class TestContentManifest(object):
                 }]
             },
             {
-                "id": "third_section",
+                "slug": "third_section",
                 "name": "Third section",
                 "editable": True,
                 "questions": [{
@@ -350,7 +350,7 @@ class TestContentManifest(object):
     def test_get_all_data(self):
         content = ContentManifest([
             {
-                "id": "first_section",
+                "slug": "first_section",
                 "name": "First section",
                 "questions": [{
                     "id": "q1",
@@ -359,7 +359,7 @@ class TestContentManifest(object):
                 }]
             },
             {
-                "id": "second_section",
+                "slug": "second_section",
                 "name": "Second section",
                 "questions": [{
                     "id": "q2",
@@ -368,7 +368,7 @@ class TestContentManifest(object):
                 }]
             },
             {
-                "id": "third_section",
+                "slug": "third_section",
                 "name": "Third section",
                 "questions": [{
                     "id": "q3",
@@ -395,7 +395,7 @@ class TestContentManifest(object):
     def test_question_numbering(self):
         content = ContentManifest([
             {
-                "id": "first_section",
+                "slug": "first_section",
                 "name": "First section",
                 "questions": [
                     {
@@ -411,7 +411,7 @@ class TestContentManifest(object):
                 ]
             },
             {
-                "id": "second_section",
+                "slug": "second_section",
                 "name": "Second section",
                 "questions": [
                     {
@@ -430,7 +430,7 @@ class TestContentManifest(object):
     def test_question_numbers_respect_filtering(self):
         content = ContentManifest([
             {
-                "id": "first_section",
+                "slug": "first_section",
                 "name": "First section",
                 "questions": [{
                     "id": "q1",
@@ -442,7 +442,7 @@ class TestContentManifest(object):
                 }]
             },
             {
-                "id": "second_section",
+                "slug": "second_section",
                 "name": "Second section",
                 "questions": [
                     {
@@ -473,7 +473,7 @@ class TestContentManifest(object):
 class TestContentSection(object):
     def test_get_question_ids(self):
         section = ContentSection.create({
-            "id": "first_section",
+            "slug": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "q1",
@@ -489,7 +489,7 @@ class TestContentSection(object):
 
     def test_get_question_ids_filtered_by_type(self):
         section = ContentSection.create({
-            "id": "first_section",
+            "slug": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "q1",
@@ -505,7 +505,7 @@ class TestContentSection(object):
 
     def test_get_data(self):
         section = ContentSection.create({
-            "id": "first_section",
+            "slug": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "q1",
@@ -623,7 +623,7 @@ class TestContentSection(object):
 
     def test_unformat_data(self):
         section = ContentSection.create({
-            "id": "first_section",
+            "slug": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "q1",
@@ -708,7 +708,7 @@ class TestContentSection(object):
 
     def test_get_question(self):
         section = ContentSection.create({
-            "id": "first_section",
+            "slug": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "q1",
@@ -724,7 +724,7 @@ class TestContentSection(object):
 
     def test_get_field_names_with_pricing_question(self):
         section = ContentSection.create({
-            "id": "first_section",
+            "slug": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "q1",
@@ -737,7 +737,7 @@ class TestContentSection(object):
 
     def test_get_field_names_with_no_pricing_question(self):
         section = ContentSection.create({
-            "id": "second_section",
+            "slug": "second_section",
             "name": "Second section",
             "questions": [{
                 "id": "q2",
@@ -750,7 +750,7 @@ class TestContentSection(object):
 
     def test_has_changes_to_save_no_changes(self):
         section = ContentSection.create({
-            "id": "second_section",
+            "slug": "second_section",
             "name": "Second section",
             "questions": [{
                 "id": "q2",
@@ -762,7 +762,7 @@ class TestContentSection(object):
 
     def test_hash_changes_to_save_field_different(self):
         section = ContentSection.create({
-            "id": "second_section",
+            "slug": "second_section",
             "name": "Second section",
             "questions": [{
                 "id": "q2",
@@ -774,7 +774,7 @@ class TestContentSection(object):
 
     def test_has_changes_to_save_field_not_set_on_service(self):
         section = ContentSection.create({
-            "id": "second_section",
+            "slug": "second_section",
             "name": "Second section",
             "questions": [{
                 "id": "q2",
@@ -786,7 +786,7 @@ class TestContentSection(object):
 
     def test_get_error_message(self):
         section = ContentSection.create({
-            "id": "second_section",
+            "slug": "second_section",
             "name": "Second section",
             "questions": [{
                 "id": "q2",
@@ -802,7 +802,7 @@ class TestContentSection(object):
 
     def test_get_error_message_returns_default(self):
         section = ContentSection.create({
-            "id": "second_section",
+            "slug": "second_section",
             "name": "Second section",
             "questions": [{
                 "id": "q2",
@@ -818,7 +818,7 @@ class TestContentSection(object):
 
     def test_get_error_messages(self):
         section = ContentSection.create({
-            "id": "second_section",
+            "slug": "second_section",
             "name": "Second section",
             "questions": [{
                 "id": "q2",
@@ -867,7 +867,7 @@ class TestContentSection(object):
 
     def test_section_description(self):
         section = ContentSection.create({
-            "id": "first_section",
+            "slug": "first_section",
             "name": "First section",
             "questions": [],
             "description": "This is the first section"
@@ -927,7 +927,7 @@ class TestContentLoader(object):
                      'name': 'question1', 'id': 'question1'},
                     {'depends': [{'being': 'SaaS', 'on': 'lot'}],
                      'name': 'question2', 'id': 'question2'}],
-                'id': 'section1'}
+                'slug': 'section1'}
         ]
         read_yaml_mock.assert_has_calls([
             mock.call('content/frameworks/framework-slug/manifests/my-manifest.yml'),

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -509,6 +509,47 @@ class TestContentSection(object):
         })
         assert section.get_question_ids() == ['q2', 'q3']
 
+    def test_get_question_as_section(self):
+        section = ContentSection.create({
+            "slug": "first_section",
+            "edit_questions": False,
+            "name": "First section",
+            "questions": [{
+                "id": "q0",
+                "slug": "q0-slug",
+                "question": "Q0",
+                "type": "multiquestion",
+                "questions": [
+                    {
+                        "id": "q2",
+                        "type": "text"
+                    },
+                    {
+                        "id": "q3",
+                        "type": "text"
+                    }
+                ]
+            }]
+        })
+
+        question_section = section.get_question_as_section('q0-slug')
+        assert question_section.name == "Q0"
+        assert question_section.editable == section.edit_questions
+        assert question_section.get_question_ids() == ['q2', 'q3']
+
+    def test_get_question_as_section_missing_question(self):
+        section = ContentSection.create({
+            "slug": "first_section",
+            "name": "First section",
+            "questions": [{
+                "id": "q0",
+                "question": "Q0",
+            }]
+        })
+
+        question_section = section.get_question_as_section('q0-slug')
+        assert question_section is None
+
     def test_get_question_ids_filtered_by_type(self):
         section = ContentSection.create({
             "slug": "first_section",

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -38,7 +38,7 @@ class TestContentManifest(object):
 
         content = ContentManifest([section(1), section(2), section(3)])
 
-        assert [section.id for section in content] == [1, 2, 3]
+        assert [s.id for s in content] == [1, 2, 3]
 
     def test_a_question_with_a_dependency(self):
         content = ContentManifest([{
@@ -250,6 +250,38 @@ class TestContentManifest(object):
 
         content = content.filter({"lot": "IaaS"})
         assert content.get_section("first_section") is None
+
+    def test_summary(self):
+        content = ContentManifest([{
+            "slug": "first_section",
+            "name": "First section",
+            "questions": [
+                {
+                    "id": "q1",
+                    "question": 'First question',
+                    "questions": [
+                        {"id": "q2", "type": "text"},
+                        {"id": "q3", "type": "text"}
+                    ]
+                },
+                {"id": "q4", "type": "text", "optional": True},
+                {"id": "q5", "type": "text", "optional": False},
+                {"id": "q6", "type": "text", "optional": False},
+            ]
+        }])
+
+        summary = content.summary({'q2': 'some value', 'q6': 'another value'})
+        assert summary.get_question('q1').value == [
+            summary.get_question('q2'), summary.get_question('q3')
+        ]
+        assert summary.get_question('q1').answer_required
+        assert summary.get_question('q2').value == 'some value'
+        assert not summary.get_question('q2').answer_required
+        assert summary.get_question('q3').answer_required
+        assert summary.get_question('q4').value == ''
+        assert not summary.get_question('q4').answer_required
+        assert summary.get_question('q5').answer_required
+        assert not summary.get_question('q6').answer_required
 
     def test_get_question(self):
         content = ContentManifest([

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1238,13 +1238,13 @@ class TestContentLoader(object):
         with pytest.raises(ContentNotFoundError):
             messages.load_messages('not-a-framework', ['index'])
 
-    def test_get_builder(self, read_yaml_mock):
+    def test_get_manifest(self, read_yaml_mock):
         self.set_read_yaml_mock_response(read_yaml_mock)
 
         yaml_loader = ContentLoader('content/')
         yaml_loader.load_manifest('framework-slug', 'question-set', 'manifest')
 
-        builder = yaml_loader.get_builder('framework-slug', 'manifest')
+        builder = yaml_loader.get_manifest('framework-slug', 'manifest')
         assert isinstance(builder, ContentManifest)
 
         assert [
@@ -1257,12 +1257,12 @@ class TestContentLoader(object):
         yaml_loader = ContentLoader('content/')
         yaml_loader.load_manifest('framework-slug', 'question-set', 'manifest')
 
-        builder1 = yaml_loader.get_builder('framework-slug', 'manifest')
-        builder2 = yaml_loader.get_builder('framework-slug', 'manifest')
+        builder1 = yaml_loader.get_manifest('framework-slug', 'manifest')
+        builder2 = yaml_loader.get_manifest('framework-slug', 'manifest')
 
         assert builder1 != builder2
 
-    def test_get_builder_fails_if_manifest_has_not_been_loaded(self, read_yaml_mock):
+    def test_get_manifest_fails_if_manifest_has_not_been_loaded(self, read_yaml_mock):
         with pytest.raises(ContentNotFoundError):
             yaml_loader = ContentLoader('content/')
-            yaml_loader.get_builder('framework-slug', 'manifest')
+            yaml_loader.get_manifest('framework-slug', 'manifest')

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -530,6 +530,12 @@ class TestContentSection(object):
             "slug": "first_section",
             "name": "First section",
             "questions": [{
+                "id": "q0",
+                "questions": [
+                    {"id": "q01", "type": "text"},
+                    {"id": "q02", "type": "radios"}
+                ]
+            }, {
                 "id": "q1",
                 "question": "Boolean question",
                 "type": "boolean",
@@ -579,6 +585,7 @@ class TestContentSection(object):
 
         form = ImmutableMultiDict([
             ('q1', 'true'),
+            ('q01', 'some nested question'),
             ('q2', 'Some text stuff'),
             ('q3', 'value'),
             ('q3', 'Should be lost'),
@@ -602,6 +609,7 @@ class TestContentSection(object):
         data = section.get_data(form)
 
         assert data == {
+            'q01': 'some nested question',
             'q1': True,
             'q2': 'Some text stuff',
             'q3': 'value',
@@ -648,6 +656,12 @@ class TestContentSection(object):
             "slug": "first_section",
             "name": "First section",
             "questions": [{
+                "id": "q0",
+                "questions": [
+                    {"id": "q01", "type": "text"},
+                    {"id": "q02", "type": "radios"}
+                ]
+            }, {
                 "id": "q1",
                 "question": "Boolean question",
                 "type": "boolean",
@@ -696,6 +710,7 @@ class TestContentSection(object):
         })
 
         data = {
+            'q01': 'q01 value',
             'q1': True,
             'q2': 'Some text stuff',
             'q3': 'value',
@@ -713,6 +728,7 @@ class TestContentSection(object):
         form = section.unformat_data(data)
 
         assert form == {
+            'q01': 'q01 value',
             'q1': True,
             'q2': 'Some text stuff',
             'q3': 'value',

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -203,7 +203,7 @@ class TestUploadDocument(unittest.TestCase):
 class TestUploadServiceDocuments(object):
     def setup(self):
         self.section = ContentSection.create({
-            "id": "first_section",
+            "slug": "first_section",
             "name": "First section",
             "questions": [{
                 "id": "pricingDocumentURL",


### PR DESCRIPTION
### Rename ContentBuilder to ContentManifest
Class name is not used outside `dmutils` and `ContentManifest` feels
like a more descriptive name, especially since `ContentSection` was
added.

### Add support for loading nested questions
Reuses the existing section loading to load `questions:` for question
files. Since the original function also added an `id` to the section
and we need a way to create URLs addressing `multiquestions` we kept
the existing logic but replaced `id` key with `slug` to differentiate
between addressable and non-addressable questions.

Section `slug` is only used internally for now: once section data is
transformed into `ContentSection` instance it can be addressed as
`section.id`. Since renaming it is a breaking change it's kept as
TODO for now. Questions should use `.slug` for URL referencing.

### Add ContentQuestionSummary to replace service_attribute
Adds a new class for a question containing a reference to the service
data. This allows adding additional methods to the question: `.value`
and `.answer_required`.

`ContentQuestionSummary` instances are created by calling `.summary`
on manifest or section objects, which returns a copy of the object
with all questions transformed to `ContentQuestionSummary` instances.

This replaces `service_attribute.Attribute` class and removes the need
for creating section look-alike dictionaries with "rows" key for summary
table display since ordinary section objects can be used instead and
there's no need to propagate the changes in section attributes.

### Add support for individually editable questions
Adds a helper method that allows returning a multiquestion question
as a section object containing all the nested questions. Parent
section `edit_questions` is stored to the new `section.edtiable`
so we can reuse the existing write protection/display section logic.

### Allow access to question data keys as attributes on ContentQuestion
Similar to ContentSection we want to access question keys as
attributes. Since questions have a lot of keys, instead of listing
them in the constructor arguments we just set __getattr__ to continue
attribute lookup in _data dictionary keys.

### Use question.name or .question as ContentQuestion.label
Question content 'name' key can be used for short question names to
be displayed in the summary tables instead of the full question.

ContentQuestion.label attribute is now present on all questions and will
try to use name instead of `question` if set.