### PR TITLE
Fix README badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Digital Marketplace utils
 =========================
 
-[![Coverage Status](https://coveralls.io/repos/alphagov/digitalmarketplace-utils/badge.svg?branch=multiquestion-questions&service=github)](https://coveralls.io/github/alphagov/digitalmarketplace-utils?branch=multiquestion-questions)
-[![Requirements Status](https://requires.io/github/alphagov/digitalmarketplace-utils/requirements.svg?branch=multiquestion-questions)](https://requires.io/github/alphagov/digitalmarketplace-utils/requirements/?branch=multiquestion-questions)
+[![Coverage Status](https://coveralls.io/repos/alphagov/digitalmarketplace-utils/badge.svg?branch=master&service=github)](https://coveralls.io/github/alphagov/digitalmarketplace-utils?branch=master)
+[![Requirements Status](https://requires.io/github/alphagov/digitalmarketplace-utils/requirements.svg?branch=master)](https://requires.io/github/alphagov/digitalmarketplace-utils/requirements/?branch=master)
 
 ## What's in here?
 


### PR DESCRIPTION
Badge URLs pointed to a PR branch instead of master