### PR TITLE
Rename `fields` property in ContentQuestion.

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '14.0.0'
+__version__ = '14.0.1'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -200,12 +200,12 @@ class ContentSection(object):
         """
 
         return [
-            field for question in self.questions for field in question.fields
+            form_field for question in self.questions for form_field in question.form_fields
         ]
 
     def get_question_ids(self, type=None):
         return [
-            field for question in self.questions for field in question.get_question_ids(type)
+            form_field for question in self.questions for form_field in question.get_question_ids(type)
         ]
 
     def get_data(self, form_data):
@@ -416,7 +416,7 @@ class ContentQuestion(object):
         return self.get('name') or self.question
 
     @property
-    def fields(self):
+    def form_fields(self):
         if self.type == 'pricing':
             return PRICE_FIELDS
         else:


### PR DESCRIPTION
Some of our questions' .yml descriptions contain [a `fields` key](https://github.com/alphagov/digitalmarketplace-frameworks/blob/master/frameworks/digital-outcomes-and-specialists/questions/services/agileCoachDayRate.yml) which was being overwritten by the `fields` property in ContentQuestion.  

Renaming `fields` -> `form_fields` should fix it.