### PR TITLE
Add method to get question by slug from a manifest

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '14.0.1'
+__version__ = '14.1.0'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -136,6 +136,12 @@ class ContentManifest(object):
             if question:
                 return question
 
+    def get_question_by_slug(self, question_slug):
+        for section in self.sections:
+            question = section.get_question_by_slug(question_slug)
+            if question:
+                return question
+
 
 class ContentSection(object):
     @classmethod

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -329,6 +329,42 @@ class TestContentManifest(object):
         content = content.filter({'lot': 'IaaS'})
         assert content.get_question('q1') is None
 
+    def test_get_question_by_slug(self):
+        content = ContentManifest([
+            {
+                "slug": "first_section",
+                "name": "First section",
+                "questions": [{
+                    "id": "q1",
+                    "type": "multiquestion",
+                    "question": 'Section one question',
+                    "slug": "section-one-question",
+                    "questions": [{"id": "sec1One"}, {"id": "sec1Two"}],
+                    "depends": [{
+                        "on": "lot",
+                        "being": ["digital-specialists"]
+                    }]
+                }]
+            },
+            {
+                "slug": "second_section",
+                "name": "Second section",
+                "questions": [{
+                    "id": "q2",
+                    "type": "multiquestion",
+                    "question": 'Section two question',
+                    "slug": "section-two-question",
+                    "questions": [{"id": "sec2One"}, {"id": "sec2Two"}],
+                    "depends": [{
+                        "on": "lot",
+                        "being": ["digital-specialists"]
+                    }]
+                }]
+            }
+        ])
+
+        assert content.get_question_by_slug('section-two-question').get('id') == 'q2'
+
     def test_get_next_section(self):
         content = ContentManifest([
             {


### PR DESCRIPTION
There is already a method to get a question by slug from a section, but it is useful to be able to do this at the manifest level too - this avoids having to pass section IDs as well as question slugs into views that deal with subsections.