### PR TITLE
Multiquestion validation related fixes

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '15.0.0'
+__version__ = '15.1.0'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -274,7 +274,7 @@ class ContentSection(object):
 
             errors_map[error_key] = {
                 'input_name': field_name,
-                'question': question['question'],
+                'question': question.label,
                 'message': validation_message,
             }
         return errors_map

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -253,7 +253,7 @@ class ContentSection(object):
         """
         return any([
             any(service.get(key) != update_data[key] for key in update_data),
-            any(question.id not in service for question in self.questions)
+            any(form_field not in service for form_field in self.get_field_names())
         ])
 
     def get_error_messages(self, errors, lot):

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -197,7 +197,7 @@ class ContentSection(object):
             editable=self.edit_questions,
             edit_questions=False,
             questions=question.questions,
-            description=question.get('description')
+            description=question.get('hint')
         )
 
     def get_field_names(self):

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -511,13 +511,12 @@ class ContentQuestionSummary(ContentQuestion):
 
     @property
     def answer_required(self):
-        if self.questions:
-            return any(question.answer_required for question in self.questions)
-        elif self.value in ['', [], None]:
-            if not self.get('optional'):
-                return True
-        else:
+        if self.get('optional'):
             return False
+        elif self.questions:
+            return any(question.answer_required for question in self.questions)
+        else:
+            return self.is_empty
 
 
 class ContentLoader(object):

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -378,6 +378,8 @@ class ContentQuestion(object):
         if self.id not in form_data:
             if self.get('assuranceApproach') and '{}--assurance'.format(self.id) in form_data:
                 return {self.id: {'assurance': form_data.get('{}--assurance'.format(self.id))}}
+            elif self.type in ['list', 'checkboxes']:
+                return {self.id: []}
             else:
                 return {}
 

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -486,9 +486,13 @@ class ContentQuestionSummary(ContentQuestion):
         return self.get('field_defaults', {}).get(field_key)
 
     @property
+    def is_empty(self):
+        return self.value in ['', [], None]
+
+    @property
     def value(self):
         if self.questions:
-            return self.questions
+            return [question for question in self.questions if not question.is_empty]
         if self.type == "pricing":
             minimum_price = self._service_data.get(self.fields.get('minimum_price'))
             maximum_price = self._service_data.get(self.fields.get('maximum_price'))

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -302,7 +302,7 @@ class TestContentManifest(object):
             'q7.min': '10',
             'q7.unit': 'day'})
         assert summary.get_question('q1').value == [
-            summary.get_question('q2'), summary.get_question('q3')
+            summary.get_question('q2')
         ]
         assert summary.get_question('q1').answer_required
         assert summary.get_question('q2').value == 'some value'

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1043,6 +1043,7 @@ class TestContentSection(object):
             "questions": [{
                 "id": "q2",
                 "question": "Second question",
+                "name": "second",
                 "type": "text",
                 "validations": [
                     {'name': 'the_error', 'message': 'This is the error message'},
@@ -1089,6 +1090,7 @@ class TestContentSection(object):
 
         assert result['priceString']['message'] == "No min price"
         assert result['q2']['message'] == "This is the error message"
+        assert result['q2']['question'] == "second"
         assert result['q3--assurance']['message'] == "There there, it'll be ok."
         assert result['serviceTypes']['message'] == "This is the error message"
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -630,6 +630,7 @@ class TestContentSection(object):
                 "slug": "q0-slug",
                 "question": "Q0",
                 "type": "multiquestion",
+                "hint": "Some description",
                 "questions": [
                     {
                         "id": "q2",
@@ -645,6 +646,7 @@ class TestContentSection(object):
 
         question_section = section.get_question_as_section('q0-slug')
         assert question_section.name == "Q0"
+        assert question_section.description == "Some description"
         assert question_section.editable == section.edit_questions
         assert question_section.get_question_ids() == ['q2', 'q3']
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -292,7 +292,16 @@ class TestContentManifest(object):
                     "optional_fields": [
                         "maximum_price"
                     ]
-                }
+                },
+                {
+                    "id": "q9",
+                    "question": 'Never required question',
+                    "optional": True,
+                    "questions": [
+                        {"id": "q71", "type": "text"},
+                        {"id": "q72", "type": "text"}
+                    ]
+                },
             ]
         }])
 
@@ -315,6 +324,7 @@ class TestContentManifest(object):
         assert summary.get_question('q7').value == u'£10 per day'
         assert not summary.get_question('q7').answer_required
         assert summary.get_question('q8').answer_required
+        assert not summary.get_question('q9').answer_required
 
     def test_get_question(self):
         content = ContentManifest([

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -789,6 +789,8 @@ class TestContentSection(object):
         ])
         data = section.get_data(form)
         assert data == {
+            'q4': [],
+            'q5': [],
             'q6': {'assurance': 'yes I am'},
         }
 


### PR DESCRIPTION
### Only return non-empty questions for multiquestion .value
Filters out empty questions from multiquestion .value. This makes
it easier to check whether `empty_message` should be displayed
by checking if the multiquestion is empty (which is true only if
all nested question are empty).

### Send empty list value to the API for list/checkbox questions
New JSON schemas always define minItems for checkbox/list questions.
Since questions can be required to have a value even if the field name
is not listed in the schema required keys (e.g. questions that are part
of a multiquestions and have to be answered if any other related
question was answered) we can no longer send empty update to the API and
rely on the API returning an error based on mismatch between required
and request page_questions.

Instead, for list and checkbox questions we send the empty list value to
the API, so that it's validated against the `minItems` requirement.

### Set `answer_required=False` for optional multiquestions
If a question is optional `answer_required` message should never
be displayed, even if nested questions don't specify the optional
flag.

### Use question.hint as question_as_section description
Since 'description' is not a defined field on question content data
we use question hint instead

### Use question.form_fields for section.has_changes_to_save check
`question.id` no longer represents the service data fields writable
by the question, so there's a chance of missing answer required
API errors by not sending the update to the API or submitting the
same data as an update for sections with question.ids that don't
match any service data fields