### PR TITLE
Raise error on unrecognised error key

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '15.1.0'
+__version__ = '15.2.0'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -16,6 +16,10 @@ class ContentNotFoundError(Exception):
     pass
 
 
+class QuestionNotFoundError(Exception):
+    pass
+
+
 class ContentManifest(object):
     """An ordered set of sections each made up of one or more questions.
 
@@ -266,6 +270,8 @@ class ContentSection(object):
         errors_map = {}
         for field_name, message_key in errors.items():
             question = self.get_question(field_name)
+            if not question:
+                raise QuestionNotFoundError(field_name)
             validation_message = question.get_error_message(message_key, field_name)
 
             error_key = question.id

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -8,7 +8,7 @@ import io
 
 from dmutils.content_loader import (
     ContentLoader, ContentSection, ContentQuestion, ContentManifest,
-    read_yaml, ContentNotFoundError
+    read_yaml, ContentNotFoundError, QuestionNotFoundError
 )
 
 from sys import version_info
@@ -1093,6 +1093,19 @@ class TestContentSection(object):
         assert result['q2']['question'] == "second"
         assert result['q3--assurance']['message'] == "There there, it'll be ok."
         assert result['serviceTypes']['message'] == "This is the error message"
+
+    def test_get_error_messages_with_unknown_error_key(self):
+        section = ContentSection.create({
+            "slug": "second_section",
+            "name": "Second section",
+            "questions": []
+        })
+        errors = {
+            "q1": "the_error"
+        }
+
+        with pytest.raises(QuestionNotFoundError):
+            section.get_error_messages(errors, "SCS")
 
     def test_section_description(self):
         section = ContentSection.create({


### PR DESCRIPTION
If an unrecognised error key is returned from the API then we should
raise an exception as it implies a form error.