### PR TITLE
Remove empty fields

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '15.4.0'
+__version__ = '15.5.0'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -373,7 +373,7 @@ class ContentQuestion(object):
     def get_data(self, form_data):
         if self.fields:
             return {
-                key: form_data[key]
+                key: form_data[key] if form_data[key] else None
                 for key in self.fields.values()
                 if key in form_data
             }
@@ -411,7 +411,7 @@ class ContentQuestion(object):
                 "assurance": form_data.get(self.id + '--assurance'),
             }
 
-        return {self.id: value}
+        return {self.id: value if value else None}
 
     def get_error_message(self, message_key, field_name=None):
         """Return a single error message.

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -811,6 +811,12 @@ class TestContentSection(object):
             'q6': {'assurance': 'yes I am'},
         }
 
+        # Test empty lists are not converted to `None`
+        form = ImmutableMultiDict([
+            ('q4', '')
+        ])
+        assert section.get_data(form)['q4'] == ['']
+
     def test_unformat_data(self):
         section = ContentSection.create({
             "slug": "first_section",

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -740,6 +740,10 @@ class TestContentSection(object):
                 "id": "q11",
                 "question": "Text question",
                 "type": "text"
+            }, {
+                "id": "q12",
+                "question": "Text question",
+                "type": "text"
             }]
         })
 
@@ -756,14 +760,14 @@ class TestContentSection(object):
             ('q6', '71234567890'),
             ('q6--assurance', 'yes I am'),
             ('q7-min_price', '12.12'),
-            ('q7-max_price', '13.13'),
+            ('q7-max_price', ''),
             ('q7-price_unit', 'Unit'),
             ('q7-price_interval', 'Hour'),
             ('q8', 'blah blah'),
             ('q9', '12.12'),
             ('q10', 'Looooooooaaaaaaaaads of text'),
             ('extra_field', 'Should be lost'),
-            ('q12', 'Should be lost'),
+            ('q12', ''),
         ])
 
         data = section.get_data(form)
@@ -777,11 +781,12 @@ class TestContentSection(object):
             'q5': ['check 1', 'check 2'],
             'q6': {'assurance': 'yes I am', 'value': '71234567890'},
             'q7-min_price': '12.12',
-            'q7-max_price': '13.13',
+            'q7-max_price': None,
             'q7-price_unit': 'Unit',
             'q7-price_interval': 'Hour',
             'q9': 12.12,
             'q10': 'Looooooooaaaaaaaaads of text',
+            'q12': None,
         }
 
         # Failure modes


### PR DESCRIPTION
When getting data from a form with the content loader empty fields
should be replaced with None to cause the field to be removed in the
API. This means that the API will throw the correct error
(answer_required) when all types of field are not filled in.