### PR TITLE
Fix rendering assurance questions

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '15.6.0'
+__version__ = '15.6.1'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -333,7 +333,7 @@ class ContentSection(object):
     def _has_assurance(self, key):
         """Return True if a question has an assurance component"""
         question = self.get_question(key)
-        return bool(question) and question.get('assuranceApproach', False)
+        return bool(question) and question.has_assurance()
 
 
 class ContentQuestion(object):
@@ -459,6 +459,9 @@ class ContentQuestion(object):
         else:
             return []
 
+    def has_assurance(self):
+        return self.get('assuranceApproach', False)
+
     def get_question_ids(self, type=None):
         if self.questions:
             return [question.id for question in self.questions if type in [question.type, None]]
@@ -518,7 +521,16 @@ class ContentQuestionSummary(ContentQuestion):
                 return format_price(minimum_price, maximum_price, price_unit, price_interval)
             else:
                 return ''
+        if self.has_assurance():
+            return self._service_data.get(self.id, {}).get('value', '')
+
         return self._service_data.get(self.id, '')
+
+    @property
+    def assurance(self):
+        if self.has_assurance():
+            return self._service_data.get(self.id, {}).get('assurance', '')
+        return ''
 
     @property
     def answer_required(self):

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -460,7 +460,7 @@ class ContentQuestion(object):
             return []
 
     def has_assurance(self):
-        return self.get('assuranceApproach', False)
+        return True if self.get('assuranceApproach') else False
 
     def get_question_ids(self, type=None):
         if self.questions:

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -302,6 +302,13 @@ class TestContentManifest(object):
                         {"id": "q72", "type": "text"}
                     ]
                 },
+                {
+                    "id": "q10",
+                    "question": 'Are you sure you are assured?',
+                    'type': 'boolean',
+                    "optional": False,
+                    'assuranceApproach': '2answers-type1',
+                }
             ]
         }])
 
@@ -309,7 +316,11 @@ class TestContentManifest(object):
             'q2': 'some value',
             'q6': 'another value',
             'q7.min': '10',
-            'q7.unit': 'day'})
+            'q7.unit': 'day',
+            'q10': {'value': True, 'assurance': 'Service provider assertion'},
+            'q11': {'value': True}
+        })
+
         assert summary.get_question('q1').value == [
             summary.get_question('q2')
         ]
@@ -319,12 +330,15 @@ class TestContentManifest(object):
         assert summary.get_question('q3').answer_required
         assert summary.get_question('q4').value == ''
         assert not summary.get_question('q4').answer_required
+        assert summary.get_question('q4').assurance == ''  # question without assurance returns an empty string
         assert summary.get_question('q5').answer_required
         assert not summary.get_question('q6').answer_required
         assert summary.get_question('q7').value == u'£10 per day'
         assert not summary.get_question('q7').answer_required
         assert summary.get_question('q8').answer_required
         assert not summary.get_question('q9').answer_required
+        assert summary.get_question('q10').value is True
+        assert summary.get_question('q10').assurance == 'Service provider assertion'
 
     def test_get_question(self):
         content = ContentManifest([


### PR DESCRIPTION
This pull request fixes the rendering of any questions with assurances on our service summary screens.

After rewriting the content loader, some of the logic around questions' assurances went missing.  This meant that calling `question.value` and `question.assurance` stopped working in
our templates. 

Now, `ContentQuestionSummary` objects can once again return their question `value`s and (optional) `assurance` values correctly.

***

## Broken
![screen shot 2015-12-01 at 12 36 21](https://cloud.githubusercontent.com/assets/2454380/11531035/9def8c06-98f1-11e5-81a0-9dde94c2efb2.png)

## Fixed
![screen shot 2015-12-02 at 14 42 31](https://cloud.githubusercontent.com/assets/2454380/11533697/fad6dfa8-9902-11e5-9cfe-ccb833518569.png)