### PR TITLE
Do not require a key for ContentLoader.get_message

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '15.5.0'
+__version__ = '15.6.0'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -605,7 +605,7 @@ class ContentLoader(object):
 
         return self._questions[framework_slug][question_set][question].copy()
 
-    def get_message(self, framework_slug, block, key, sub_key=None):
+    def get_message(self, framework_slug, block, key=None, sub_key=None):
         """
         `block` corresponds to
           - a file in the frameworks directory
@@ -620,10 +620,12 @@ class ContentLoader(object):
             raise ContentNotFoundError(
                 "Message file at {} not loaded".format(self._message_path(framework_slug, block))
             )
-
-        return self._messages[framework_slug][block].get(
-            self._message_key(key, sub_key), None
-        )
+        if key is not None:
+            return self._messages[framework_slug][block].get(
+                self._message_key(key, sub_key), None
+            )
+        else:
+            return self._messages[framework_slug][block]
 
     def load_messages(self, framework_slug, blocks):
         if not isinstance(blocks, list):

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1411,6 +1411,20 @@ class TestContentLoader(object):
         }
         mock_read_yaml.assert_called_with('content/frameworks/g-cloud-7/messages/index.yml')
 
+    def test_get_message_with_no_key(self, mock_read_yaml):
+        mock_read_yaml.return_value = {
+            'field_one': 'value_one',
+            'field_two': 'value_two',
+        }
+        messages = ContentLoader('content/')
+        messages.load_messages('g-cloud-7', ['index'])
+
+        assert messages.get_message('g-cloud-7', 'index') == {
+            'field_one': 'value_one',
+            'field_two': 'value_two',
+        }
+        assert messages.get_message('g-cloud-7', 'index', 'field_one') == 'value_one'
+
     def test_load_message_argument_types(self, mock_read_yaml):
 
         mock_read_yaml.return_value = {}


### PR DESCRIPTION
The dates messages is just a flat mapping so it is easier to just return the whole thing.