### PR TITLE
Fix error labels order and price fields links

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '15.6.1'
+__version__ = '15.7.0'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -284,7 +284,7 @@ class ContentSection(object):
                 error_key = '{}--assurance'.format(error_key)
 
             errors_map[error_key] = {
-                'input_name': field_name,
+                'input_name': error_key,
                 'question': question.label,
                 'message': validation_message,
             }

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1101,14 +1101,18 @@ class TestContentSection(object):
                 "validations": [
                     {"name": "assurance_required", "message": "There there, it'll be ok."},
                 ]
+            }, {
+                "id": "q4",
+                "question": "No Errors",
+                "type": "text"
             }]
         })
 
         errors = {
             "q2": "the_error",
+            "q3": "assurance_required",
             "serviceTypes": "the_error",
             "priceString-min": "answer_required",
-            "q3": "assurance_required",
         }
 
         result = section.get_error_messages(errors, 'SCS')
@@ -1118,6 +1122,10 @@ class TestContentSection(object):
         assert result['q2']['question'] == "second"
         assert result['q3--assurance']['message'] == "There there, it'll be ok."
         assert result['serviceTypes']['message'] == "This is the error message"
+
+        assert result["priceString"]["input_name"] == "priceString"
+
+        assert list(result.keys()) == ["q2", "serviceTypes", "priceString", "q3--assurance"]
 
     def test_get_error_messages_with_unknown_error_key(self):
         section = ContentSection.create({


### PR DESCRIPTION
### Fix pricing field error label not linking to the form
[#109072494](https://www.pivotaltracker.com/story/show/109072494)

Toolkit forms use question IDs for linking to the question input.
This is the same for multi-field questions: instead of using the
field name for priceMax/priceMin we should use the parent quesiton
id.

### Sort form errors to match the question order
errors_map is sorted according to the question order within the
section.

Returns an OrderedDict to preserve the question order since frontend
templates expect errors to be a dictionary.

### Move get_error_messages logic to the ContentQuestion
Similar to `.get_data`, `.get_error_messages` for individual quesiton
should be the responsibility of the question class, so we move the
logic to `ContentQuestion.get_error_messages`.

In order to check that the API didn't return any errors that don't
belong to the current section we compare the error fields with the
list of section fields, and if there are any errors that are not
part of the current section question we raise an exception.

This also takes care of ordering the errors to  match the question
order without sorting since the initial iteration is based on
section question order.