### PR TITLE
Do not convert boolean false to None

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '15.7.0'
+__version__ = '15.7.1'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -381,7 +381,7 @@ class ContentQuestion(object):
             if self.get('assuranceApproach') and '{}--assurance'.format(self.id) in form_data:
                 return {self.id: {'assurance': form_data.get('{}--assurance'.format(self.id))}}
             elif self.type in ['list', 'checkboxes']:
-                return {self.id: []}
+                return {self.id: None}
             else:
                 return {}
 

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -402,7 +402,10 @@ class ContentQuestion(object):
                 "assurance": form_data.get(self.id + '--assurance'),
             }
 
-        return {self.id: value if value else None}
+        if self.type != 'boolean':
+            value = value if value else None
+
+        return {self.id: value}
 
     def get_error_messages(self, errors):
         error_fields = set(errors.keys()) & set(self.form_fields)

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -825,8 +825,8 @@ class TestContentSection(object):
         ])
         data = section.get_data(form)
         assert data == {
-            'q4': [],
-            'q5': [],
+            'q4': None,
+            'q5': None,
             'q6': {'assurance': 'yes I am'},
         }
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -810,6 +810,11 @@ class TestContentSection(object):
         assert section.get_data(form)['q1'] == 'not boolean'
 
         form = ImmutableMultiDict([
+            ('q1', 'false')
+        ])
+        assert section.get_data(form)['q1'] is False
+
+        form = ImmutableMultiDict([
             ('q9', 'not a number')
         ])
         assert section.get_data(form)['q9'] == 'not a number'


### PR DESCRIPTION
This fixes a bug where selecting 'No' would result in None being sent to the data API. As a result of this fix Yes / No questions cannot be unanswered once answered.