### PR TITLE
Update python-json-logger to use PyPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask>=0.10
 six==1.9.0
 requests==2.7.0
 pyyaml==3.11
-git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
+python-json-logger==0.1.4
 inflection==0.2.1
 Flask-FeatureFlags==0.6
 enum34==1.0.4


### PR DESCRIPTION
This package was broken in PyPI for a while, it is now fixed.