### PR TITLE
Multiple recipient emails

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '15.7.1'
+__version__ = '15.8.0'

--- a/dmutils/email.py
+++ b/dmutils/email.py
@@ -1,6 +1,8 @@
 import hashlib
 import base64
+
 from flask import current_app
+from flask._compat import string_types
 from mandrill import Mandrill, Error
 from itsdangerous import URLSafeTimedSerializer
 
@@ -9,14 +11,10 @@ class MandrillException(Exception):
     pass
 
 
-def send_email(
-        email_address,
-        email_body,
-        api_key,
-        subject,
-        from_email,
-        from_name,
-        tags):
+def send_email(to_email_addresses, email_body, api_key, subject, from_email, from_name, tags):
+    if isinstance(to_email_addresses, string_types):
+        to_email_addresses = [to_email_addresses]
+
     try:
         mandrill_client = Mandrill(api_key)
 
@@ -27,25 +25,21 @@ def send_email(
             'from_name': from_name,
             'to': [{
                 'email': email_address,
-                'name': 'Recipient Name',
                 'type': 'to'
-            }],
+            } for email_address in to_email_addresses],
             'important': False,
-            'track_opens': None,
-            'track_clicks': None,
+            'track_opens': False,
+            'track_clicks': False,
             'auto_text': True,
             'tags': tags,
-            'headers': {'Reply-To': from_email},  # noqa
+            'headers': {'Reply-To': from_email},
+            'preserve_recipients': False,
             'recipient_metadata': [{
                 'rcpt': email_address
-            }]
+            } for email_address in to_email_addresses]
         }
 
-        result = mandrill_client.messages.send(
-            message=message,
-            async=False,
-            ip_pool='Main Pool'
-        )
+        result = mandrill_client.messages.send(message=message)
     except Error as e:
         # Mandrill errors are thrown as exceptions
         current_app.logger.error("A mandrill error occurred: {error}",

--- a/dmutils/email.py
+++ b/dmutils/email.py
@@ -39,7 +39,7 @@ def send_email(to_email_addresses, email_body, api_key, subject, from_email, fro
             } for email_address in to_email_addresses]
         }
 
-        result = mandrill_client.messages.send(message=message)
+        result = mandrill_client.messages.send(message=message, async=True)
     except Error as e:
         # Mandrill errors are thrown as exceptions
         current_app.logger.error("A mandrill error occurred: {error}",

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -60,7 +60,7 @@ def test_calls_send_email_with_correct_params(email_app, mandrill):
 
         )
 
-        mandrill.messages.send.assert_called_once_with(message=expected_call)
+        mandrill.messages.send.assert_called_once_with(message=expected_call, async=True)
 
 
 def test_calls_send_email_to_multiple_addresses(email_app, mandrill):

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -35,15 +35,15 @@ def test_calls_send_email_with_correct_params(email_app, mandrill):
             'from_name': "from_name",
             'to': [{
                 'email': "email_address",
-                'name': 'Recipient Name',
                 'type': 'to'
             }],
             'important': False,
-            'track_opens': None,
-            'track_clicks': None,
+            'track_opens': False,
+            'track_clicks': False,
             'auto_text': True,
             'tags': ['password-resets'],
             'headers': {'Reply-To': "from_email"},  # noqa
+            'preserve_recipients': False,
             'recipient_metadata': [{
                 'rcpt': "email_address"
             }]
@@ -60,11 +60,35 @@ def test_calls_send_email_with_correct_params(email_app, mandrill):
 
         )
 
-        mandrill.messages.send.assert_called_once_with(
-            message=expected_call,
-            async=False,
-            ip_pool='Main Pool'
+        mandrill.messages.send.assert_called_once_with(message=expected_call)
+
+
+def test_calls_send_email_to_multiple_addresses(email_app, mandrill):
+    with email_app.app_context():
+
+        mandrill.messages.send.return_value = [
+            {'_id': '123', 'email': '123'}]
+
+        send_email(
+            ["email_address1", "email_address2"],
+            "body",
+            "api_key",
+            "subject",
+            "from_email",
+            "from_name",
+            ["password-resets"]
+
         )
+
+        assert mandrill.messages.send.call_args[1]['message']['to'] == [
+            {'email': "email_address1", 'type': 'to'},
+            {'email': "email_address2", 'type': 'to'},
+        ]
+
+        assert mandrill.messages.send.call_args[1]['message']['recipient_metadata'] == [
+            {'rcpt': "email_address1"},
+            {'rcpt': "email_address2"},
+        ]
 
 
 def test_should_throw_exception_if_mandrill_fails(email_app, mandrill):


### PR DESCRIPTION
### Add support for multiple recipients to send_email
`to_email_addresses` can be a string or a list of strings.
Emails to multiple recipients are sent with `preserve_recipients`
flag set to `False`, which makes Mandrill send a separate 'To:' email
for each address.

Removed ignored ip_pool option and optional recipient name.

### Set async=True on mandrill API send email requests
Since we're not checking the status of messages in the API response
there's no reason to wait for them to be sent. Emails with more than
10 recipients are always sent asynchronously, but for messages with
less than 10 to addresses the API response can still take some time.

From [mandrill docs](https://mandrillapp.com/api/docs/messages.python.html):

> enable a background sending mode that is optimized for bulk sending.
> In async mode, messages/send will immediately return a status of
> "queued" for every recipient.