### PR TITLE
Use datetime format for timestamp metadata.

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '15.9.0'
+__version__ = '15.9.1'

--- a/dmutils/s3.py
+++ b/dmutils/s3.py
@@ -6,6 +6,7 @@ import boto.exception
 import datetime
 import mimetypes
 import logging
+from dateutil.parser import parse as parse_time
 
 from boto.exception import S3ResponseError  # noqa
 
@@ -119,11 +120,14 @@ class S3(object):
             key = self.bucket.get_key(key.name)
             timestamp = key.get_metadata('timestamp')
 
+        timestamp = timestamp or key.last_modified
+        timestamp = parse_time(timestamp)
+
         return {
             'path': key.name,
             'filename': filename,
             'ext': ext[1:],
-            'last_modified': timestamp or key.last_modified,
+            'last_modified': timestamp.strftime(DATETIME_FORMAT),
             'size': key.size
         }
 

--- a/dmutils/s3.py
+++ b/dmutils/s3.py
@@ -9,6 +9,7 @@ import logging
 
 from boto.exception import S3ResponseError  # noqa
 
+from .formats import DATETIME_FORMAT
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +54,8 @@ class S3(object):
 
         key = self.bucket.new_key(path)
         filesize = get_file_size_up_to_maximum(file)
-        key.set_metadata('timestamp', (timestamp or datetime.datetime.utcnow()).isoformat())
+        timestamp = timestamp or datetime.datetime.utcnow()
+        key.set_metadata('timestamp', timestamp.strftime(DATETIME_FORMAT))
         key.set_contents_from_file(
             file,
             headers={'Content-Type': self._get_mimetype(key.name)}

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -147,7 +147,7 @@ class TestS3Uploader(unittest.TestCase):
         S3('test-bucket').save('folder/test-file.pdf', mock_file('blah', 123))
 
         mock_bucket.s3_key_mock.set_metadata.assert_called_once_with(
-            'timestamp', "2015-10-10T00:00:00")
+            'timestamp', "2015-10-10T00:00:00.000000Z")
 
     @freeze_time('2015-10-10')
     def test_save_sets_timestamp_to_provided_time(self):
@@ -158,7 +158,7 @@ class TestS3Uploader(unittest.TestCase):
                                timestamp=datetime.datetime(2015, 10, 11))
 
         mock_bucket.s3_key_mock.set_metadata.assert_called_once_with(
-            'timestamp', "2015-10-11T00:00:00")
+            'timestamp', "2015-10-11T00:00:00.000000Z")
 
     def test_save_sets_content_type_and_acl(self):
         mock_bucket = FakeBucket()

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -93,7 +93,7 @@ class TestS3Uploader(unittest.TestCase):
         self.s3_mock.get_bucket.return_value = mock_bucket
 
         fake_key_later = FakeKey('dir/file 1.odt')
-        fake_key_earlier = FakeKey('dir/file 2.odt', last_modified='2014-08-17T14:00:00.000Z')
+        fake_key_earlier = FakeKey('dir/file 2.odt', last_modified='2014-08-17T14:00:00.000000Z')
         mock_bucket.list.return_value = [
             fake_key_later,
             fake_key_earlier
@@ -113,7 +113,7 @@ class TestS3Uploader(unittest.TestCase):
         mock_bucket.list.return_value = [fake_key]
         mock_bucket.get_key.return_value = FakeKey('dir/file 1.odt', timestamp='2015-10-10T15:00:00.0000Z')
 
-        assert S3('test-bucket').list(load_timestamps=True)[0]['last_modified'] == '2015-10-10T15:00:00.0000Z'
+        assert S3('test-bucket').list(load_timestamps=True)[0]['last_modified'] == '2015-10-10T15:00:00.000000Z'
 
     def test_list_files_with_loading_custom_timestamps_sorts_by_timestamp(self):
         mock_bucket = mock.Mock()
@@ -128,9 +128,9 @@ class TestS3Uploader(unittest.TestCase):
         ]
 
         results = S3('test-bucket').list(load_timestamps=True)
-        assert results[0]['last_modified'] == '2015-08-17T14:00:00.000Z'
-        assert results[1]['last_modified'] == '2015-11-10T15:00:00.0000Z'
-        assert results[2]['last_modified'] == '2015-12-10T15:00:00.0000Z'
+        assert results[0]['last_modified'] == '2015-08-17T14:00:00.000000Z'
+        assert results[1]['last_modified'] == '2015-11-10T15:00:00.000000Z'
+        assert results[2]['last_modified'] == '2015-12-10T15:00:00.000000Z'
 
     def test_save_file(self):
         mock_bucket = FakeBucket()
@@ -266,7 +266,7 @@ class FakeBucket(object):
 class FakeKey(object):
     def __init__(self, name, last_modified=None, size=None, timestamp=None):
         self.name = name
-        self.last_modified = last_modified or '2015-08-17T14:00:00.000Z'
+        self.last_modified = last_modified or '2015-08-17T14:00:00.000000Z'
         self.size = size if size is not None else 1
         self.timestamp = timestamp
 


### PR DESCRIPTION
We use it elsewhere and expect timestamps to be formatted this way
