### PR TITLE
Add get and delete to s3

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '16.0.0'
+__version__ = '16.1.0'

--- a/dmutils/s3.py
+++ b/dmutils/s3.py
@@ -95,8 +95,10 @@ class S3(object):
         return a list of file keys (ordered by last_modified date) from an s3 bucket
 
         Prefix & Delimiter: http://docs.aws.amazon.com/AmazonS3/latest/dev/ListingKeysHierarchy.html
-        :param prefix:      filter by files whose names begin with the prefix
-        :param delimiter:   filter out files whose names contain the delimiter
+        :param prefix:         filter by files whose names begin with the prefix
+        :param delimiter:      filter out files whose names contain the delimiter
+        :param load_timestamp: by default custom timestamps are not loaded as they require an extra API call.
+                               If you need to show the timestamp set this to True.
         :return: list
         """
         # http://boto.readthedocs.org/en/latest/ref/s3.html#boto.s3.bucket.Bucket.list
@@ -111,7 +113,9 @@ class S3(object):
         """
         transform a boto s3 Key object into a (simpler) dict
 
-        :param key: http://boto.readthedocs.org/en/latest/ref/s3.html#boto.s3.key.Key
+        :param key:            http://boto.readthedocs.org/en/latest/ref/s3.html#boto.s3.key.Key
+        :param load_timestamp: by default custom timestamps are not loaded as they require an extra API call.
+                               If you need to show the timestamp set this to True.
         :return:    dict
         """
         filename, ext = os.path.splitext(os.path.basename(key.name))

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -64,6 +64,32 @@ class TestS3Uploader(unittest.TestCase):
         S3('test-bucket').get_signed_url('documents/file.pdf', 10)
         mock_bucket.s3_key_mock.generate_url.assert_called_with(10)
 
+    def test_get_key(self):
+        mock_bucket = mock.Mock()
+        self.s3_mock.get_bucket.return_value = mock_bucket
+
+        fake_key = FakeKey('dir/file1.pdf')
+        mock_bucket.get_key.return_value = fake_key
+
+        assert S3('test-bucket').get_key('dir/file1.pdf') == fake_key.fake_format_key(filename='file1', ext='pdf')
+
+    def test_delete_key(self):
+        mock_bucket = FakeBucket(['folder/test-file.pdf'])
+        self.s3_mock.get_bucket.return_value = mock_bucket
+
+        S3('test-bucket').delete_key('folder/test-file.pdf')
+
+        assert 'folder/test-file.pdf' not in mock_bucket.keys
+
+    @freeze_time('2015-10-10')
+    def test_delete_key_moves_file_with_prefix(self):
+        mock_bucket = FakeBucket(['folder/test-file.pdf'])
+        self.s3_mock.get_bucket.return_value = mock_bucket
+
+        S3('test-bucket').delete_key('folder/test-file.pdf')
+
+        assert 'folder/2015-10-10T00:00:00-test-file.pdf' in mock_bucket.keys
+
     def test_list_files(self):
         mock_bucket = mock.Mock()
         self.s3_mock.get_bucket.return_value = mock_bucket


### PR DESCRIPTION
# Add load_timestamp to docstrings
I forgot to update the docs when I first added the parameter.

# Add S3 methods to get and delete keys
Add a method to get a key that returns the response in the same was as
list does (as a formatted dictionary).

Add a method to delete a key that creates a timestamped archive of in
the same way that save does.