### PR TITLE
Add login utils

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '16.2.1'
+__version__ = '16.3.0'

--- a/dmutils/email.py
+++ b/dmutils/email.py
@@ -93,12 +93,10 @@ def decode_password_reset_token(token, data_api_client):
         )
     except SignatureExpired:
         current_app.logger.info("Password reset attempt with expired token.")
-        flash('token_expired', 'error')
-        return None
+        return {'error': 'token_expired'}
     except BadSignature as e:
         current_app.logger.info("Error changing password: {error}", extra={'error': six.text_type(e)})
-        flash('token_invalid', 'error')
-        return None
+        return {'error': 'token_invalid'}
 
     user = data_api_client.get_user(decoded["user"])
     user_last_changed_password_at = datetime.strptime(
@@ -111,8 +109,7 @@ def decode_password_reset_token(token, data_api_client):
             user_last_changed_password_at
     ):
         current_app.logger.info("Error changing password: Token generated earlier than password was last changed.")
-        flash('token_invalid', 'error')
-        return None
+        return {'error': 'token_invalid'}
 
     return decoded
 

--- a/dmutils/email.py
+++ b/dmutils/email.py
@@ -1,10 +1,18 @@
-import hashlib
 import base64
+import hashlib
+import six
 
-from flask import current_app
+from flask import current_app, flash
 from flask._compat import string_types
+
+from datetime import datetime
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 from mandrill import Mandrill, Error
-from itsdangerous import URLSafeTimedSerializer
+
+from .formats import DATETIME_FORMAT
+
+ONE_DAY_IN_SECONDS = 86400
+SEVEN_DAYS_IN_SECONDS = 604800
 
 
 class MandrillException(Exception):
@@ -73,3 +81,68 @@ def hash_email(email):
     m.update(email.encode('utf-8'))
 
     return base64.urlsafe_b64encode(m.digest())
+
+
+def decode_password_reset_token(token, data_api_client):
+    try:
+        decoded, timestamp = decode_token(
+            token,
+            current_app.config["SECRET_KEY"],
+            current_app.config["RESET_PASSWORD_SALT"],
+            ONE_DAY_IN_SECONDS
+        )
+    except SignatureExpired:
+        current_app.logger.info("Password reset attempt with expired token.")
+        flash('token_expired', 'error')
+        return None
+    except BadSignature as e:
+        current_app.logger.info("Error changing password: {error}", extra={'error': six.text_type(e)})
+        flash('token_invalid', 'error')
+        return None
+
+    user = data_api_client.get_user(decoded["user"])
+    user_last_changed_password_at = datetime.strptime(
+        user['users']['passwordChangedAt'],
+        DATETIME_FORMAT
+    )
+
+    if token_created_before_password_last_changed(
+            timestamp,
+            user_last_changed_password_at
+    ):
+        current_app.logger.info("Error changing password: Token generated earlier than password was last changed.")
+        flash('token_invalid', 'error')
+        return None
+
+    return decoded
+
+
+def decode_invitation_token(encoded_token, role):
+    required_fields = ['email_address', 'supplier_id', 'supplier_name'] if role == 'supplier' else ['email_address']
+    try:
+        token, timestamp = decode_token(
+            encoded_token,
+            current_app.config['SHARED_EMAIL_KEY'],
+            current_app.config['INVITE_EMAIL_SALT'],
+            SEVEN_DAYS_IN_SECONDS
+        )
+        if all(field in token for field in required_fields):
+            return token
+        else:
+            raise ValueError('Invitation token is missing required keys')
+    except SignatureExpired as e:
+        current_app.logger.info("Invitation attempt with expired token. error {error}",
+                                extra={'error': six.text_type(e)})
+        return None
+    except BadSignature as e:
+        current_app.logger.info("Invitation reset attempt with expired token. error {error}",
+                                extra={'error': six.text_type(e)})
+        return None
+    except ValueError as e:
+        current_app.logger.info("error {error}",
+                                extra={'error': six.text_type(e)})
+        return None
+
+
+def token_created_before_password_last_changed(token_timestamp, user_timestamp):
+    return token_timestamp < user_timestamp


### PR DESCRIPTION
This moves token-decoding functions into utils, as they are used by both buyer and supplier app now (well, the `decode_invitation_token` is used by both, and I think it is worth keeping them together so `decode_password_reset_token` is here too, even though that is only used by the buyer app.

I'm aware that this is missing tests for failure modes of `decode_password_reset_token`.  Suggestions for how to do this welcome.  I have lost quite a lot of time to it so far - I've tried using freezegun to pass a too-old token, and tried passing in an incomplete token but in both cases I get a weird "working outside of app context" error which I've failed miserably to debug.