### PR TITLE
Add optional content disposition header when uploading a file to S3

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '16.1.0'
+__version__ = '16.2.0'

--- a/dmutils/s3.py
+++ b/dmutils/s3.py
@@ -36,7 +36,7 @@ class S3(object):
 
         return match.group(1)
 
-    def save(self, path, file, acl='public-read', move_prefix=None, timestamp=None):
+    def save(self, path, file, acl='public-read', move_prefix=None, timestamp=None, download_filename=None):
         """Save a file in an S3 bucket
 
         canned ACL list: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
@@ -57,9 +57,12 @@ class S3(object):
         filesize = get_file_size_up_to_maximum(file)
         timestamp = timestamp or datetime.datetime.utcnow()
         key.set_metadata('timestamp', timestamp.strftime(DATETIME_FORMAT))
+        headers = {'Content-Type': self._get_mimetype(key.name)}
+        if download_filename:
+            headers['Content-Disposition'] = 'attachment; filename="{}"'.format(download_filename)
         key.set_contents_from_file(
             file,
-            headers={'Content-Type': self._get_mimetype(key.name)}
+            headers=headers
         )
         key.set_acl(acl)
         logger.info(

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -197,6 +197,19 @@ class TestS3Uploader(unittest.TestCase):
             mock.ANY, headers={'Content-Type': 'application/pdf'})
         mock_bucket.s3_key_mock.set_acl.assert_called_with('public-read')
 
+    def test_save_sets_content_type_and_content_disposition_header(self):
+        mock_bucket = FakeBucket()
+        self.s3_mock.get_bucket.return_value = mock_bucket
+
+        S3('test-bucket').save('folder/test-file.pdf', mock_file('blah', 123), download_filename='new-test-file.pdf')
+        self.assertEqual(mock_bucket.keys, set(['folder/test-file.pdf']))
+
+        mock_bucket.s3_key_mock.set_contents_from_file.assert_called_with(
+            mock.ANY, headers={
+                'Content-Type': 'application/pdf',
+                'Content-Disposition': 'attachment; filename="new-test-file.pdf"'
+            })
+
     def test_save_strips_leading_slash(self):
         mock_bucket = FakeBucket()
         self.s3_mock.get_bucket.return_value = mock_bucket


### PR DESCRIPTION
`Content-Disposition` header forces a file to be downloaded instead of viewed in the browser and suggests a different filename when the file is saved locally.