### PR TITLE
Encode Content-Disposition header

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '16.2.0'
+__version__ = '16.2.1'

--- a/dmutils/s3.py
+++ b/dmutils/s3.py
@@ -59,7 +59,7 @@ class S3(object):
         key.set_metadata('timestamp', timestamp.strftime(DATETIME_FORMAT))
         headers = {'Content-Type': self._get_mimetype(key.name)}
         if download_filename:
-            headers['Content-Disposition'] = 'attachment; filename="{}"'.format(download_filename)
+            headers['Content-Disposition'] = 'attachment; filename="{}"'.format(download_filename).encode('utf-8')
         key.set_contents_from_file(
             file,
             headers=headers

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -207,7 +207,7 @@ class TestS3Uploader(unittest.TestCase):
         mock_bucket.s3_key_mock.set_contents_from_file.assert_called_with(
             mock.ANY, headers={
                 'Content-Type': 'application/pdf',
-                'Content-Disposition': 'attachment; filename="new-test-file.pdf"'
+                'Content-Disposition': 'attachment; filename="new-test-file.pdf"'.encode('utf-8')
             })
 
     def test_save_strips_leading_slash(self):


### PR DESCRIPTION
Sending a unicode string would result in escaped spaces in our header value.  
ie, we were getting something that looked like:
`attachment;%20filename="DM_Functional_Test_Supplier-11111-signed-framework-agreement.pdf"`

Encoding in utf-8 fixes the bug.

