### PR TITLE
No supplier name in agreement document path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 Records breaking changes from major version bumps
 
+## 17.0.0
+
+PR: [#238](https://github.com/alphagov/digitalmarketplace-utils/pull/238)
+
+### What changed
+
+`documents.get_agreement_document_path` no longer takes `supplier_name` argument since uploaded
+file paths are constructed using `supplier_id` and `document_name` only.
+
+`documents.get_countersigned_agreement_document_path` has been removed.
+
+### Example app change
+
+Old:
+```python
+get_agreement_document_path(framework_slug, supplier_id, legal_supplier_name, document_name)
+```
+
+New:
+```python
+get_agreement_document_path(framework_slug, supplier_id, document_name)
+```
+
+Old:
+```python
+get_countersigned_agreement_document_path(framework_slug, supplier_id)
+```
+
+New:
+```python
+from dmutils.documents import COUNTERSIGNED_AGREEMENT_FILENAME
+
+get_agreement_document_path(framework_slug, supplier_id, COUNTERSIGNED_AGREEMENT_FILENAME)
+```
+
 ## 16.0.0
 
 PR: [#233](https://github.com/alphagov/digitalmarketplace-utils/pull/233)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '16.3.0'
+__version__ = '17.0.0'

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -12,6 +12,11 @@ from .s3 import S3ResponseError, get_file_size_up_to_maximum, FILE_SIZE_LIMIT
 BAD_SUPPLIER_NAME_CHARACTERS = ['#', '%', '&', '{', '}', '\\', '<', '>', '*', '?', '/', '$',
                                 '!', "'", '"', ':', '@', '+', '`', '|', '=', ',', '.']
 
+RESULT_LETTER_FILENAME = 'result-letter.pdf'
+AGREEMENT_FILENAME = 'framework-agreement.pdf'
+SIGNED_AGREEMENT_PREFIX = 'signed-framework-agreement'
+COUNTERSIGNED_AGREEMENT_FILENAME = 'countersigned-framework-agreement.pdf'
+
 
 def filter_empty_files(files):
     """Remove any empty files from the list.
@@ -200,13 +205,6 @@ def get_agreement_document_path(framework_slug, supplier_id, document_name):
         framework_slug,
         supplier_id,
         document_name
-    )
-
-
-def get_countersigned_agreement_document_path(framework_slug, supplier_id):
-    return '{0}/agreements/{1}/{1}-countersigned-framework-agreement.pdf'.format(
-        framework_slug,
-        supplier_id
     )
 
 

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -195,11 +195,10 @@ def get_signed_url(bucket, path, base_url):
         return url
 
 
-def get_agreement_document_path(framework_slug, supplier_id, supplier_name, document_name):
-    return '{0}/agreements/{1}/{2}-{1}-{3}'.format(
+def get_agreement_document_path(framework_slug, supplier_id, document_name):
+    return '{0}/agreements/{1}/{1}-{2}'.format(
         framework_slug,
         supplier_id,
-        sanitise_supplier_name(supplier_name),
         document_name
     )
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -308,8 +308,8 @@ def test_get_signed_url(base_url, expected):
 
 
 def test_get_agreement_document_path():
-    assert get_agreement_document_path('g-cloud-7', 1234, 'supplier name', 'foo.pdf') == \
-        'g-cloud-7/agreements/1234/supplier_name-1234-foo.pdf'
+    assert get_agreement_document_path('g-cloud-7', 1234, 'foo.pdf') == \
+        'g-cloud-7/agreements/1234/1234-foo.pdf'
 
 
 def test_get_countersigned_agreement_document_path():

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -16,7 +16,8 @@ from dmutils.documents import (
     validate_documents,
     upload_document, upload_service_documents,
     get_signed_url, get_agreement_document_path,
-    sanitise_supplier_name, file_is_pdf, file_is_zip, get_countersigned_agreement_document_path)
+    sanitise_supplier_name, file_is_pdf, file_is_zip
+)
 
 
 class TestGenerateFilename(unittest.TestCase):
@@ -310,11 +311,6 @@ def test_get_signed_url(base_url, expected):
 def test_get_agreement_document_path():
     assert get_agreement_document_path('g-cloud-7', 1234, 'foo.pdf') == \
         'g-cloud-7/agreements/1234/1234-foo.pdf'
-
-
-def test_get_countersigned_agreement_document_path():
-    assert get_countersigned_agreement_document_path('g-cloud-12', 1234) == \
-        'g-cloud-12/agreements/1234/1234-countersigned-framework-agreement.pdf'
 
 
 def test_sanitise_supplier_name():


### PR DESCRIPTION
### Don't add supplier name to the agreement document path
S3 file names now only have supplier id and document name, so that
they don't need to change if supplier name is changed.

Supplier name should be added to the uploaded file Content-Disposition
header by the app.