### PR TITLE
Add generic document path method

### DIFF
--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -200,9 +200,19 @@ def get_signed_url(bucket, path, base_url):
         return url
 
 
+# this method is deprecated
 def get_agreement_document_path(framework_slug, supplier_id, document_name):
     return '{0}/agreements/{1}/{1}-{2}'.format(
         framework_slug,
+        supplier_id,
+        document_name
+    )
+
+
+def get_document_path(framework_slug, supplier_id, bucket_category, document_name):
+    return '{0}/{1}/{2}/{2}-{3}'.format(
+        framework_slug,
+        bucket_category,
         supplier_id,
         document_name
     )

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -15,7 +15,7 @@ from dmutils.documents import (
     file_is_open_document_format,
     validate_documents,
     upload_document, upload_service_documents,
-    get_signed_url, get_agreement_document_path,
+    get_signed_url, get_agreement_document_path, get_document_path,
     sanitise_supplier_name, file_is_pdf, file_is_zip
 )
 
@@ -310,6 +310,11 @@ def test_get_signed_url(base_url, expected):
 
 def test_get_agreement_document_path():
     assert get_agreement_document_path('g-cloud-7', 1234, 'foo.pdf') == \
+        'g-cloud-7/agreements/1234/1234-foo.pdf'
+
+
+def test_get_document_path():
+    assert get_document_path('g-cloud-7', 1234, 'agreements', 'foo.pdf') == \
         'g-cloud-7/agreements/1234/1234-foo.pdf'
 
 


### PR DESCRIPTION
Method allows documents to be uploaded to buckets other than agreements bucket.