### PR TITLE
Make make content section slugs nicer

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '17.0.0'
+__version__ = '17.1.0'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -714,7 +714,7 @@ def _load_question(question, directory):
 
 def _make_slug(name):
     return inflection.underscore(
-        re.sub(r"\s", "_", name)
+        re.sub(r"[\s&?]", "_", name).strip("_")
     ).replace('_', '-')
 
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -8,7 +8,7 @@ import io
 
 from dmutils.content_loader import (
     ContentLoader, ContentSection, ContentQuestion, ContentManifest,
-    read_yaml, ContentNotFoundError, QuestionNotFoundError
+    read_yaml, ContentNotFoundError, QuestionNotFoundError, _make_slug
 )
 
 from sys import version_info
@@ -1545,3 +1545,12 @@ class TestContentLoader(object):
         with pytest.raises(ContentNotFoundError):
             yaml_loader = ContentLoader('content/')
             yaml_loader.get_manifest('framework-slug', 'manifest')
+
+
+@pytest.mark.parametrize("title,slug", [
+    ("The Title", "the-title"),
+    ("This\nAnd\tThat ", "this-and-that"),
+    ("This&That?", "this-that"),
+])
+def test_make_slug(title, slug):
+    assert _make_slug(title) == slug


### PR DESCRIPTION
Strip ampersands and question marks from section names an trim them when converting them into slugs. Question marks in slugs make my day really bad.