### PR TITLE
[#112338109] ContentLoader accepts `yes_no_question` type questions

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '17.2.0'
+__version__ = '17.3.0'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -377,7 +377,7 @@ class ContentQuestion(object):
             return self._get_single_question_data(form_data)
 
     def _get_single_question_data(self, form_data):
-        if self.id not in form_data and self.type != 'yes_no_question':
+        if self.id not in form_data and self.type != 'boolean_list':
             if self.get('assuranceApproach') and '{}--assurance'.format(self.id) in form_data:
                 return {self.id: {'assurance': form_data.get('{}--assurance'.format(self.id))}}
             elif self.type in ['list', 'checkboxes']:
@@ -387,7 +387,7 @@ class ContentQuestion(object):
 
         if self.id == 'serviceTypes' or self.type in ['list', 'checkboxes']:
             value = form_data.getlist(self.id)
-        elif self.type == 'yes_no_question':
+        elif self.type == 'boolean_list':
 
             # if self.id is 'q5', form keys will come back as ('q5-0', 'true'), ('q5-1', 'false'), ('q5-3', 'true'), ...
             # here, we build a dict with keys as indices and values converted to boolean, eg {0: True, 1: False, 3: True, ...}  # noqa

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -387,6 +387,8 @@ class ContentQuestion(object):
 
         if self.id == 'serviceTypes' or self.type in ['list', 'checkboxes']:
             value = form_data.getlist(self.id)
+        elif self.type == 'yes_no_question':
+            value = list(map(convert_to_boolean, form_data.getlist(self.id)))
         elif self.type == 'boolean':
             value = convert_to_boolean(form_data[self.id])
         elif self.type == 'percentage':

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -11,11 +11,10 @@ from dmutils.content_loader import (
     read_yaml, ContentNotFoundError, QuestionNotFoundError, _make_slug
 )
 
-from sys import version_info
-if version_info.major == 2:
-    import __builtin__ as builtins
-else:
+try:
     import builtins
+except ImportError:
+    import __builtin__ as builtins
 
 
 class TestContentManifest(object):

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -721,41 +721,45 @@ class TestContentSection(object):
                 "type": "list",
             }, {
                 "id": "q5",
+                "question": "Yes no question",
+                "type": "yes_no_question",
+            }, {
+                "id": "q6",
                 "question": "Checkboxes question",
                 "type": "checkboxes",
             }, {
-                "id": "q6",
+                "id": "q7",
                 "question": "Service ID question",
                 "type": "service_id",
                 "assuranceApproach": "2answers-type1",
             }, {
-                "id": "q7",
+                "id": "q8",
                 "question": "Pricing question",
                 "type": "pricing",
                 "fields": {
-                    "minimum_price": "q7-min_price",
-                    "maximum_price": "q7-max_price",
-                    "price_unit": "q7-price_unit",
-                    "price_interval": "q7-price_interval"
+                    "minimum_price": "q8-min_price",
+                    "maximum_price": "q8-max_price",
+                    "price_unit": "q8-price_unit",
+                    "price_interval": "q8-price_interval"
                 }
             }, {
-                "id": "q8",
+                "id": "q9",
                 "question": "Upload question",
                 "type": "upload",
             }, {
-                "id": "q9",
+                "id": "q10",
                 "question": "Percentage question",
                 "type": "percentage",
             }, {
-                "id": "q10",
+                "id": "q11",
                 "question": "Large text question",
                 "type": "textbox_large",
             }, {
-                "id": "q11",
+                "id": "q12",
                 "question": "Text question",
                 "type": "text"
             }, {
-                "id": "q12",
+                "id": "q13",
                 "question": "Text question",
                 "type": "text"
             }]
@@ -769,19 +773,21 @@ class TestContentSection(object):
             ('q3', 'Should be lost'),
             ('q4', 'value 1'),
             ('q4', 'value 2'),
-            ('q5', 'check 1'),
-            ('q5', 'check 2'),
-            ('q6', '71234567890'),
-            ('q6--assurance', 'yes I am'),
-            ('q7-min_price', '12.12'),
-            ('q7-max_price', ''),
-            ('q7-price_unit', 'Unit'),
-            ('q7-price_interval', 'Hour'),
-            ('q8', 'blah blah'),
-            ('q9', '12.12'),
-            ('q10', 'Looooooooaaaaaaaaads of text'),
+            ('q5', 'true'),
+            ('q5', 'false'),
+            ('q6', 'check 1'),
+            ('q6', 'check 2'),
+            ('q7', '71234567890'),
+            ('q7--assurance', 'yes I am'),
+            ('q8-min_price', '12.12'),
+            ('q8-max_price', ''),
+            ('q8-price_unit', 'Unit'),
+            ('q8-price_interval', 'Hour'),
+            ('q9', 'blah blah'),
+            ('q10', '12.12'),
+            ('q11', 'Looooooooaaaaaaaaads of text'),
             ('extra_field', 'Should be lost'),
-            ('q12', ''),
+            ('q13', ''),
         ])
 
         data = section.get_data(form)
@@ -792,15 +798,16 @@ class TestContentSection(object):
             'q2': 'Some text stuff',
             'q3': 'value',
             'q4': ['value 1', 'value 2'],
-            'q5': ['check 1', 'check 2'],
-            'q6': {'assurance': 'yes I am', 'value': '71234567890'},
-            'q7-min_price': '12.12',
-            'q7-max_price': None,
-            'q7-price_unit': 'Unit',
-            'q7-price_interval': 'Hour',
-            'q9': 12.12,
-            'q10': 'Looooooooaaaaaaaaads of text',
-            'q12': None,
+            'q5': [True, False],
+            'q6': ['check 1', 'check 2'],
+            'q7': {'assurance': 'yes I am', 'value': '71234567890'},
+            'q8-min_price': '12.12',
+            'q8-max_price': None,
+            'q8-price_unit': 'Unit',
+            'q8-price_interval': 'Hour',
+            'q10': 12.12,
+            'q11': 'Looooooooaaaaaaaaads of text',
+            'q13': None,
         }
 
         # Failure modes
@@ -815,19 +822,19 @@ class TestContentSection(object):
         assert section.get_data(form)['q1'] is False
 
         form = ImmutableMultiDict([
-            ('q9', 'not a number')
+            ('q10', 'not a number')
         ])
-        assert section.get_data(form)['q9'] == 'not a number'
+        assert section.get_data(form)['q10'] == 'not a number'
 
         # Test 'orphaned' assurance is returned
         form = ImmutableMultiDict([
-            ('q6--assurance', 'yes I am'),
+            ('q7--assurance', 'yes I am'),
         ])
         data = section.get_data(form)
         assert data == {
             'q4': None,
-            'q5': None,
-            'q6': {'assurance': 'yes I am'},
+            'q6': None,
+            'q7': {'assurance': 'yes I am'},
         }
 
         # Test empty lists are not converted to `None`
@@ -835,6 +842,11 @@ class TestContentSection(object):
             ('q4', '')
         ])
         assert section.get_data(form)['q4'] == ['']
+
+        form = ImmutableMultiDict([
+            ('q5', '')
+        ])
+        assert section.get_data(form)['q5'] == ['']
 
     def test_unformat_data(self):
         section = ContentSection.create({
@@ -864,37 +876,41 @@ class TestContentSection(object):
                 "type": "list",
             }, {
                 "id": "q5",
+                "question": "Yes no question",
+                "type": "yes_no_question",
+            }, {
+                "id": "q6",
                 "question": "Checkboxes question",
                 "type": "checkboxes",
             }, {
-                "id": "q6",
+                "id": "q7",
                 "question": "Service ID question",
                 "type": "service_id",
                 "assuranceApproach": "2answers-type1",
             }, {
-                "id": "q7",
+                "id": "q8",
                 "question": "Pricing question",
                 "type": "pricing",
                 "fields": {
-                    "minimim_price": "q7-min",
-                    "maximum_price": "q7-min",
-                    "price_unit": "q7-unit",
-                    "price_interval": "q7-interval"
+                    "minimim_price": "q8-min",
+                    "maximum_price": "q8-min",
+                    "price_unit": "q8-unit",
+                    "price_interval": "q8-interval"
                 }
             }, {
-                "id": "q8",
+                "id": "q9",
                 "question": "Upload question",
                 "type": "upload",
             }, {
-                "id": "q9",
+                "id": "q10",
                 "question": "Percentage question",
                 "type": "percentage",
             }, {
-                "id": "q10",
+                "id": "q11",
                 "question": "Large text question",
                 "type": "textbox_large",
             }, {
-                "id": "q11",
+                "id": "q12",
                 "question": "Text question",
                 "type": "text"
             }]
@@ -906,14 +922,15 @@ class TestContentSection(object):
             'q2': 'Some text stuff',
             'q3': 'value',
             'q4': ['value 1', 'value 2'],
-            'q5': ['check 1', 'check 2'],
-            'q6': {'assurance': 'yes I am', 'value': '71234567890'},
-            'q7-min': '12.12',
-            'q7-max': '13.13',
-            'q7-unit': 'Unit',
-            'q7-interval': 'Hour',
-            'q9': 12.12,
-            'q10': 'Looooooooaaaaaaaaads of text',
+            'q5': [True, False],
+            'q6': ['check 1', 'check 2'],
+            'q7': {'assurance': 'yes I am', 'value': '71234567890'},
+            'q8-min': '12.12',
+            'q8-max': '13.13',
+            'q8-unit': 'Unit',
+            'q8-interval': 'Hour',
+            'q10': 12.12,
+            'q11': 'Looooooooaaaaaaaaads of text',
         }
 
         form = section.unformat_data(data)
@@ -924,15 +941,16 @@ class TestContentSection(object):
             'q2': 'Some text stuff',
             'q3': 'value',
             'q4': ['value 1', 'value 2'],
-            'q5': ['check 1', 'check 2'],
-            'q6': '71234567890',
-            'q6--assurance': 'yes I am',
-            'q7-min': '12.12',
-            'q7-max': '13.13',
-            'q7-unit': 'Unit',
-            'q7-interval': 'Hour',
-            'q9': 12.12,
-            'q10': 'Looooooooaaaaaaaaads of text',
+            'q5': [True, False],
+            'q6': ['check 1', 'check 2'],
+            'q7': '71234567890',
+            'q7--assurance': 'yes I am',
+            'q8-min': '12.12',
+            'q8-max': '13.13',
+            'q8-unit': 'Unit',
+            'q8-interval': 'Hour',
+            'q10': 12.12,
+            'q11': 'Looooooooaaaaaaaaads of text',
         }
 
     def test_get_question(self):

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -772,8 +772,10 @@ class TestContentSection(object):
             ('q3', 'Should be lost'),
             ('q4', 'value 1'),
             ('q4', 'value 2'),
-            ('q5', 'true'),
-            ('q5', 'false'),
+            ('q5-0', 'true'),
+            ('q5-1', 'false'),
+            ('q5-4', 'true'),
+            ('q5-not-valid', 'true'),
             ('q6', 'check 1'),
             ('q6', 'check 2'),
             ('q7', '71234567890'),
@@ -797,7 +799,7 @@ class TestContentSection(object):
             'q2': 'Some text stuff',
             'q3': 'value',
             'q4': ['value 1', 'value 2'],
-            'q5': [True, False],
+            'q5': [True, False, None, None, True],
             'q6': ['check 1', 'check 2'],
             'q7': {'assurance': 'yes I am', 'value': '71234567890'},
             'q8-min_price': '12.12',
@@ -821,12 +823,6 @@ class TestContentSection(object):
         assert section.get_data(form)['q1'] is False
 
         form = ImmutableMultiDict([
-            ('q5', 'not boolean'),
-            ('q5', 'falsey')
-        ])
-        assert section.get_data(form)['q5'] == ['not boolean', 'falsey']
-
-        form = ImmutableMultiDict([
             ('q10', 'not a number')
         ])
         assert section.get_data(form)['q10'] == 'not a number'
@@ -848,10 +844,18 @@ class TestContentSection(object):
         ])
         assert section.get_data(form)['q4'] == ['']
 
+        # if we have one empty value
         form = ImmutableMultiDict([
-            ('q5', '')
+            ('q5-0', '')
         ])
         assert section.get_data(form)['q5'] == ['']
+
+        # if we have a value without an index number, we ignore it
+        form = ImmutableMultiDict([
+            ('q5', 'true'),
+            ('q5-', 'true')
+        ])
+        assert 'q5' not in section.get_data(form)
 
     def test_unformat_data(self):
         section = ContentSection.create({

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -721,7 +721,7 @@ class TestContentSection(object):
             }, {
                 "id": "q5",
                 "question": "Yes no question",
-                "type": "yes_no_question",
+                "type": "boolean_list",
             }, {
                 "id": "q6",
                 "question": "Checkboxes question",
@@ -886,7 +886,7 @@ class TestContentSection(object):
             }, {
                 "id": "q5",
                 "question": "Yes no question",
-                "type": "yes_no_question",
+                "type": "boolean_list",
             }, {
                 "id": "q6",
                 "question": "Checkboxes question",

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -822,6 +822,12 @@ class TestContentSection(object):
         assert section.get_data(form)['q1'] is False
 
         form = ImmutableMultiDict([
+            ('q5', 'not boolean'),
+            ('q5', 'falsey')
+        ])
+        assert section.get_data(form)['q5'] == ['not boolean', 'falsey']
+
+        form = ImmutableMultiDict([
             ('q10', 'not a number')
         ])
         assert section.get_data(form)['q10'] == 'not a number'


### PR DESCRIPTION
Supplier responses to briefs are going to be returning a new data type to the `ContentLoader`.
I've called them `boolean_list` in the manifest files -- essentially they're lists of boolean values.  ([Pull request for `boolean_list` is open in digitalmarketlace-utils right now](https://github.com/alphagov/digitalmarketplace-frameworks/pull/196))

I've put them directly after `list` questions in our test because it seemed appropriate.
Then I reindexed all of the following questions, which makes the diff harder to look at.
<sub>(Sorry about that.) </sub>

[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/112338109)