### PR TITLE
Remove serviceTypes special case check in question.get_data

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '17.3.0'
+__version__ = '17.3.1'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -385,7 +385,7 @@ class ContentQuestion(object):
             else:
                 return {}
 
-        if self.id == 'serviceTypes' or self.type in ['list', 'checkboxes']:
+        if self.type in ['list', 'checkboxes']:
             value = form_data.getlist(self.id)
         elif self.type == 'boolean_list':
 


### PR DESCRIPTION
Special check for serviceTypes seems to have been carried over from
the old content_loader behaviour. It was required when question types
were looked up in the questions dictionary using the form field name
and the dictionary key didn't match the modified question.id.

Since then content loader was rewritten so that question ids are
set early on and questions are never looked up in the dictionary,
so `serviceTypes` question will preserve all question metadata
(including type) and shouldn't require any special handling.