### PR TITLE
Fix log message double formatting

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '17.3.1'
+__version__ = '17.3.2'

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -108,11 +108,13 @@ class CustomLogFormatter(logging.Formatter):
 
     def format(self, record):
         record = self.add_fields(record)
+        msg = super(CustomLogFormatter, self).format(record)
+
         try:
-            record.msg = record.msg.format(**record.__dict__)
+            msg = msg.format(**record.__dict__)
         except KeyError as e:
             logger.exception("failed to format log message: {} not found".format(e))
-        return super(CustomLogFormatter, self).format(record)
+        return msg
 
 
 class JSONFormatter(BaseJSONFormatter):


### PR DESCRIPTION
Log records are mutable, so modifying `.msg` in plaintext log
formatter means that JSON logger tries to format the string that's
already been formatted, returning an error if any of the values
contained braces.

To avoid this, instead of modifying the record object we format the
message string returned by base formatter. This could cause issues if
the default format string returns a message containing braces, but this
shouldn't happen with our current format string.