### PR TITLE
Remove unicode from sanitised supplier names

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '17.3.2'
+__version__ = '17.3.3'

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -220,7 +220,8 @@ def get_document_path(framework_slug, supplier_id, bucket_category, document_nam
 
 def sanitise_supplier_name(supplier_name):
     """Replace ampersands with 'and' and spaces with a single underscore."""
-    sanitised_supplier_name = supplier_name.strip().replace(' ', '_').replace('&', 'and')
+    sanitised_supplier_name = supplier_name.encode("ascii", errors="ignore").decode("ascii").strip()
+    sanitised_supplier_name = sanitised_supplier_name.replace(' ', '_').replace('&', 'and')
     for bad_char in BAD_SUPPLIER_NAME_CHARACTERS:
         sanitised_supplier_name = sanitised_supplier_name.replace(bad_char, '')
     while '__' in sanitised_supplier_name:

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest==2.7.0
+pytest==2.8.7
 mock==1.0.1
 pep8==1.6.2
 freezegun==0.3.4

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 import unittest
 
 import mock
@@ -319,8 +320,9 @@ def test_get_document_path():
 
 
 def test_sanitise_supplier_name():
-    assert sanitise_supplier_name('Kev\'s Butties') == 'Kevs_Butties'
-    assert sanitise_supplier_name('   Supplier A   ') == 'Supplier_A'
-    assert sanitise_supplier_name('Kev & Sons. | Ltd') == 'Kev_and_Sons_Ltd'
-    assert sanitise_supplier_name('\ / : * ? \' " < > |') == '_'
-    assert sanitise_supplier_name('kev@the*agency') == 'kevtheagency'
+    assert sanitise_supplier_name(u'Kev\'s Butties') == 'Kevs_Butties'
+    assert sanitise_supplier_name(u'   Supplier A   ') == 'Supplier_A'
+    assert sanitise_supplier_name(u'Kev & Sons. | Ltd') == 'Kev_and_Sons_Ltd'
+    assert sanitise_supplier_name(u'\ / : * ? \' " < > |') == '_'
+    assert sanitise_supplier_name(u'kev@the*agency') == 'kevtheagency'
+    assert sanitise_supplier_name(u"Ψ is a silly character") == "is_a_silly_character"


### PR DESCRIPTION
Suppliers can have unicode characters in their names. However, we do not want to include these in the sanitised name as we're unsure whether this is supported in the `Content-disposition` header by all browsers.