### PR TITLE
Inject base template data in init

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '17.3.3'
+__version__ = '17.4.0'

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -56,6 +56,10 @@ def init_app(
     application.add_template_filter(formats.dateformat)
     application.add_template_filter(formats.datetimeformat)
 
+    @application.context_processor
+    def inject_global_template_variables():
+        return application.config['BASE_TEMPLATE_DATA']
+
 
 def get_extra_files(paths):
     for path in paths:


### PR DESCRIPTION
By adding this here we will no longer need to pass in `BASE_TEMPLATE_DATA` to every single view in the frontend apps.

I have tested it locally and everything seems to still work OK with the views still explicitly passing BASE_TEMPLATE_DATA into the templates, so this isn't a breaking change.