### PR TITLE
Use ContentQuestion ID if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Records breaking changes from major version bumps
 
+## 18.0.0
+
+PR: [#247](https://github.com/alphagov/digitalmarketplace-utils/pull/247)
+
+### What changed
+
+The `ContentLoader` now takes the question `id` from the contents of the YAML file if it is there.
+It still falls back to the file name if there is no `id` in the file. The reason this is a breaking
+change is that the `serviceTypes` id is now expected to be taken from the `id` field.
+
+### Example app change
+
+Upgrade [digitalmarketplace-frameworks](https://github.com/alphagov/digitalmarketplace-frameworks) to
+version 0.20.0 or above.
+
 ## 17.0.0
 
 PR: [#238](https://github.com/alphagov/digitalmarketplace-utils/pull/238)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '17.4.0'
+__version__ = '18.0.0'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -724,7 +724,7 @@ def _load_question(question, directory):
         os.path.join(directory, '{}.yml'.format(question))
     )
 
-    question_content["id"] = _make_question_id(question)
+    question_content["id"] = question_content.get("id", question)
 
     return question_content
 
@@ -733,12 +733,6 @@ def _make_slug(name):
     return inflection.underscore(
         re.sub(r"[\s&?]", "_", name).strip("_")
     ).replace('_', '-')
-
-
-def _make_question_id(question):
-    if re.match('^serviceTypes(SCS|SaaS|PaaS|IaaS)', question):
-        return 'serviceTypes'
-    return question
 
 
 def read_yaml(yaml_file):

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1311,7 +1311,7 @@ class TestContentLoader(object):
         return {"name": "question1", "depends": [{"on": "lot", "being": "SaaS"}]}
 
     def question2(self):
-        return {"name": "question2", "depends": [{"on": "lot", "being": "SaaS"}]}
+        return {"id": "q2", "name": "question2", "depends": [{"on": "lot", "being": "SaaS"}]}
 
     def question3(self):
         return {"name": "question3", "depends": [{"on": "lot", "being": "SaaS"}]}
@@ -1329,7 +1329,7 @@ class TestContentLoader(object):
                     {'depends': [{'being': 'SaaS', 'on': 'lot'}],
                      'name': 'question1', 'id': 'question1'},
                     {'depends': [{'being': 'SaaS', 'on': 'lot'}],
-                     'name': 'question2', 'id': 'question2'}],
+                     'name': 'question2', 'id': 'q2'}],
                 'slug': 'section1'}
         ]
         read_yaml_mock.assert_has_calls([
@@ -1368,6 +1368,18 @@ class TestContentLoader(object):
         }
         read_yaml_mock.assert_called_with(
             'content/frameworks/framework-slug/questions/question-set/question1.yml')
+
+    def test_get_question_uses_id_if_available(self, read_yaml_mock):
+        read_yaml_mock.return_value = self.question2()
+
+        yaml_loader = ContentLoader("content/")
+
+        assert yaml_loader.get_question('framework-slug', 'question-set', 'question2') == {
+            'depends': [{'being': 'SaaS', 'on': 'lot'}],
+            'name': 'question2', 'id': 'q2'
+        }
+        read_yaml_mock.assert_called_with(
+            'content/frameworks/framework-slug/questions/question-set/question2.yml')
 
     def test_get_question_loads_nested_questions(self, read_yaml_mock):
         read_yaml_mock.side_effect = [


### PR DESCRIPTION
By default the id of a content loader question is set to the name of the YAML file. This change uses the `id` field if it is available.