### PR TITLE
[#112216471] Shove the logic for `boolean_list` questions into Content Loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 Records breaking changes from major version bumps
 
+## 19.0.0
+
+PR: [#248](https://github.com/alphagov/digitalmarketplace-utils/pull/248)
+
+### What changed
+
+Removed the `lot` parameter from the `.get_error_messages()` method of a `ContentSection`.  It wasn't
+being used for anything, so the logic remains unaffected.  Calling `.get_error_messages()` with
+the lot slug will from this point forward throw an error.
+
+### Example app change
+
+Old:
+```python
+section.get_error_messages(errors, lot['slug'])
+```
+
+New:
+```python
+section.get_error_messages(errors)
+```
+
 ## 18.0.0
 
 PR: [#247](https://github.com/alphagov/digitalmarketplace-utils/pull/247)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '18.0.0'
+__version__ = '19.0.0'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -318,6 +318,10 @@ class ContentSection(object):
             if question.get('slug') == question_slug:
                 return question
 
+    def inject_brief_questions_into_boolean_list_question(self, brief):
+        for question in self.questions:
+            question.inject_brief_questions_into_boolean_list_question(brief)
+
     # Type checking
 
     def _has_assurance(self, key):
@@ -493,6 +497,10 @@ class ContentQuestion(object):
         else:
             return []
 
+    def inject_brief_questions_into_boolean_list_question(self, brief):
+        if self.type == 'boolean_list':
+            self.boolean_list_questions = brief[self.id]
+
     def has_assurance(self):
         return True if self.get('assuranceApproach') else False
 
@@ -532,8 +540,39 @@ class ContentQuestionSummary(ContentQuestion):
             self.questions = [q.summary(service_data) for q in self.questions]
         self.fields = question.fields
 
+        if question.get('boolean_list_questions'):
+            self.boolean_list_questions = question.boolean_list_questions
+
     def _default_for_field(self, field_key):
         return self.get('field_defaults', {}).get(field_key)
+
+    def get_error_messages(self, errors):
+
+        question_errors = super(ContentQuestionSummary, self).get_error_messages(errors)
+
+        boolean_list_questions = self.get('boolean_list_questions')
+        boolean_list_values = self.get('value') or []
+
+        if self.id in question_errors and self.type == 'boolean_list' and boolean_list_questions:
+            # pad list of values to same length as boolean_list_questions
+            boolean_list_values.extend([None] * (len(boolean_list_questions) - len(boolean_list_values)))
+
+            for index, boolean_list_question in enumerate(boolean_list_questions):
+                if not isinstance(boolean_list_values[index], bool):
+                    # Each non-boolean value is an error
+                    boolean_question_id = "{}-{}".format(self.id, index)
+                    question_errors[boolean_question_id] = {
+                        'input_name': boolean_question_id,
+                        'message': question_errors[self.id]['message'],
+                        'question': boolean_list_question
+                    }
+
+            question_errors[self.id] = True
+            question_errors = OrderedDict([
+                (k, question_errors[k]) for k in sorted(question_errors.keys())
+            ])
+
+        return question_errors
 
     @property
     def is_empty(self):

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -265,11 +265,10 @@ class ContentSection(object):
             any(form_field not in service for form_field in self.get_field_names())
         ])
 
-    def get_error_messages(self, errors, lot):
+    def get_error_messages(self, errors):
         """Convert API error keys into error messages
 
         :param errors: error dictionary as returned by the data API
-        :param lot: the lot of the service
         :return: error dictionary with human readable error messages
         """
         if set(errors.keys()) - set(self.get_field_names()):

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1147,7 +1147,7 @@ class TestContentSection(object):
             "priceString-min": "answer_required",
         }
 
-        result = section.get_error_messages(errors, 'SCS')
+        result = section.get_error_messages(errors)
 
         assert result['priceString']['message'] == "No min price"
         assert result['q2']['message'] == "This is the error message"
@@ -1170,7 +1170,7 @@ class TestContentSection(object):
         }
 
         with pytest.raises(QuestionNotFoundError):
-            section.get_error_messages(errors, "SCS")
+            section.get_error_messages(errors)
 
     def test_section_description(self):
         section = ContentSection.create({

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -720,7 +720,7 @@ class TestContentSection(object):
                 "type": "list",
             }, {
                 "id": "q5",
-                "question": "Yes no question",
+                "question": "Boolean list question",
                 "type": "boolean_list",
             }, {
                 "id": "q6",
@@ -885,7 +885,7 @@ class TestContentSection(object):
                 "type": "list",
             }, {
                 "id": "q5",
-                "question": "Yes no question",
+                "question": "Boolean list question",
                 "type": "boolean_list",
             }, {
                 "id": "q6",

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 
 import mock
-from werkzeug.datastructures import ImmutableMultiDict
+from werkzeug.datastructures import ImmutableOrderedMultiDict
 import pytest
 
 import io
@@ -502,7 +502,7 @@ class TestContentManifest(object):
             }
         ])
 
-        form = ImmutableMultiDict([
+        form = ImmutableOrderedMultiDict([
             ('q1', 'some text'),
             ('q2', 'other text'),
             ('q3', '  lots of      whitespace     \t\n'),
@@ -795,7 +795,7 @@ class TestContentSection(object):
             }]
         })
 
-        form = ImmutableMultiDict([
+        form = ImmutableOrderedMultiDict([
             ('q1', 'true'),
             ('q01', 'some nested question'),
             ('q2', 'Some text stuff'),
@@ -843,23 +843,23 @@ class TestContentSection(object):
         }
 
         # Failure modes
-        form = ImmutableMultiDict([
+        form = ImmutableOrderedMultiDict([
             ('q1', 'not boolean')
         ])
         assert section.get_data(form)['q1'] == 'not boolean'
 
-        form = ImmutableMultiDict([
+        form = ImmutableOrderedMultiDict([
             ('q1', 'false')
         ])
         assert section.get_data(form)['q1'] is False
 
-        form = ImmutableMultiDict([
+        form = ImmutableOrderedMultiDict([
             ('q10', 'not a number')
         ])
         assert section.get_data(form)['q10'] == 'not a number'
 
         # Test 'orphaned' assurance is returned
-        form = ImmutableMultiDict([
+        form = ImmutableOrderedMultiDict([
             ('q7--assurance', 'yes I am'),
         ])
         data = section.get_data(form)
@@ -870,19 +870,19 @@ class TestContentSection(object):
         }
 
         # Test empty lists are not converted to `None`
-        form = ImmutableMultiDict([
+        form = ImmutableOrderedMultiDict([
             ('q4', '')
         ])
         assert section.get_data(form)['q4'] == ['']
 
         # if we have one empty value
-        form = ImmutableMultiDict([
+        form = ImmutableOrderedMultiDict([
             ('q5-0', '')
         ])
         assert section.get_data(form)['q5'] == ['']
 
         # if we have a value without an index number, we ignore it
-        form = ImmutableMultiDict([
+        form = ImmutableOrderedMultiDict([
             ('q5', 'true'),
             ('q5-', 'true')
         ])


### PR DESCRIPTION
After a _few_ false starts on how to handle the `boolean_list_question` type, this seems to me to be the neatest way to get all the non-reusable code into the ContentLoader.  

Two main things: (1) adding brief questions to the section data and (2) getting the right error messages.
- Boolean list questions need, at some point, to receive a list of questions typed by buyers into their brief.  Adding `.inject_brief_questions_into_boolean_list_question()` methods to both the `ContentSection` and the `ContentQuestion` is a fairly straightforward way to do this.
- Calling `.get_error_messages()` on a `ContentQuestionSummary` returns the right error messages for boolean lists
 - _if_ `self.id` key is returned by API's validation messages
 - _if_ `self.type == 'boolean_list'`
 - _if_ a `boolean_list_questions` key exists

Logic in the supplier app is [wayyy simpler](https://github.com/alphagov/digitalmarketplace-supplier-frontend/commit/59f5c68e708420b00029ad19c84a16dc204f62d5).

Wrote the tests.  Should be good to go.