### PR TITLE
Accommodate for optional boolean_list questions

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '19.0.0'
+__version__ = '19.0.1'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -499,6 +499,9 @@ class ContentQuestion(object):
 
     def inject_brief_questions_into_boolean_list_question(self, brief):
         if self.type == 'boolean_list':
+            if self.id not in brief.keys() and not self.get('optional'):
+                raise ContentNotFoundError("No {} found for brief {}".format(self.id, brief['id']))
+
             # briefs might not have optional boolean_list questions
             self.boolean_list_questions = brief.get(self.id, [])
 

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -499,7 +499,8 @@ class ContentQuestion(object):
 
     def inject_brief_questions_into_boolean_list_question(self, brief):
         if self.type == 'boolean_list':
-            self.boolean_list_questions = brief[self.id]
+            # briefs might not have optional boolean_list questions
+            self.boolean_list_questions = brief.get(self.id, [])
 
     def has_assurance(self):
         return True if self.get('assuranceApproach') else False

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1329,6 +1329,20 @@ class TestContentSection(object):
         section.inject_brief_questions_into_boolean_list_question(brief['briefs'])
         assert section.get_question('q0').get('boolean_list_questions') == brief['briefs']['q0']
 
+    def test_inject_messages_into_section_optional_question_missing(self):
+
+        section, brief, form_data = self.setup_for_boolean_list_tests()
+        # add an optional boolean list question
+        section['questions'].append({
+            "id": "q1",
+            "question": "Optional boolean list question",
+            "type": "boolean_list",
+        })
+
+        section = ContentSection.create(section)
+        section.inject_brief_questions_into_boolean_list_question(brief['briefs'])
+        assert section.get_question('q0').get('boolean_list_questions') == brief['briefs']['q0']
+
     def test_inject_messages_into_section_and_section_summary(self):
 
         section, brief, form_data = self.setup_for_boolean_list_tests()

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -608,6 +608,7 @@ class TestContentSection(object):
 
         brief = {
             "briefs": {
+                "id": "0",
                 "q0": [
                     "Can you do Sketch, Photoshop, Illustrator, and InDesign?",
                     "Can you can communicate like a boss?",
@@ -1337,11 +1338,22 @@ class TestContentSection(object):
             "id": "q1",
             "question": "Optional boolean list question",
             "type": "boolean_list",
+            "optional": True
         })
 
         section = ContentSection.create(section)
         section.inject_brief_questions_into_boolean_list_question(brief['briefs'])
         assert section.get_question('q0').get('boolean_list_questions') == brief['briefs']['q0']
+
+    def test_inject_messages_into_section_non_optional_question_missing(self):
+
+        section, brief, form_data = self.setup_for_boolean_list_tests()
+        # add an optional boolean list question
+        brief['briefs'].pop("q0")
+
+        section = ContentSection.create(section)
+        with pytest.raises(ContentNotFoundError):
+            section.inject_brief_questions_into_boolean_list_question(brief['briefs'])
 
     def test_inject_messages_into_section_and_section_summary(self):
 


### PR DESCRIPTION
`boolean_list` questions have buyers' essential/nice-to-have questions passed into them from published briefs so that they can build forms and do error messages properly.  
The `QuestionContent` object knows about itself.  It knows 
- Its `type` (ie, `boolean_list`) 
- Its `id` (ie, `niceToHaveRequirements`)

Once we pass in brief JSON data to a section, `boolean_list` questions will look for their `id` value in the brief (ie, they'll look for `brief['niceToHaveRequirements`]).  Unfortunately, since some `boolean_list` questions are optional, there was a possibility that the brief wouldn't contain the key and we'd see our 500-level error page.

This pull request recovers from situations where an optional `boolean_list` question can't be found in the brief.  It throws an error if a non-optional question is missing. 

#### Notes 

- Is it worth checking for an error?  I can't really see how a brief returned from the API could get into a state where a required bit of information is missing.
 - If not, we can stop checking if a question is optional (see [the first commit](https://github.com/alphagov/digitalmarketplace-utils/commit/35aa8dd6c3f6ff95232bbde9a6525fa04daf1cad))
 - If so, is `ContentNotFoundError` the right one to use?