### PR TITLE
Replace question value with matching option label if present

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '19.0.1'
+__version__ = '19.1.0'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -603,7 +603,15 @@ class ContentQuestionSummary(ContentQuestion):
         if self.has_assurance():
             return self._service_data.get(self.id, {}).get('value', '')
 
-        return self._service_data.get(self.id, '')
+        # Look up display values for options that have different labels from values
+        options = self.get('options')
+        value = self._service_data.get(self.id, '')
+        if options and value:
+            for option in options:
+                if 'label' in option and 'value' in option and option['value'] == value:
+                    return option['label']
+
+        return value
 
     @property
     def assurance(self):

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1216,7 +1216,7 @@ class TestContentSection(object):
         section_summary = section.summary(response_data)
         error_messages = section_summary.get_error_messages(errors)
 
-        assert error_messages['q0'] == True
+        assert error_messages['q0'] is True
         for error_key in ['q0-3']:
             assert error_key in error_messages
             base_error_key, index = error_key.split('-')[0], int(error_key.split('-')[-1])
@@ -1237,7 +1237,7 @@ class TestContentSection(object):
         section_summary = section.summary(response_data)
         error_messages = section_summary.get_error_messages(errors)
 
-        assert error_messages['q0'] == True
+        assert error_messages['q0'] is True
         for error_key in ['q0-0', 'q0-1', 'q0-2', 'q0-3']:
             assert error_key in error_messages
             base_error_key, index = error_key.split('-')[0], int(error_key.split('-')[-1])
@@ -1467,6 +1467,29 @@ class TestContentQuestion(object):
             ]
         })
         assert question.required_form_fields == ['example2']
+
+
+class TestContentQuestionSummary(object):
+    def test_question_value_with_no_options(self):
+        question = ContentQuestion({
+            "id": "example",
+            "type": "text",
+        }).summary({'example': 'value1'})
+
+        assert question.value == 'value1'
+
+    def test_question_value_returns_matching_option_label(self):
+        question = ContentQuestion({
+            "id": "example",
+            "type": "checkboxes",
+            "options": [
+                {"label": "Wrong label", "value": "value"},
+                {"label": "Option label", "value": "value1"},
+                {"label": "Wrong label", "value": "value11"},
+            ]
+        }).summary({'example': 'value1'})
+
+        assert question.value == 'Option label'
 
 
 class TestReadYaml(object):


### PR DESCRIPTION
ContentQuestionSummary.value will return the matching option label for the question value instead of the value itself, so that questions that have human-readable labels for values display them in the summary tables.

This is similar to the processing we do for displaying price strings, so `.value` seems like a good place for it.