### PR TITLE
Allow Reply-To to be overridden when sending email

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '19.1.0'
+__version__ = '19.2.0'

--- a/dmutils/email.py
+++ b/dmutils/email.py
@@ -19,7 +19,7 @@ class MandrillException(Exception):
     pass
 
 
-def send_email(to_email_addresses, email_body, api_key, subject, from_email, from_name, tags):
+def send_email(to_email_addresses, email_body, api_key, subject, from_email, from_name, tags, reply_to=None):
     if isinstance(to_email_addresses, string_types):
         to_email_addresses = [to_email_addresses]
 
@@ -40,7 +40,7 @@ def send_email(to_email_addresses, email_body, api_key, subject, from_email, fro
             'track_clicks': False,
             'auto_text': True,
             'tags': tags,
-            'headers': {'Reply-To': from_email},
+            'headers': {'Reply-To': reply_to or from_email},
             'preserve_recipients': False,
             'recipient_metadata': [{
                 'rcpt': email_address

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -103,6 +103,46 @@ def test_calls_send_email_to_multiple_addresses(email_app, mandrill):
         ]
 
 
+def test_calls_send_email_with_alternative_reply_to(email_app, mandrill):
+    with email_app.app_context():
+        mandrill.messages.send.return_value = [
+            {'_id': '123', 'email': '123'}]
+
+        expected_call = {
+            'html': "body",
+            'subject': "subject",
+            'from_email': "from_email",
+            'from_name': "from_name",
+            'to': [{
+                'email': "email_address",
+                'type': 'to'
+            }],
+            'important': False,
+            'track_opens': False,
+            'track_clicks': False,
+            'auto_text': True,
+            'tags': ['password-resets'],
+            'headers': {'Reply-To': "reply_address"},
+            'preserve_recipients': False,
+            'recipient_metadata': [{
+                'rcpt': "email_address"
+            }]
+        }
+
+        send_email(
+            "email_address",
+            "body",
+            "api_key",
+            "subject",
+            "from_email",
+            "from_name",
+            ["password-resets"],
+            reply_to="reply_address"
+        )
+
+        mandrill.messages.send.assert_called_once_with(message=expected_call, async=True)
+
+
 def test_should_throw_exception_if_mandrill_fails(email_app, mandrill):
     with email_app.app_context():
 


### PR DESCRIPTION
MailChimp will soon only allow emails to be sent from correctly authorized domains. This change allows the Reply-To address to be different to the From address which means we can send emails from an address we own while sending the reply to the supplier.