### PR TITLE
Add pluralize template function

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '19.2.0'
+__version__ = '19.3.0'

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -58,7 +58,13 @@ def init_app(
 
     @application.context_processor
     def inject_global_template_variables():
-        return application.config['BASE_TEMPLATE_DATA']
+        return dict(
+            pluralize=pluralize,
+            **(application.config['BASE_TEMPLATE_DATA'] or {}))
+
+
+def pluralize(count, singular, plural):
+    return singular if count == 1 else plural
 
 
 def get_extra_files(paths):

--- a/tests/test_flask_init.py
+++ b/tests/test_flask_init.py
@@ -1,0 +1,11 @@
+from dmutils.flask_init import pluralize
+import pytest
+
+
+@pytest.mark.parametrize("count,singular,plural,output", [
+    (0, "person", "people", "people"),
+    (1, "person", "people", "person"),
+    (2, "person", "people", "people"),
+])
+def test_pluralize(count, singular, plural, output):
+    assert pluralize(count, singular, plural) == output


### PR DESCRIPTION
Add a function to Jinja context for pluralization. This function works in a similar way to Rails's pluralize function (but without the magic understanding of English).
http://apidock.com/rails/ActionView/Helpers/TextHelper/pluralize