### PR TITLE
Add has summary page property to content section

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '19.3.0'
+__version__ = '19.4.0'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -331,7 +331,7 @@ class ContentSection(object):
 
     @property
     def has_summary_page(self):
-        return len(self.questions) > 1 or self.description
+        return len(self.questions) > 1 or self.description is not None
 
 
 class ContentQuestion(object):

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -329,6 +329,10 @@ class ContentSection(object):
         question = self.get_question(key)
         return bool(question) and question.has_assurance()
 
+    @property
+    def has_summary_page(self):
+        return len(self.questions) > 1 or self.description
+
 
 class ContentQuestion(object):
     def __init__(self, data, number=None):

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -627,6 +627,47 @@ class TestContentSection(object):
 
         return section, brief, form
 
+    def test_has_summary_page_if_multiple_questions(self):
+        section = ContentSection.create({
+            "slug": "first_section",
+            "name": "First section",
+            "questions": [{
+                "id": "q1",
+                "question": "Boolean question",
+                "type": "boolean",
+            }, {
+                "id": "q2",
+                "question": "Text question",
+                "type": "text",
+            }]
+        })
+        assert section.has_summary_page == True
+
+    def test_has_no_summary_page_if_single_question_no_description(self):
+        section = ContentSection.create({
+            "slug": "first_section",
+            "name": "First section",
+            "questions": [{
+                "id": "q1",
+                "question": "Boolean question",
+                "type": "boolean",
+            }]
+        })
+        assert section.has_summary_page == False
+
+    def test_has_summary_page_if_single_question_with_description(self):
+        section = ContentSection.create({
+            "slug": "first_section",
+            "name": "First section",
+            "description": "Section about a single topic",
+            "questions": [{
+                "id": "q1",
+                "question": "Boolean question",
+                "type": "boolean",
+            }]
+        })
+        assert section.has_summary_page == True
+
     def test_get_question_ids(self):
         section = ContentSection.create({
             "slug": "first_section",

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -641,7 +641,7 @@ class TestContentSection(object):
                 "type": "text",
             }]
         })
-        assert section.has_summary_page == True
+        assert section.has_summary_page is True
 
     def test_has_no_summary_page_if_single_question_no_description(self):
         section = ContentSection.create({
@@ -653,7 +653,7 @@ class TestContentSection(object):
                 "type": "boolean",
             }]
         })
-        assert section.has_summary_page == False
+        assert section.has_summary_page is False
 
     def test_has_summary_page_if_single_question_with_description(self):
         section = ContentSection.create({
@@ -666,7 +666,7 @@ class TestContentSection(object):
                 "type": "boolean",
             }]
         })
-        assert section.has_summary_page == True
+        assert section.has_summary_page is True
 
     def test_get_question_ids(self):
         section = ContentSection.create({


### PR DESCRIPTION
As part of the DOS work, a need has come up for section pages to appear based on certain conditions.

1. [if a section has some description text](http://dm-prototype.herokuapp.com/outcomesqa) the user needs to read
2. [if a section holds more than one question](http://dm-prototype.herokuapp.com/outcomes-brief) the user needs to be able to see them all in one place

If neither of these are the case, and so there is only one question in the section, the user should be taken straight to that section's question.

These conditions are based on a relationship between properties on instances of the ContentSection class so it seems sensible for a property to be added which indicates the boolean result of that decision.