### PR TITLE
Add `step` property to ContentSection

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '19.4.0'
+__version__ = '19.5.0'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -163,10 +163,19 @@ class ContentSection(object):
                 edit_questions=section.get('edit_questions'),
                 questions=[ContentQuestion(question) for question in section['questions']],
                 description=section.get('description'),
-                summary_page_description=section.get('summary_page_description'))
+                summary_page_description=section.get('summary_page_description'),
+                step=section.get('step'))
 
     def __init__(
-        self, slug, name, editable, edit_questions, questions, description=None, summary_page_description=None
+            self,
+            slug,
+            name,
+            editable,
+            edit_questions,
+            questions,
+            description=None,
+            summary_page_description=None,
+            step=None
     ):
         self.id = slug  # TODO deprecated, use `.slug` instead
         self.slug = slug
@@ -176,6 +185,7 @@ class ContentSection(object):
         self.questions = questions
         self.description = description
         self.summary_page_description = summary_page_description
+        self.step = step
 
     def __getitem__(self, key):
         return getattr(self, key)
@@ -188,7 +198,8 @@ class ContentSection(object):
             edit_questions=self.edit_questions,
             questions=self.questions[:],
             description=self.description,
-            summary_page_description=self.summary_page_description)
+            summary_page_description=self.summary_page_description,
+            step=self.step)
 
     def summary(self, service_data):
         summary_section = self.copy()

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1363,6 +1363,18 @@ class TestContentSection(object):
         assert copy_of_section.description == "This is the first section"
         assert copy_of_section.summary_page_description == "This is a summary of the first section"
 
+    def test_section_step(self):
+        section = ContentSection.create({
+            "slug": "first_section",
+            "name": "First section",
+            "questions": [],
+            "step": 1
+        })
+        assert section.step == 1
+
+        copy_of_section = section.copy()
+        assert copy_of_section.step == 1
+
     def test_inject_messages_into_section(self):
 
         section, brief, form_data = self.setup_for_boolean_list_tests()


### PR DESCRIPTION
Adds an optional `step` property to ContentSection objects. Pretty straightforward.

Steps are a (new!) key in our `edit_brief.yml` manifest.  Or they will be, once [the relevant pull request](https://github.com/alphagov/digitalmarketplace-frameworks/pull/220) goes in.