### PR TITLE
Add support for unpacking pricing 'price' field

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '19.5.0'
+__version__ = '19.6.0'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -602,6 +602,7 @@ class ContentQuestionSummary(ContentQuestion):
         if self.questions:
             return [question for question in self.questions if not question.is_empty]
         if self.type == "pricing":
+            price = self._service_data.get(self.fields.get('price'))
             minimum_price = self._service_data.get(self.fields.get('minimum_price'))
             maximum_price = self._service_data.get(self.fields.get('maximum_price'))
             price_unit = self._service_data.get(self.fields.get('price_unit'),
@@ -611,8 +612,8 @@ class ContentQuestionSummary(ContentQuestion):
             hours_for_price = self._service_data.get(self.fields.get('hours_for_price'),
                                                      self._default_for_field('hours_for_price'))
 
-            if minimum_price and price_unit:
-                return format_price(minimum_price, maximum_price, price_unit, price_interval, hours_for_price)
+            if price or minimum_price:
+                return format_price(price or minimum_price, maximum_price, price_unit, price_interval, hours_for_price)
             else:
                 return ''
         if self.has_assurance():

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -98,10 +98,13 @@ def format_price(min_price, max_price, unit, interval, hours_for_price=None):
     if hours_for_price:
         return u'{} for £{}'.format(hours_for_price, min_price)
 
+    if min_price is None:
+        raise TypeError('min_price should be string or integer, not None')
     formatted_price = u'£{}'.format(min_price)
     if max_price:
         formatted_price += u' to £{}'.format(max_price)
-    formatted_price += ' per ' + unit.lower()
+    if unit:
+        formatted_price += ' per ' + unit.lower()
     if interval:
         formatted_price += ' per ' + interval.lower()
     return formatted_price

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -68,6 +68,7 @@ def test_format_price():
         (('12', None, 'Unit', 'Second'), u'£12 per unit per second'),
         ((12, 13, 'Unit', None), u'£12 to £13 per unit'),
         (('34', None, 'Lab', None, '4 hours'), u'4 hours for £34'),
+        (('12', None, None, None), u'£12'),
     ]
 
     def check_price_formatting(args, formatted_price):
@@ -79,7 +80,6 @@ def test_format_price():
 
 def test_format_price_errors():
     cases = [
-        ('12', None, None, None),
         (None, None, None, None),
     ]
 


### PR DESCRIPTION
'price' field is already part of the pricing form template. It was added when we thought specialist prices will be a number instead of a range, but it seems that utils support hasn't been finished.

This also makes unit an optional field, so that price string can be formatted with price alone. This shouldn't affect anything since questions with required price unit will have to validate it first before displaying summary price string.