### PR TITLE
Allow abbreviations in our markdown filter

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '19.6.0'
+__version__ = '19.7.0'

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -2,4 +2,4 @@ from markdown import markdown
 
 
 def markdown_filter(text, *args, **kwargs):
-    return markdown(text, *args, **kwargs)
+    return markdown(text, ['markdown.extensions.extra'], *args, **kwargs)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -10,7 +10,12 @@ def test_markdown_filter_produces_markup():
 
 Paragraph
 **Bold**
-*Emphasis*"""
+*Emphasis*
+
+HTML is an abbreviation.
+
+*[HTML]: Hyper Text Markup Language
+"""
 
     html_string = """<h2>H2 title</h2>
 <ul>
@@ -19,6 +24,7 @@ Paragraph
 </ul>
 <p>Paragraph
 <strong>Bold</strong>
-<em>Emphasis</em></p>"""
+<em>Emphasis</em></p>
+<p><abbr title="Hyper Text Markup Language">HTML</abbr> is an abbreviation.</p>"""
 
     assert markdown_filter(markdown_string) == html_string


### PR DESCRIPTION
Abbreviations are an extremely valuable and important part of HTML, and it's frankly shocking that we've not supported them before now.

We're using them [in some of our framework messages](https://github.com/alphagov/digitalmarketplace-frameworks/blob/master/frameworks/digital-outcomes-and-specialists/messages/dates.yml), so this way we could reformat them as markdown and avoid having to fall back to the `|safe` filter.

[Syntax for abbreviations here](http://pythonhosted.org/Markdown/extensions/abbreviations.html).