### PR TITLE
Extend markdown less

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '19.7.0'
+__version__ = '19.7.1'

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -2,4 +2,4 @@ from markdown import markdown
 
 
 def markdown_filter(text, *args, **kwargs):
-    return markdown(text, ['markdown.extensions.extra'], *args, **kwargs)
+    return markdown(text, ['markdown.extensions.abbr'], *args, **kwargs)


### PR DESCRIPTION
So I've made one mistake in my life.

This pull request updates the `|markdown` filter to only use the `abbr` extension.
`extra` includes 6 other extensions, none of which we need right now.