### PR TITLE
Do not localize time when displaying dates only

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '19.7.1'
+__version__ = '19.7.2'

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -38,11 +38,11 @@ def timeformat(value, default_value=None):
 
 
 def shortdateformat(value, default_value=None):
-    return _format_date(value, default_value, DISPLAY_SHORT_DATE_FORMAT)
+    return _format_date(value, default_value, DISPLAY_SHORT_DATE_FORMAT, localize=False)
 
 
 def dateformat(value, default_value=None):
-    return _format_date(value, default_value, DISPLAY_DATE_FORMAT)
+    return _format_date(value, default_value, DISPLAY_DATE_FORMAT, localize=False)
 
 
 def datetimeformat(value, default_value=None):
@@ -52,14 +52,17 @@ def datetimeformat(value, default_value=None):
 EUROPE_LONDON = pytz.timezone("Europe/London")
 
 
-def _format_date(value, default_value, fmt):
+def _format_date(value, default_value, fmt, localize=True):
     if not value:
         return default_value
     if not isinstance(value, datetime):
         value = datetime.strptime(value, DATETIME_FORMAT)
     if value.tzinfo is None:
         value = pytz.utc.localize(value)
-    return value.astimezone(EUROPE_LONDON).strftime(fmt)
+    if localize:
+        return value.astimezone(EUROPE_LONDON).strftime(fmt)
+    else:
+        return value.strftime(fmt)
 
 
 def lot_to_lot_case(lot_to_check):

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -114,6 +114,8 @@ def test_shortdateformat():
         (datetime(2012, 8, 10, 9, 8, 7, 6), "10 August"),
         ("2012-08-10T09:08:07.0Z", "10 August"),
         (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "10 August"),
+        ("2016-04-27T23:59:59.0Z", "27 April"),
+        (datetime(2016, 4, 27, 23, 59, 59, 0, tzinfo=pytz.utc), "27 April"),
     ]
 
     def check_shortdateformat(dt, formatted_date):
@@ -130,6 +132,8 @@ def test_dateformat():
         (datetime(2012, 8, 10, 9, 8, 7, 6), "Friday 10 August 2012"),
         ("2012-08-10T09:08:07.0Z", "Friday 10 August 2012"),
         (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "Friday 10 August 2012"),
+        ("2016-04-27T23:59:59.0Z", "Wednesday 27 April 2016"),
+        (datetime(2016, 4, 27, 23, 59, 59, 0), "Wednesday 27 April 2016"),
     ]
 
     def check_dateformat(dt, formatted_date):


### PR DESCRIPTION
When displaying a date only from a datetime we shouldn't localize to London time.

Example
 =======
 Consider the datetime `2016-04-27T23:59:59.0Z`
 When displaying this as a date it should be "Wednesday 27 April 2016", but when localized to London, as it is BST the hour gets rolled forward and the displayed date becomes "Thursday 28 April 2016", which is wrong.

 When displaying the actual time it makes sense to continue to localize.