### PR TITLE
Check for csv filetype

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '19.7.2'
+__version__ = '19.8.0'

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -152,6 +152,13 @@ def file_is_pdf(file_object):
     ]
 
 
+def file_is_csv(file_object):
+    """Checks file extension as being PDF."""
+    return get_extension(file_object.filename) in [
+        ".csv"
+    ]
+
+
 def file_is_zip(file_object):
     """Checks file extension as being ZIP."""
     return get_extension(file_object.filename) in [

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -17,8 +17,8 @@ from dmutils.documents import (
     validate_documents,
     upload_document, upload_service_documents,
     get_signed_url, get_agreement_document_path, get_document_path,
-    sanitise_supplier_name, file_is_pdf, file_is_zip
-)
+    sanitise_supplier_name, file_is_pdf, file_is_zip,
+    file_is_csv)
 
 
 class TestGenerateFilename(unittest.TestCase):
@@ -76,6 +76,10 @@ class TestValidateDocuments(unittest.TestCase):
     def test_file_is_pdf(self):
         self.assertTrue(file_is_pdf(mock_file('file.pdf', 1)))
         self.assertFalse(file_is_pdf(mock_file('file.doc', 1)))
+
+    def test_file_is_csv(self):
+        self.assertTrue(file_is_csv(mock_file('file.csv', 1)))
+        self.assertFalse(file_is_csv(mock_file('file.sit', 1)))
 
     def test_file_is_zip(self):
         self.assertTrue(file_is_zip(mock_file('file.zip', 1)))


### PR DESCRIPTION
Related to this story: https://www.pivotaltracker.com/story/show/118178617

Communications files can be PDF or CSV, so we need this additional test for document type.