### PR TITLE
Remove date format zero-padding

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '19.8.0'
+__version__ = '19.8.1'

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -4,10 +4,10 @@ import pytz
 
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_FORMAT = "%Y-%m-%d"
-DISPLAY_SHORT_DATE_FORMAT = '%d %B'
-DISPLAY_DATE_FORMAT = '%A %d %B %Y'
+DISPLAY_SHORT_DATE_FORMAT = '%-d %B'
+DISPLAY_DATE_FORMAT = '%A %-d %B %Y'
 DISPLAY_TIME_FORMAT = '%H:%M:%S'
-DISPLAY_DATETIME_FORMAT = '%A %d %B %Y at %H:%M'
+DISPLAY_DATETIME_FORMAT = '%A %-d %B %Y at %H:%M'
 
 LOTS = [
     {

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -98,6 +98,7 @@ def test_timeformat():
         (datetime(2012, 8, 10, 9, 8, 7, 6), "10:08:07"),
         ("2012-08-12T12:12:12.0Z", "13:12:12"),
         (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "10:08:07"),
+        (datetime(2012, 8, 10, 0, 8, 7, 6, tzinfo=pytz.utc), "01:08:07"),
     ]
 
     def check_timeformat(dt, formatted_time):
@@ -116,6 +117,7 @@ def test_shortdateformat():
         (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "10 August"),
         ("2016-04-27T23:59:59.0Z", "27 April"),
         (datetime(2016, 4, 27, 23, 59, 59, 0, tzinfo=pytz.utc), "27 April"),
+        (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), "1 August"),
     ]
 
     def check_shortdateformat(dt, formatted_date):
@@ -134,6 +136,7 @@ def test_dateformat():
         (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "Friday 10 August 2012"),
         ("2016-04-27T23:59:59.0Z", "Wednesday 27 April 2016"),
         (datetime(2016, 4, 27, 23, 59, 59, 0), "Wednesday 27 April 2016"),
+        (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), "Wednesday 1 August 2012"),
     ]
 
     def check_dateformat(dt, formatted_date):
@@ -150,6 +153,7 @@ def test_datetimeformat():
         (datetime(2012, 8, 10, 9, 8, 7, 6), "Friday 10 August 2012 at 10:08"),
         ("2012-08-10T09:08:07.0Z", "Friday 10 August 2012 at 10:08"),
         (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "Friday 10 August 2012 at 10:08"),
+        (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), "Wednesday 1 August 2012 at 10:08"),
     ]
 
     def check_datetimeformat(dt, formatted_datetime):


### PR DESCRIPTION
Doesn't add leading zeroes to day of the month when displaying the date.