### PR TITLE
Replace 'percentage' question type with 'number'

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '19.8.1'
+__version__ = '19.9.0'

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -622,6 +622,11 @@ class ContentQuestionSummary(ContentQuestion):
         # Look up display values for options that have different labels from values
         options = self.get('options')
         value = self._service_data.get(self.id, '')
+        if self.type == "number" and self.get('unit'):
+            if self.unit_position == "after":
+                return u"{}{}".format(value, self.unit)
+            else:
+                return u"{}{}".format(self.unit, value)
         if options and value:
             for option in options:
                 if 'label' in option and 'value' in option and option['value'] == value:

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -424,7 +424,7 @@ class ContentQuestion(object):
 
         elif self.type == 'boolean':
             value = convert_to_boolean(form_data[self.id])
-        elif self.type == 'percentage':
+        elif self.type == 'number':
             value = convert_to_number(form_data[self.id])
         elif self.type != 'upload':
             value = form_data[self.id]

--- a/dmutils/content_loader.py
+++ b/dmutils/content_loader.py
@@ -437,7 +437,7 @@ class ContentQuestion(object):
                 "assurance": form_data.get(self.id + '--assurance'),
             }
 
-        if self.type != 'boolean':
+        if self.type not in ['boolean', 'number']:
             value = value if value else None
 
         return {self.id: value}

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -820,8 +820,8 @@ class TestContentSection(object):
                 "type": "upload",
             }, {
                 "id": "q10",
-                "question": "Percentage question",
-                "type": "percentage",
+                "question": "number question",
+                "type": "number",
             }, {
                 "id": "q11",
                 "question": "Large text question",
@@ -985,8 +985,8 @@ class TestContentSection(object):
                 "type": "upload",
             }, {
                 "id": "q10",
-                "question": "Percentage question",
-                "type": "percentage",
+                "question": "number question",
+                "type": "number",
             }, {
                 "id": "q11",
                 "question": "Large text question",

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1550,6 +1550,34 @@ class TestContentQuestionSummary(object):
 
         assert question.value == 'Option label'
 
+    def test_number_questions_without_unit(self):
+        question = ContentQuestion({
+            "id": "example",
+            "type": "number",
+        }).summary({'example': '12.20'})
+
+        assert question.value == '12.20'
+
+    def test_number_questions_adds_unit_before(self):
+        question = ContentQuestion({
+            "id": "example",
+            "type": "number",
+            "unit": u"£",
+            "unit_position": "before",
+        }).summary({'example': '12.20'})
+
+        assert question.value == u'£12.20'
+
+    def test_number_questions_adds_unit_after(self):
+        question = ContentQuestion({
+            "id": "example",
+            "type": "number",
+            "unit": u"£",
+            "unit_position": "after",
+        }).summary({'example': '12.20'})
+
+        assert question.value == u'12.20£'
+
 
 class TestReadYaml(object):
     @mock.patch.object(builtins, 'open', return_value=io.StringIO(u'foo: bar'))

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -823,6 +823,10 @@ class TestContentSection(object):
                 "question": "number question",
                 "type": "number",
             }, {
+                "id": "q101",
+                "question": "zero number question",
+                "type": "number",
+            }, {
                 "id": "q11",
                 "question": "Large text question",
                 "type": "textbox_large",
@@ -859,6 +863,7 @@ class TestContentSection(object):
             ('q8-price_interval', 'Hour'),
             ('q9', 'blah blah'),
             ('q10', '12.12'),
+            ('q101', '0'),
             ('q11', 'Looooooooaaaaaaaaads of text'),
             ('extra_field', 'Should be lost'),
             ('q13', ''),
@@ -880,6 +885,7 @@ class TestContentSection(object):
             'q8-price_unit': 'Unit',
             'q8-price_interval': 'Hour',
             'q10': 12.12,
+            'q101': 0,
             'q11': 'Looooooooaaaaaaaaads of text',
             'q13': None,
         }

--- a/tests/test_service_attribute.py
+++ b/tests/test_service_attribute.py
@@ -22,11 +22,11 @@ class TestAttribute(unittest.TestCase):
             ''
         )
         self.assertEqual(
-            Attribute(None, 'percentage').type,
+            Attribute(None, 'number').type,
             'text'
         )
         self.assertEqual(
-            Attribute(None, 'percentage').value,
+            Attribute(None, 'number').value,
             ''
         )
         self.assertEqual(


### PR DESCRIPTION
Follows the change made in the frameworks repo to use a more general question type for number fields.

#### [#118085921] Don't replace 0 number values with None
Number questions submitted with '0' value showed `answer_required` validation error since the falsy value was replaced with `None`.

Fixing it so it's possible to submit '0'.