### PR TITLE
Add a new filter for correctly joining lists of strings

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '20.0.0'
+__version__ = '20.1.0'

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -3,3 +3,12 @@ from markdown import markdown
 
 def markdown_filter(text, *args, **kwargs):
     return markdown(text, ['markdown.extensions.abbr'], *args, **kwargs)
+
+
+def smartjoin(list_to_join):
+    if len(list_to_join) > 1:
+        return '{} and {}'.format(', '.join(list_to_join[:-1]), list_to_join[-1])
+    elif len(list_to_join) == 1:
+        return '{}'.format(list_to_join[0])
+    else:
+        return ''

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -5,7 +5,8 @@ def markdown_filter(text, *args, **kwargs):
     return markdown(text, ['markdown.extensions.abbr'], *args, **kwargs)
 
 
-def smartjoin(list_to_join):
+def smartjoin(input):
+    list_to_join = list(input)
     if len(list_to_join) > 1:
         return '{} and {}'.format(', '.join(list_to_join[:-1]), list_to_join[-1])
     elif len(list_to_join) == 1:

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -55,6 +55,7 @@ def init_app(
     application.add_template_filter(formats.shortdateformat)
     application.add_template_filter(formats.dateformat)
     application.add_template_filter(formats.datetimeformat)
+    application.add_template_filter(filters.smartjoin)
 
     @application.context_processor
     def inject_global_template_variables():

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,4 +1,4 @@
-from dmutils.filters import markdown_filter
+from dmutils.filters import markdown_filter, smartjoin
 
 
 def test_markdown_filter_produces_markup():
@@ -28,3 +28,21 @@ HTML is an abbreviation.
 <p><abbr title="Hyper Text Markup Language">HTML</abbr> is an abbreviation.</p>"""
 
     assert markdown_filter(markdown_string) == html_string
+
+
+def test_smartjoin_for_more_than_one_item():
+    list_to_join = ['one', 'two', 'three', 'four']
+    filtered_string = 'one, two, three and four'
+    assert smartjoin(list_to_join) == filtered_string
+
+
+def test_smartjoin_for_one_item():
+    list_to_join = ['one']
+    filtered_string = 'one'
+    assert smartjoin(list_to_join) == filtered_string
+
+
+def test_smartjoin_for_empty_list():
+    list_to_join = []
+    filtered_string = ''
+    assert smartjoin(list_to_join) == filtered_string


### PR DESCRIPTION
Part of the work for [this](https://www.pivotaltracker.com/story/show/118472411) story on Pivotal.

Creates a new filter for joining a list of strings with a comma, except for the last item which is joined with 'and'.

It deals with a couple of edge cases. If the list only has one item, it just returns that item without a comma or 'and'. If the list has no items it just returns an empty string.

All strings are lower case.