### PR TITLE
Send logs to STDERR only if DM_LOG_PATH is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 Records breaking changes from major version bumps
 
+## 21.0.0
+
+PR: [#266](https://github.com/alphagov/digitalmarketplace-utils/pull/266)
+
+### What changed
+
+Logs will be written to a file or stdout/stderr based on the value of `DM_LOG_PATH`, even for environments with `DEBUG = True`.
+To write logs to stderr `DM_LOG_PATH` should be set to a falsy value (eg `None` or empty string). Currently, most app configs
+set `DM_LOG_PATH` to `/var/log/...` in the shared config. This declaration should be moved to Preview/Staging/Production configs,
+with the shared default set to `None`.
+
+### Example app change
+
+Old:
+```python
+
+class Config(object):
+    DM_LOG_PATH = '/var/log/digitalmarketplace/application.log'
+
+class Live(object):
+    pass
+
+```
+
+New:
+```python
+
+class Config(object):
+    DM_LOG_PATH = None
+
+class Live(object):
+    DM_LOG_PATH = '/var/log/digitalmarketplace/application.log'
+
+```
+
+
 ## 20.0.0
 
 PR: [#264](https://github.com/alphagov/digitalmarketplace-utils/pull/264)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '20.1.0'
+__version__ = '21.0.0'

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 def init_app(app):
     app.config.setdefault('DM_LOG_LEVEL', 'INFO')
     app.config.setdefault('DM_APP_NAME', 'none')
-    app.config.setdefault('DM_LOG_PATH', './log/application.log')
+    app.config.setdefault('DM_LOG_PATH', None)
 
     @app.after_request
     def after_request(response):
@@ -59,15 +59,16 @@ def get_handlers(app):
     standard_formatter = CustomLogFormatter(LOG_FORMAT, TIME_FORMAT)
     json_formatter = JSONFormatter(LOG_FORMAT, TIME_FORMAT)
 
-    if app.debug:
-        handler = logging.StreamHandler(sys.stderr)
-        handlers.append(configure_handler(handler, app, standard_formatter))
-    else:
+    # Log to files if the path is set, otherwise log to stderr
+    if app.config['DM_LOG_PATH']:
         handler = logging.FileHandler(app.config['DM_LOG_PATH'])
         handlers.append(configure_handler(handler, app, standard_formatter))
 
         handler = logging.FileHandler(app.config['DM_LOG_PATH'] + '.json')
         handlers.append(configure_handler(handler, app, json_formatter))
+    else:
+        handler = logging.StreamHandler(sys.stderr)
+        handlers.append(configure_handler(handler, app, standard_formatter))
 
     return handlers
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -28,17 +28,15 @@ def test_formatter_request_id_in_non_logging_app(app):
         assert RequestIdFilter().request_id == 'no-request-id'
 
 
-def test_init_app_adds_stream_handler_in_debug(app):
-    app.config['DEBUG'] = True
+def test_init_app_adds_stream_handler_without_log_path(app):
     init_app(app)
 
     assert len(app.logger.handlers) == 1
     assert isinstance(app.logger.handlers[0], logging.StreamHandler)
 
 
-def test_init_app_adds_file_handlers_in_non_debug(app):
+def test_init_app_adds_file_handlers_with_log_path(app):
     with tempfile.NamedTemporaryFile() as f:
-        app.config['DEBUG'] = False
         app.config['DM_LOG_PATH'] = f.name
         init_app(app)
 


### PR DESCRIPTION
At the moment, the decision to write logs to a file instead of to stdout/stderr is based on the value of DEBUG flag, with DEBUG=False environments writing to files and DEBUG=True to stderr. This worked
reasonably well when all non-DEBUG environments were hosted on AWS and the only DEBUG ones were development and testing. But this split is less useful for eg deploying to PaaS, since Cloud Foundry expects logs to be sent to stdout and stderr, but at the same time we don't necessarily want to switch apps to debug mode.

Basing the logging decision solely on DM_LOG_PATH makes more sense and would also allow us to switch debug on/off without redirecting the logs.