### PR TITLE
Add filter to format links.

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '21.0.0'
+__version__ = '21.1.0'

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -1,4 +1,6 @@
+import re
 from markdown import markdown
+from flask import Markup
 
 
 def markdown_filter(text, *args, **kwargs):
@@ -13,3 +15,28 @@ def smartjoin(input):
         return '{}'.format(list_to_join[0])
     else:
         return ''
+
+
+def format_links(text):
+    url_match = re.compile(r"""(
+                                (?:https?://|www\.)       # start with http:// or www.
+                                (?:[^\s/?\.#<>"']+\.?)+   # first part of host name
+                                \.                        # match dot in host name
+                                (?:[^\s/?\.#<>"']+\.?)+   # match rest of domain
+                                (?:/[^\s<>"']*)?          # rest of url
+                                [^\s<>"'\.]               # no dot at end
+                                )""", re.X)
+    matches = url_match.findall(text)
+    link = '{0}<a href={1} rel="external">{1}</a>'
+    if matches:
+        textArray = url_match.split(text)
+        formattedText = ""
+        for text in textArray:
+            if text in matches:
+                formattedText = link.format(formattedText, Markup.escape(text))
+            else:
+                formattedText = '{}{}'.format(formattedText, Markup.escape(text))
+        formattedText = Markup(formattedText)
+        return formattedText
+    else:
+        return text

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -50,7 +50,7 @@ def init_app(
     @application.template_filter('markdown')
     def markdown_filter_flask(data):
         return Markup(filters.markdown_filter(data))
-
+    application.add_template_filter(filters.format_links)
     application.add_template_filter(formats.timeformat)
     application.add_template_filter(formats.shortdateformat)
     application.add_template_filter(formats.dateformat)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,4 +1,4 @@
-from dmutils.filters import markdown_filter, smartjoin
+from dmutils.filters import markdown_filter, smartjoin, format_links
 
 
 def test_markdown_filter_produces_markup():
@@ -46,3 +46,40 @@ def test_smartjoin_for_empty_list():
     list_to_join = []
     filtered_string = ''
     assert smartjoin(list_to_join) == filtered_string
+
+
+def test_format_link():
+    link = 'http://www.example.com'
+    formatted_link = '<a href=http://www.example.com rel="external">http://www.example.com</a>'
+    assert format_links(link) == formatted_link
+
+
+def test_format_link_with_implied_protocol():
+    link = 'www.example.com'
+    formatted_link = '<a href=www.example.com rel="external">www.example.com</a>'
+    assert format_links(link) == formatted_link
+
+
+def test_format_link_with_text():
+    text = 'This is the link: http://www.example.com'
+    formatted_text = 'This is the link: <a href=http://www.example.com rel="external">http://www.example.com</a>'
+    assert format_links(text) == formatted_text
+
+
+def test_format_link_and_text_escapes_extra_html():
+    text = 'This is the <strong>link</strong>: http://www.example.com'
+    formatted_text = 'This is the &lt;strong&gt;link&lt;/strong&gt;: <a href=http://www.example.com rel="external">http://www.example.com</a>'  # noqa
+    assert format_links(text) == formatted_text
+
+
+def test_multiple_urls():
+    text = 'This is the first link http://www.example.com and this is the second http://secondexample.com.'  # noqa
+    formatted_text = 'This is the first link <a href=http://www.example.com '\
+        'rel="external">http://www.example.com</a> and this is the second '\
+        '<a href=http://secondexample.com rel="external">http://secondexample.com</a>.'
+    assert format_links(text) == formatted_text
+
+
+def test_no_links_no_change():
+    text = 'There are no links.'
+    assert format_links(text) == text


### PR DESCRIPTION
Add filter to format links.  Allows user inputted links to be marked up, and will prevent styled links in summary tables from breaking on mobile view.