### PR TITLE
Add.🐈 .for.`get_extension`.jpg

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '21.2.0'
+__version__ = '21.2.1'

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -9,7 +9,7 @@ from .helpers import mock_file
 from dmutils.s3 import S3ResponseError
 
 from dmutils.documents import (
-    generate_file_name,
+    generate_file_name, get_extension,
     file_is_not_empty, file_is_empty, filter_empty_files,
     file_is_less_than_5mb,
     file_is_open_document_format,
@@ -41,6 +41,15 @@ class TestGenerateFilename(unittest.TestCase):
 
 
 class TestValidateDocuments(unittest.TestCase):
+    def test_get_extension(self):
+        assert get_extension('what.jpg') == '.jpg'
+        assert get_extension('what the.jpg') == '.jpg'
+        assert get_extension('what.the.jpg') == '.jpg'
+        assert get_extension('what.the..jpg') == '.jpg'
+        assert get_extension('what.the.🐈.jpg') == '.jpg'
+        assert get_extension('what.the.🐈jpg') == '.🐈jpg'
+        assert get_extension('ಠ▃ಠ.jpg') == '.jpg'
+
     def test_file_is_not_empty(self):
         non_empty_file = mock_file('file1', 1)
         assert file_is_not_empty(non_empty_file)


### PR DESCRIPTION
Addresses some of the comments by @risicle in [the previous pull request](https://github.com/alphagov/digitalmarketplace-utils/pull/269).  
Specifically, tests that the correct extension is returned for files with multiple `.`s, for weird characters or even 🐈  s.  

