### PR TITLE
Make regex less catastrophic

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '21.2.1'
+__version__ = '21.2.2'

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -20,18 +20,15 @@ def smartjoin(input):
 
 def format_links(text):
     url_match = re.compile(r"""(
-                                (?:https?://|www\.)       # start with http:// or www.
-                                (?:[^\s/?\.#<>"']+\.?)+   # first part of host name
-                                \.                        # match dot in host name
-                                (?:[^\s/?\.#<>"']+\.?)+   # match rest of domain
-                                (?:/[^\s<>"']*)?          # rest of url
-                                [^\s<>,"'\.]              # no dot at end
+                                (?:https?://|www\.)    # start with http:// or www.
+                                (?:[^\s<>"'/?#]+)      # domain doesn't have these characters
+                                (?:[^\s<>"']+)         # post-domain part of URL doesn't have these characters
+                                [^\s<>,"'\.]           # no dot at end
                                 )""", re.X)
     matched_urls = url_match.findall(text)
     if matched_urls:
         link = '<a href="{0}" rel="external">{0}</a>'
         plaintext_link = '<span class="break-link">{0}</span>'
-        formatted_text = ""
         text_array = url_match.split(text)
         formatted_text_array = []
         for partial_text in text_array:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -56,7 +56,7 @@ def test_format_link():
     assert format_links(link) == formatted_link
 
 
-def test_format_link_withput_protocol():
+def test_format_link_without_protocol():
     link = 'www.example.com'
     formatted_link = '<span class="break-link">www.example.com</span>'
     assert format_links(link) == formatted_link
@@ -71,6 +71,15 @@ def test_format_link_with_text():
 def test_format_link_and_text_escapes_extra_html():
     text = 'This is the <strong>link</strong>: http://www.example.com'
     formatted_text = 'This is the &lt;strong&gt;link&lt;/strong&gt;: <a href="http://www.example.com" rel="external">http://www.example.com</a>'  # noqa
+    assert format_links(text) == formatted_text
+
+
+def test_format_link_does_not_die_horribly():
+    text = 'This is the URL that made a previous regex die horribly' \
+           'https://something&lt;span&gt;what&lt;/span&gt;something.com'
+    formatted_text = 'This is the URL that made a previous regex die horribly' \
+                     '<a href="https://something&amp;lt;span&amp;gt;what&amp;lt;/span&amp;gt;something.com" ' \
+                     'rel="external">https://something&amp;lt;span&amp;gt;what&amp;lt;/span&amp;gt;something.com</a>'
     assert format_links(text) == formatted_text
 
 


### PR DESCRIPTION
This replaces the old regular expression for URL matching with a new simpler one that doesn't die horribly on certain inputs.

The new version is not quite as precise (this one will match eg `www.foo` but the previous one required a further `.` before matching.  But we can live with this better than the whole site getting taken down by a bad brief.