### PR TITLE
[#124752631]format_links: apply specific (but customizable) classes to inserted html elements

### DIFF
--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -18,7 +18,16 @@ def smartjoin(input):
         return ''
 
 
-def format_links(text):
+def format_links(text, link_classes=("urlized-link",), plaintext_link_classes=("urlized-plaintext-link",)):
+    """
+        Replaces apparent urls in plaintext `text` with <a href="..."> elements, applying `link_classes` to the
+        resulting elements.
+
+        Apparent pseudo-urls (url-like substrings missing the scheme (beginning "www") are wrapped in a <span> element
+        to which `plaintext_link_classes` are applied.
+
+        `link_classes` and `plaintext_link_classes` are expected to be valid sensible html class names
+    """
     url_match = re.compile(r"""(
                                 (?:https?://|www\.)    # start with http:// or www.
                                 (?:[^\s<>"'/?#]+)      # domain doesn't have these characters
@@ -27,16 +36,18 @@ def format_links(text):
                                 )""", re.X)
     matched_urls = url_match.findall(text)
     if matched_urls:
-        link = '<a href="{0}" rel="external">{0}</a>'
-        plaintext_link = '<span class="break-link">{0}</span>'
+        link = '<a href="{0}" class="{1}" rel="external">{0}</a>'
+        plaintext_link = '<span class="{1}">{0}</span>'
+        joined_link_classes = " ".join(link_classes)
+        joined_plaintext_link_classes = " ".join(plaintext_link_classes)
         text_array = url_match.split(text)
         formatted_text_array = []
         for partial_text in text_array:
             if partial_text in matched_urls:
                 if partial_text.startswith('www'):
-                    url = plaintext_link.format(Markup.escape(partial_text))
+                    url = plaintext_link.format(Markup.escape(partial_text), joined_plaintext_link_classes)
                 else:
-                    url = link.format(Markup.escape(partial_text))
+                    url = link.format(Markup.escape(partial_text), joined_link_classes)
                 formatted_text_array.append(url)
             else:
                 partial_text = Markup.escape(partial_text)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -52,25 +52,25 @@ def test_smartjoin_for_empty_list():
 
 def test_format_link():
     link = 'http://www.example.com'
-    formatted_link = '<a href="http://www.example.com" rel="external">http://www.example.com</a>'
+    formatted_link = '<a href="http://www.example.com" class="urlized-link" rel="external">http://www.example.com</a>'
     assert format_links(link) == formatted_link
 
 
 def test_format_link_without_protocol():
     link = 'www.example.com'
-    formatted_link = '<span class="break-link">www.example.com</span>'
+    formatted_link = '<span class="urlized-plaintext-link">www.example.com</span>'
     assert format_links(link) == formatted_link
 
 
 def test_format_link_with_text():
     text = 'This is the Greek Γ Δ Ε Ζ Η Θ Ι Κ Λ link: http://www.exΔmple.com'
-    formatted_text = 'This is the Greek Γ Δ Ε Ζ Η Θ Ι Κ Λ link: <a href="http://www.exΔmple.com" rel="external">http://www.exΔmple.com</a>'  # noqa
+    formatted_text = 'This is the Greek Γ Δ Ε Ζ Η Θ Ι Κ Λ link: <a href="http://www.exΔmple.com" class="urlized-link" rel="external">http://www.exΔmple.com</a>'  # noqa
     assert format_links(text) == formatted_text
 
 
 def test_format_link_and_text_escapes_extra_html():
     text = 'This is the <strong>link</strong>: http://www.example.com'
-    formatted_text = 'This is the &lt;strong&gt;link&lt;/strong&gt;: <a href="http://www.example.com" rel="external">http://www.example.com</a>'  # noqa
+    formatted_text = 'This is the &lt;strong&gt;link&lt;/strong&gt;: <a href="http://www.example.com" class="urlized-link" rel="external">http://www.example.com</a>'  # noqa
     assert format_links(text) == formatted_text
 
 
@@ -78,17 +78,26 @@ def test_format_link_does_not_die_horribly():
     text = 'This is the URL that made a previous regex die horribly' \
            'https://something&lt;span&gt;what&lt;/span&gt;something.com'
     formatted_text = 'This is the URL that made a previous regex die horribly' \
-                     '<a href="https://something&amp;lt;span&amp;gt;what&amp;lt;/span&amp;gt;something.com" ' \
-                     'rel="external">https://something&amp;lt;span&amp;gt;what&amp;lt;/span&amp;gt;something.com</a>'
+                     '<a href="https://something&amp;lt;span&amp;gt;what&amp;lt;/span&amp;gt;something.com"' \
+                     ' class="urlized-link" rel="external">https://something&amp;lt;span&amp;gt;what&amp;lt;/span'\
+                     '&amp;gt;something.com</a>'
     assert format_links(text) == formatted_text
 
 
 def test_multiple_urls():
     text = 'This is the first link http://www.example.com and this is the second http://secondexample.com.'  # noqa
-    formatted_text = 'This is the first link <a href="http://www.example.com" '\
+    formatted_text = 'This is the first link <a href="http://www.example.com" class="urlized-link" '\
         'rel="external">http://www.example.com</a> and this is the second '\
-        '<a href="http://secondexample.com" rel="external">http://secondexample.com</a>.'
+        '<a href="http://secondexample.com" class="urlized-link" rel="external">http://secondexample.com</a>.'
     assert format_links(text) == formatted_text
+
+
+def test_multiple_urls_alternate_classes():
+    text = 'This is the first link www.example.com. This is the second http://secondexample.com...'  # noqa
+    formatted_text = 'This is the first link '\
+        '<span class="four">www.example.com</span>. This is the second '\
+        '<a href="http://secondexample.com" class="one two-three" rel="external">http://secondexample.com</a>...'
+    assert format_links(text, link_classes=("one", "two-three",), plaintext_link_classes=("four",)) == formatted_text
 
 
 def test_no_links_no_change():


### PR DESCRIPTION
This is how I would go about tackling the issues in story https://www.pivotaltracker.com/story/show/124752631

Would clearly be an api-breakage - on that note could someone explain how we use `__version__` in -utils. Two-numbered versioning I get. Not sure what the third number is being used for (currently `21.2.2`?).

utils consumers would need to update their css to style `urlized-link` and `urlized-plaintext-link` to their desires. Or override the defaults, or whatever...