### PR TITLE
Move csv generating logic into utils

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '21.5.0'
+__version__ = '21.6.0'

--- a/dmutils/csv_generator.py
+++ b/dmutils/csv_generator.py
@@ -2,7 +2,6 @@ import unicodecsv
 
 
 def iter_csv(rows):
-
     class Line(object):
         def __init__(self):
             self._line = None

--- a/dmutils/csv_generator.py
+++ b/dmutils/csv_generator.py
@@ -1,0 +1,20 @@
+import unicodecsv
+
+
+def iter_csv(rows):
+
+    class Line(object):
+        def __init__(self):
+            self._line = None
+
+        def write(self, line):
+            self._line = line
+
+        def read(self):
+            return self._line
+
+    line = Line()
+    writer = unicodecsv.writer(line)
+    for row in rows:
+        writer.writerow(row)
+        yield line.read()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ Flask-WTF==0.12
 markdown==2.6.2
 Flask-Script==2.0.5
 workdays==1.4
+unicodecsv==0.14.1

--- a/tests/test_csv_generator.py
+++ b/tests/test_csv_generator.py
@@ -1,0 +1,15 @@
+from dmutils.csv_generator import iter_csv
+
+
+class TestIterCsv():
+    def test_it_creates_csv_lines_from_lit_of_rows(self):
+        rows = [
+            ['a', 'b', 'c', 'd'],
+            ['e', 'f', 'g', 'h']
+        ]
+
+        result = iter_csv(rows)
+        lines = [line for line in result]
+
+        assert lines[0] == 'a,b,c,d\r\n'
+        assert lines[1] == 'e,f,g,h\r\n'

--- a/tests/test_csv_generator.py
+++ b/tests/test_csv_generator.py
@@ -11,5 +11,5 @@ class TestIterCsv():
         result = iter_csv(rows)
         lines = [line for line in result]
 
-        assert lines[0] == 'a,b,c,d\r\n'
-        assert lines[1] == 'e,f,g,h\r\n'
+        assert lines[0] == b'a,b,c,d\r\n'
+        assert lines[1] == b'e,f,g,h\r\n'


### PR DESCRIPTION
Part of this [story](https://www.pivotaltracker.com/story/show/124104161) on Pivotal.

The admin frontend and the buyer frontend were both using very similar logic to generate CSV files. This PR extracts it out to dmutils to prevent repetition.

Buyer frontend uses the logic [here](https://www.pivotaltracker.com/story/show/124104161).
Admin frontend uses it [here](https://github.com/alphagov/digitalmarketplace-admin-frontend/blob/master/app/main/views/users.py#L71), as well as another place in my PR for the admin app [here](https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/202).