### PR TITLE
[#125516661] Add metadata and logger parameters to send_email

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '21.6.0'
+__version__ = '21.7.0'

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -55,6 +55,7 @@ def test_calls_send_email_with_correct_params(email_app, mandrill):
             'auto_text': True,
             'tags': ['password-resets'],
             'headers': {'Reply-To': "from_email"},  # noqa
+            'metadata': None,
             'preserve_recipients': False,
             'recipient_metadata': [{
                 'rcpt': "email_address"
@@ -69,7 +70,6 @@ def test_calls_send_email_with_correct_params(email_app, mandrill):
             "from_email",
             "from_name",
             ["password-resets"]
-
         )
 
         mandrill.messages.send.assert_called_once_with(message=expected_call, async=True)
@@ -122,6 +122,7 @@ def test_calls_send_email_with_alternative_reply_to(email_app, mandrill):
             'track_clicks': False,
             'auto_text': True,
             'tags': ['password-resets'],
+            'metadata': None,
             'headers': {'Reply-To': "reply_address"},
             'preserve_recipients': False,
             'recipient_metadata': [{


### PR DESCRIPTION
Allows overwriting the logger to make it possible to use send_email outside app context.

Setting metadata argument will attach it to the messages in Mandrill, so that it can be used to find the relevant message using Mandrill message search API.