### PR TITLE
add xmlutils, containing `squashed_element_text` & some whitespace-normalizing functions

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '21.7.0'
+__version__ = '21.8.0'

--- a/dmutils/xmlutils.py
+++ b/dmutils/xmlutils.py
@@ -1,0 +1,29 @@
+import re
+
+
+def squashed_element_text(element):
+    """
+        returns a concatenation of text contents of `element` and all its children
+    """
+    return (element.text or u"") + u"".join(
+        squashed_element_text(child_element)+(child_element.tail or u"") for child_element in element
+    )
+
+
+_whitespace_re = re.compile(r"\s+", flags=re.UNICODE)
+
+
+def normalize_whitespace(whitespace_in_this):
+    """
+        returns string with whitespace normalized (to single spaces, stripped at ends)
+
+        Note proper xml-standard way of doing this is a little more complex afaik
+    """
+    return _whitespace_re.sub(" ", whitespace_in_this).strip()
+
+
+def squashed_normalized_text(element):
+    """
+        A shortcut for `normalize_whitespace`-wrapped `squashed_element_text`
+    """
+    return normalize_whitespace(squashed_element_text(element))

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -6,3 +6,4 @@ freezegun==0.3.4
 coverage==3.7.1
 pytest-cov==2.2.0
 python-coveralls==2.5.0
+lxml==3.4.4

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -94,6 +94,11 @@ def test_User_has_any_role(user_json):
     assert not user.has_any_role('other', 'admin')
 
 
+def test_User_modern_getattr(user_json):
+    user = User.from_json(user_json)
+    assert getattr(user, "banana", "mango") == "mango"
+
+
 def test_User_load_user(user_json):
     data_api_client = mock.Mock()
     data_api_client.get_user.return_value = user_json

--- a/tests/test_xmlutils.py
+++ b/tests/test_xmlutils.py
@@ -1,0 +1,41 @@
+from lxml import etree
+import pytest
+
+from dmutils.xmlutils import squashed_element_text, normalize_whitespace, squashed_normalized_text
+
+
+_torture_xml = """
+<one>
+  <two language="pig-latin">
+    Lorem  ipsum<three> dolor</three>,
+    <four></four><five> </five>
+  </two>
+  sit &amp; 
+\t  amet
+</one>"""  # noqa
+
+
+def test_squashed_element_text_torture():
+    doc = etree.fromstring(_torture_xml)
+    assert squashed_element_text(doc) == u"\n  \n    Lorem  ipsum dolor,\n     \n  \n  sit & \n\t  amet\n"
+    elem_two = doc.xpath("//two")[0]
+    assert squashed_element_text(elem_two) == u"\n    Lorem  ipsum dolor,\n     \n  "
+    elem_three = doc.xpath("//three")[0]
+    assert squashed_element_text(elem_three) == u" dolor"
+    elem_four = doc.xpath("//four")[0]
+    assert squashed_element_text(elem_four) == u""
+    elem_five = doc.xpath("//five")[0]
+    assert squashed_element_text(elem_five) == u" "
+
+
+def test_squashed_normalized_text_torture():
+    doc = etree.fromstring(_torture_xml)
+    assert squashed_normalized_text(doc) == u"Lorem ipsum dolor, sit & amet"
+    elem_two = doc.xpath("//two")[0]
+    assert squashed_normalized_text(elem_two) == u"Lorem ipsum dolor,"
+    elem_three = doc.xpath("//three")[0]
+    assert squashed_normalized_text(elem_three) == u"dolor"
+    elem_four = doc.xpath("//four")[0]
+    assert squashed_normalized_text(elem_four) == u""
+    elem_five = doc.xpath("//five")[0]
+    assert squashed_normalized_text(elem_five) == u""


### PR DESCRIPTION
These are extremely useful in tests and it would be nice to have them available project-wide.