### PR TITLE
Generate agreement upload filenames

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '21.7.1'
+__version__ = '21.8.0'

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -233,6 +233,16 @@ def get_document_path(framework_slug, supplier_id, bucket_category, document_nam
     )
 
 
+def generate_timestamped_document_upload_path(framework_slug, supplier_id, bucket_category, doc_name):
+    return '{0}/{1}/{2}/{3}-{2}-{4}'.format(
+        framework_slug,
+        bucket_category,
+        supplier_id,
+        datetime.datetime.utcnow().isoformat(),
+        doc_name
+    )
+
+
 def sanitise_supplier_name(supplier_name):
     """Replace ampersands with 'and' and spaces with a single underscore."""
     sanitised_supplier_name = supplier_name.encode("ascii", errors="ignore").decode("ascii").strip()

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -17,7 +17,7 @@ from dmutils.documents import (
     upload_document, upload_service_documents,
     get_signed_url, get_agreement_document_path, get_document_path,
     sanitise_supplier_name, file_is_pdf, file_is_zip, file_is_image,
-    file_is_csv)
+    file_is_csv, generate_timestamped_document_upload_path)
 
 
 class TestGenerateFilename(unittest.TestCase):
@@ -324,6 +324,12 @@ def test_get_agreement_document_path():
 def test_get_document_path():
     assert get_document_path('g-cloud-7', 1234, 'agreements', 'foo.pdf') == \
         'g-cloud-7/agreements/1234/1234-foo.pdf'
+
+
+def test_generate_timestamped_document_upload_path():
+    with freeze_time('2015-01-02 03:04:05'):
+        assert generate_timestamped_document_upload_path('g-rain-12', '54321', 'agreeeeements', 'a-thing.pdf') == \
+            'g-rain-12/agreeeeements/54321/2015-01-02T03:04:05-54321-a-thing.pdf'
 
 
 def test_sanitise_supplier_name():


### PR DESCRIPTION
Add method to generate timestamped document names - this is to be used for new agreement upload process where we need a unique path for agreements.