### PR TITLE
Generate and degenerate timestamped paths for document files

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '21.10.0'
+__version__ = '21.11.0'

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -1,5 +1,6 @@
 import os
 import datetime
+import re
 
 try:
     import urlparse
@@ -244,6 +245,16 @@ def generate_timestamped_document_upload_path(framework_slug, supplier_id, bucke
     timestamped_doc_name = timestamped_file_name + file_extension
 
     return get_document_path(framework_slug, supplier_id, bucket_category, timestamped_doc_name)
+
+
+def degenerate_document_path_and_return_doc_name(document_path):
+    """Takes a document path and returns just the generic document name
+
+    An inverse function for `get_document_path` which returns what would have been
+    the `document_name` param (i.e. removes all framework slug, supplier id and bucket category
+    information)
+    """
+    return re.split('/\d+-', document_path)[-1]
 
 
 def sanitise_supplier_name(supplier_name):

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -238,13 +238,12 @@ def get_document_path(framework_slug, supplier_id, bucket_category, document_nam
 
 
 def generate_timestamped_document_upload_path(framework_slug, supplier_id, bucket_category, doc_name):
-    return '{0}/{1}/{2}/{3}-{2}-{4}'.format(
-        framework_slug,
-        bucket_category,
-        supplier_id,
-        datetime.datetime.utcnow().isoformat(),
-        doc_name
-    )
+    """Generates a file path with a timestamp inserted before the file extension"""
+    file_name, file_extension = os.path.splitext(doc_name)
+    timestamped_file_name = file_name + '-' + datetime.datetime.utcnow().strftime("%Y-%m-%d-%H%M%S")
+    timestamped_doc_name = timestamped_file_name + file_extension
+
+    return get_document_path(framework_slug, supplier_id, bucket_category, timestamped_doc_name)
 
 
 def sanitise_supplier_name(supplier_name):

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -329,7 +329,7 @@ def test_get_document_path():
 def test_generate_timestamped_document_upload_path():
     with freeze_time('2015-01-02 03:04:05'):
         assert generate_timestamped_document_upload_path('g-rain-12', '54321', 'agreeeeements', 'a-thing.pdf') == \
-            'g-rain-12/agreeeeements/54321/2015-01-02T03:04:05-54321-a-thing.pdf'
+            'g-rain-12/agreeeeements/54321/54321-a-thing-2015-01-02-030405.pdf'
 
 
 def test_sanitise_supplier_name():

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -17,7 +17,8 @@ from dmutils.documents import (
     upload_document, upload_service_documents,
     get_signed_url, get_agreement_document_path, get_document_path,
     sanitise_supplier_name, file_is_pdf, file_is_zip, file_is_image,
-    file_is_csv, generate_timestamped_document_upload_path)
+    file_is_csv, generate_timestamped_document_upload_path,
+    degenerate_document_path_and_return_doc_name)
 
 
 class TestGenerateFilename(unittest.TestCase):
@@ -330,6 +331,19 @@ def test_generate_timestamped_document_upload_path():
     with freeze_time('2015-01-02 03:04:05'):
         assert generate_timestamped_document_upload_path('g-rain-12', '54321', 'agreeeeements', 'a-thing.pdf') == \
             'g-rain-12/agreeeeements/54321/54321-a-thing-2015-01-02-030405.pdf'
+
+
+def test_degenerate_document_path_and_return_doc_name():
+    assert (
+        degenerate_document_path_and_return_doc_name(
+            "g-cloud-8/agreements/5478/5478-signed-framework-agreement-12-10-2016-101234.pdf"
+        ) == "signed-framework-agreement-12-10-2016-101234.pdf"
+    )
+    assert (
+        degenerate_document_path_and_return_doc_name(
+            "g-cloud-7/agreements/1234/1234-countersigned-framework-agreement.jpg"
+        ) == "countersigned-framework-agreement.jpg"
+    )
 
 
 def test_sanitise_supplier_name():


### PR DESCRIPTION
#### Generating
We want to generate file paths that have unique filenames (done by time stamping to the second). 
To follow the filenaming convention for services files we have the timestamp just before the file extension rather than at the beginning of the file name.

#### Degenerating
We want to take a generated file path (with or without timestamp) and strip it to it's document name, e.g.

`g-cloud-8/agreements/5478/5478-signed-framework-agreement-12-10-2016-101234.pdf`

to 

`signed-framework-agreement-12-10-2016-101234.pdf`

This document name can then be passed as a parameter to the front end routes to download a signed s3 document.
