### PR TITLE
Remove markdown filter from utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 Records breaking changes from major version bumps
 
+## 22.0.0
+
+PR: [#286](https://github.com/alphagov/digitalmarketplace-utils/pull/286)
+
+### What changed
+
+We used to be able to use a `|markdown` filter in our jinja templates which would turn markdown formatted strings into [Markup](http://jinja.pocoo.org/docs/dev/api/#jinja2.Markup) strings as well as permit HTML tags.
+This opened us up to vulnerabilities where untrusted input might end up going through one of these filters and expose us to a cross-site scripting (XSS) exploit.
+
+Going forward, markdown formatted text will be allowed in specific fields (documented in the [README for digitalmarketplace-frameworks](https://github.com/alphagov/digitalmarketplace-frameworks/blob/4c0502379910d8248f062b8aaf35fc58ce912370/README.md#template-fields)) and then rendered by TemplateFields, handled by the Content Loader.
+
+### Example app change
+
+Old:
+```jinja
+
+<h2>Question name: {{ question.name|markdown }}</h2>
+
+```
+
+New:
+```jinja
+
+<!-- question.name is now a `TemplateField` which renders markdown when accessed -->
+<h2>Question name: {{ question.name }}</h2>
+
+```
+
+
 ## 21.0.0
 
 PR: [#266](https://github.com/alphagov/digitalmarketplace-utils/pull/266)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+SHELL := /bin/bash
+VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
+
+virtualenv:
+	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv venv || true
+
+requirements_for_test: virtualenv requirements_for_test.txt
+	${VIRTUALENV_ROOT}/bin/pip install -r requirements_for_test.txt
+
+test: show_environment test_pep8 test_python
+
+test_pep8: virtualenv
+	${VIRTUALENV_ROOT}/bin/pep8 .
+
+test_python: virtualenv
+	${VIRTUALENV_ROOT}/bin/py.test ${PYTEST_ARGS}
+
+show_environment:
+	@echo "Environment variables in use:"
+	@env | grep DM_ || true
+
+.PHONY: virtualenv requirements_for_test test_pep8 test_python show_environment

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '21.11.0'
+__version__ = '22.0.0'

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -1,11 +1,6 @@
 from __future__ import unicode_literals
 import re
-from markdown import markdown
 from flask import Markup
-
-
-def markdown_filter(text, *args, **kwargs):
-    return markdown(text, ['markdown.extensions.abbr'], *args, **kwargs)
 
 
 def smartjoin(input):

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -1,7 +1,6 @@
 import os
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 from . import config, logging, proxy_fix, request_id, formats, filters
-from flask import Markup
 from flask.ext.script import Manager, Server
 
 
@@ -47,9 +46,6 @@ def init_app(
         response.headers['X-Frame-Options'] = 'DENY'
         return response
 
-    @application.template_filter('markdown')
-    def markdown_filter_flask(data):
-        return Markup(filters.markdown_filter(data))
     application.add_template_filter(filters.format_links)
     application.add_template_filter(formats.timeformat)
     application.add_template_filter(formats.shortdateformat)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ mandrill==1.0.57
 monotonic==0.3
 pytz==2015.4
 Flask-WTF==0.12
-markdown==2.6.2
 Flask-Script==2.0.5
 workdays==1.4
 unicodecsv==0.14.1

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,35 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from dmutils.filters import markdown_filter, smartjoin, format_links
-
-
-def test_markdown_filter_produces_markup():
-
-    markdown_string = """## H2 title
-
-- List item 1
-- List item 2
-
-Paragraph
-**Bold**
-*Emphasis*
-
-HTML is an abbreviation.
-
-*[HTML]: Hyper Text Markup Language
-"""
-
-    html_string = """<h2>H2 title</h2>
-<ul>
-<li>List item 1</li>
-<li>List item 2</li>
-</ul>
-<p>Paragraph
-<strong>Bold</strong>
-<em>Emphasis</em></p>
-<p><abbr title="Hyper Text Markup Language">HTML</abbr> is an abbreviation.</p>"""
-
-    assert markdown_filter(markdown_string) == html_string
+from dmutils.filters import smartjoin, format_links
 
 
 def test_smartjoin_for_more_than_one_item():


### PR DESCRIPTION
We used to be able to use a `|markdown` filter in our jinja templates which would turn markdown formatted strings into [Markup](http://jinja.pocoo.org/docs/dev/api/#jinja2.Markup) strings as well as permit HTML tags.
This opened us up to vulnerabilities where untrusted input might end up going through one of these filters and expose us to a cross-site scripting (XSS) exploit.

Going forward, markdown formatted text will be allowed in specific fields (documented in the [README for digitalmarketplace-frameworks](https://github.com/alphagov/digitalmarketplace-frameworks/blob/4c0502379910d8248f062b8aaf35fc58ce912370/README.md#template-fields)) and then rendered by TemplateFields, handled by the Content Loader.