### PR TITLE
return email in password reset

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '22.0.0'
+__version__ = '22.1.0'

--- a/dmutils/email.py
+++ b/dmutils/email.py
@@ -112,7 +112,10 @@ def decode_password_reset_token(token, data_api_client):
         current_app.logger.info("Error changing password: Token generated earlier than password was last changed.")
         return {'error': 'token_invalid'}
 
-    return decoded
+    return {
+        'user': user['users']['id'],
+        'email': user['users']['emailAddress']
+    }
 
 
 def decode_invitation_token(encoded_token, role):

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -218,9 +218,13 @@ def test_decode_password_reset_token_ok_for_good_token(email_app):
     data_api_client = mock.Mock()
     data_api_client.get_user.return_value = user
     with email_app.app_context():
-        data = {'user': 'test@example.com'}
+        data = {'user': 123}
         token = generate_token(data, 'Secret', 'PassSalt')
-        assert decode_password_reset_token(token, data_api_client) == data
+        assert decode_password_reset_token(token, data_api_client) == {
+            'user': 123,
+            'email': 'test@example.com'
+        }
+    data_api_client.get_user.assert_called_once_with(123)
 
 
 def test_decode_password_reset_token_does_not_work_if_bad_token(email_app):
@@ -228,7 +232,7 @@ def test_decode_password_reset_token_does_not_work_if_bad_token(email_app):
     user['users']['passwordChangedAt'] = "2016-01-01T12:00:00.30Z"
     data_api_client = mock.Mock()
     data_api_client.get_user.return_value = user
-    data = {'user': 'test@example.com'}
+    data = {'user': 123}
     token = generate_token(data, 'Secret', 'PassSalt')[1:]
 
     with email_app.app_context():
@@ -242,7 +246,7 @@ def test_decode_password_reset_token_does_not_work_if_token_expired(email_app):
     data_api_client.get_user.return_value = user
     with freeze_time('2015-01-02 03:04:05'):
         # Token was generated a year before current time
-        data = {'user': 'test@example.com'}
+        data = {'user': 123}
         token = generate_token(data, 'Secret', 'PassSalt')
 
     with freeze_time('2016-01-02 03:04:05'):
@@ -258,7 +262,7 @@ def test_decode_password_reset_token_does_not_work_if_password_changed_later_tha
 
     with freeze_time('2016-01-01T12:00:00.30Z'):
         # Token was generated an hour earlier than password was changed
-        data = {'user': 'test@example.com'}
+        data = {'user': 123}
         token = generate_token(data, 'Secret', 'PassSalt')
 
     with freeze_time('2016-01-01T14:00:00.30Z'):


### PR DESCRIPTION
buyer-frontend previously relied on the fields `user` and `email` being in the
token that it passes into decode_password_reset_token - as that function just
passed them straight through. but by building the return dict from the user
object, we can remove the requirement on email_address being in the token
so it isn't left unencrypted in our logs

i think this is a minor change, but it might be a patch... it removes a previously required attribute of the `token` parameter but doesn't change the functionality or output