### PR TITLE
Use encrypted tokens to pass data in URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 Records breaking changes from major version bumps
 
+## 23.0.0
+
+PR: [#288](https://github.com/alphagov/digitalmarketplace-utils/pull/288)
+
+### What changed
+
+`decode_invitation_token` previously accepted a `role` parameter, which it would switch on to assert keys of the encoded token's data. For example, if you passed in 'supplier' it would assert that the token contains 'email_address', 'supplier_id', and 'supplier_name'. The contents of the data encoded shouldn't be the responsibility of the utils app, and is left to the implementing code to either check or not.
+
+### Example app change
+
+Old:
+```python
+
+data = decode_invitation_token(token, role='supplier')
+# data is guaranteed to contain fields 'email_address', 'supplier_id', 'supplier_name'
+```
+
+New:
+```python
+
+data = decode_invitation_token(token)
+# decode_invitation_token makes no assertions about the contents of the token
+assert 'email_address' in data.keys()
+
+```
+
 ## 22.0.0
 
 PR: [#286](https://github.com/alphagov/digitalmarketplace-utils/pull/286)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '22.1.0'
+__version__ = '22.2.0'

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '22.2.0'
+__version__ = '23.0.0'

--- a/dmutils/email.py
+++ b/dmutils/email.py
@@ -2,7 +2,7 @@ import base64
 import hashlib
 import six
 
-from flask import current_app, flash
+from flask import current_app
 from flask._compat import string_types
 
 from datetime import datetime
@@ -58,7 +58,7 @@ def send_email(to_email_addresses, email_body, api_key, subject, from_email, fro
         raise MandrillException(e)
 
     logger.info("Sent {tags} response: id={id}, email={email_hash}",
-                extra={'tags': tags, 'id': result[0]['_id'], 'email_hash': hash_email(result[0]['email'])})
+                extra={'tags': tags, 'id': result[0]['_id'], 'email_hash': hash_string(result[0]['email'])})
 
 
 def generate_token(data, secret_key, salt):
@@ -77,9 +77,9 @@ def decode_token(token, secret_key, salt, max_age_in_seconds=86400):
     return decoded, timestamp
 
 
-def hash_email(email):
+def hash_string(string):
     m = hashlib.sha256()
-    m.update(email.encode('utf-8'))
+    m.update(string.encode('utf-8'))
 
     return base64.urlsafe_b64encode(m.digest())
 

--- a/dmutils/email.py
+++ b/dmutils/email.py
@@ -65,39 +65,96 @@ def send_email(to_email_addresses, email_body, api_key, subject, from_email, fro
                 extra={'tags': tags, 'id': result[0]['_id'], 'email_hash': hash_string(result[0]['email'])})
 
 
-def generate_token(data, secret_key, salt):
-    return encrypt_data(data, secret_key, salt)
+def generate_token(data, secret_key, namespace):
+    return encrypt_data(data, secret_key, namespace)
 
 
-def decode_token(token, secret_key, salt, max_age_in_seconds=86400):
+def decode_token(token, secret_key, namespace, max_age_in_seconds=86400):
+    """
+    Decode a token given a secret_key and namespace.
+
+    The token may have been created by a previous version of dmutils, which only supported signed unencrypted tokens.
+    To maintain backwards compatibility during rollouts, we try and decode using the old format, and if that fails
+    assume it is is a new encrypted token.
+
+    This functionality can be removed once all rollouts have completed and the longest time-to-live of the old signed
+    tokens has expired (seven days for an invite email).
+    """
     try:
-        return decode_signed_token(token, secret_key, salt, max_age_in_seconds)
+        return decode_signed_token(token, secret_key, namespace, max_age_in_seconds)
     except itsdangerous.BadData:
-        return decrypt_data(token, secret_key, salt, max_age_in_seconds)
+        return decrypt_data(token, secret_key, namespace, max_age_in_seconds)
 
 
-def decode_signed_token(token, secret_key, salt, max_age_in_seconds=86400):
+def decode_signed_token(token, secret_key, namespace, max_age_in_seconds=86400):
     ts = itsdangerous.URLSafeTimedSerializer(secret_key)
     decoded, timestamp = ts.loads(
         token,
-        salt=salt,
+        salt=namespace,
         max_age=max_age_in_seconds,
         return_timestamp=True
     )
     return decoded, timestamp
 
 
-def encrypt_data(json_data, secret_key, salt):
-    secret_key = hash_string(secret_key + salt)
+def encrypt_data(json_data, secret_key, namespace):
+    """
+    Encrypt data using a provided secret_key and namespace.
+
+    The process is as follows:
+    * The secret_key is combined with the namespace and hashed using sha256. The namespace ensures that a token for
+      `invite-user` cannot be re-used by an attacker on the `reset-password` endpoint. Hashing is used to ensure the
+      key conforms to the 32 byte length requirement for Fernet.
+    * The combined secret key is used to initialise the Fernet encryption algorithm. Fernet is a wrapper around AES
+      that provides HMAC, TTL (time to live), and some quality of life features (url-safe base64 encoding)
+      The fernet spec can be viewed here: https://github.com/fernet/spec/blob/master/Spec.md
+    * The data is dumped from json and encrypted.
+    * The output data is returned as a urlsafe_base64 (https://tools.ietf.org/html/rfc4648#section-5) unicode string.
+
+    Fernet acepts and returns bytes, so call `.encode` before and `.decode` after to convert to strings, to ensure we
+    use regular python strings for as much of the code flow as possible
+
+    :param json_data: data to encrypt. Must be json-like blob that `json.dumps` will accept
+    :param secret_key: The secret key to encrypt with. No length/content restrictions. Must be a string type.
+    :param namespace: The namespace to encrypt with. No length/content restrictions. Must be a string type.
+    :return: returns a urlsale_base64 encoded encrypted unicode string.
+    :rtype: `unicode`
+    """
+    secret_key = hash_string(secret_key + namespace)
     data = json.dumps(json_data).encode('utf-8')
     f = fernet.Fernet(secret_key)
     return f.encrypt(data).decode('utf-8')
 
 
-def decrypt_data(encrypted_data, secret_key, salt, max_age_in_seconds):
+def decrypt_data(encrypted_data, secret_key, namespace, max_age_in_seconds):
+    """
+    Decrypt data using a provided secret_key, namespace, and TTL (max_age_in_seconds).
+
+    The process is as follows:
+    * secret key and fernet are initialised as in `encrypt_data`
+    * the data is decrypted and json_dumped
+    * the timestamp is pulled out and compared to the max_age_in_seconds to ensure that the token has not expired
+    * the original json-able blob is returned, along with the timestamp that it was encrypted at. This timestamp can
+      then be used for verifying the authenticity of the request, for example, comparing a password reset token
+      against the last time the password was reset to ensure it is not used twice.
+
+    Fernet acepts and returns bytes, so call `.encode` before and `.decode` after to convert to strings, to ensure we
+    use regular python strings for as much of the code flow as possible
+
+    :param encrypted_data: data to decrypt. Must be a string type.
+    :param secret_key: The secret key you encrypted the data with. Must be a string type.
+    :param namespace: The namespace you encrypted the data with. Must be a string type.
+    :param max_age_in_seconds: The maximum age of the encrypted data.
+    :return: the original encrypted data and the datetime it was encrypted at.
+    :rtype: `tuple(json-able, datetime)`
+    :raises fernet.InvalidToken: If the secret key and namespace are not able to decrypt the message,
+        or max_age_in_seconds has been exceeded.
+    """
     encrypted_bytes = encrypted_data.encode('utf-8')
-    secret_key = hash_string(secret_key + salt)
+    secret_key = hash_string(secret_key + namespace)
     f = fernet.Fernet(secret_key)
+
+    # this raises fernet.InvalidToken if the key does not match or if TTL is exceeded
     data = f.decrypt(encrypted_bytes, ttl=max_age_in_seconds)
 
     timestamp = _parse_fernet_timestamp(encrypted_bytes)
@@ -157,7 +214,7 @@ def decode_password_reset_token(token, data_api_client):
     }
 
 
-def decode_invitation_token(encoded_token, role):
+def decode_invitation_token(encoded_token):
     try:
         token, timestamp = decode_token(
             encoded_token,

--- a/dmutils/email.py
+++ b/dmutils/email.py
@@ -163,7 +163,7 @@ def decrypt_data(encrypted_data, secret_key, namespace, max_age_in_seconds):
 
 def _parse_fernet_timestamp(ciphertext):
     """
-    Returns timestamp embedded in Fernet-encrypted ciphertext, converted to Python datetime object.
+    Returns utc timestamp embedded in Fernet-encrypted ciphertext, converted to Python datetime object.
 
     Decryption should be attempted before using this function, as that does cryptographically strong tests on the
     validity of the ciphertext.
@@ -175,7 +175,7 @@ def _parse_fernet_timestamp(ciphertext):
     except struct.error as e:
         raise fernet.InvalidToken(e.message)
 
-    return datetime.fromtimestamp(epoch_timestamp)
+    return datetime.utcfromtimestamp(epoch_timestamp)
 
 
 def hash_string(string):

--- a/dmutils/email.py
+++ b/dmutils/email.py
@@ -103,13 +103,13 @@ def encrypt_data(json_data, secret_key, salt):
     data = json.dumps(json_data).encode('utf-8')
     f = fernet.Fernet(secret_key)
     encrypted_data = f.encrypt(data)
-    return encrypted_data.decode()
+    return six.binary_type(encrypted_data)
 
 
 def decrypt_data(encrypted_data, secret_key, salt, max_age_in_seconds):
     secret_key = hash_string(secret_key + salt)
     f = fernet.Fernet(secret_key)
-    data = f.decrypt(encrypted_data.encode('utf-8'), ttl=max_age_in_seconds)
+    data = f.decrypt(six.binary_type(encrypted_data), ttl=max_age_in_seconds)
 
     timestamp = parse_fernet_timestamp(encrypted_data)
     return json.loads(data.decode('utf-8')), timestamp

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ Flask-WTF==0.12
 Flask-Script==2.0.5
 workdays==1.4
 unicodecsv==0.14.1
+cryptography==1.6

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -2,7 +2,6 @@
 from freezegun import freeze_time
 import pytest
 import mock
-import six
 
 from datetime import datetime
 from mandrill import Error
@@ -210,8 +209,8 @@ def test_cant_decode_token_with_wrong_key():
 
 
 @pytest.mark.parametrize('test, expected', [
-    (u'test@example.com', six.b('lz3-Rj7IV4X1-Vr1ujkG7tstkxwk5pgkqJ6mXbpOgTs=')),
-    (u'☃@example.com', six.b('jGgXle8WEBTTIFhP25dF8Ck-FxQSCZ_N0iWYBWve4Ps=')),
+    (u'test@example.com', b'lz3-Rj7IV4X1-Vr1ujkG7tstkxwk5pgkqJ6mXbpOgTs='),
+    (u'☃@example.com', b'jGgXle8WEBTTIFhP25dF8Ck-FxQSCZ_N0iWYBWve4Ps='),
 ])
 def test_hash_string(test, expected):
     assert hash_string(test) == expected
@@ -288,14 +287,6 @@ def test_decode_invitation_token_decodes_ok_for_supplier(email_app):
         data = {'email_address': 'test-user@email.com', 'supplier_id': 1234, 'supplier_name': 'A. Supplier'}
         token = generate_token(data, 'Key', 'Salt')
         assert decode_invitation_token(token, role='supplier') == data
-
-
-def test_decode_invitation_token_does_not_work_if_there_are_missing_keys(email_app):
-    with email_app.app_context():
-        data = {'email_address': 'test-user@email.com', 'supplier_name': 'A. Supplier'}
-        token = generate_token(data, email_app.config['SHARED_EMAIL_KEY'], email_app.config['INVITE_EMAIL_SALT'])
-
-        assert decode_invitation_token(token, role='supplier') is None
 
 
 def test_decode_invitation_token_does_not_work_if_bad_token(email_app):

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -6,6 +6,7 @@ import six
 
 from datetime import datetime
 from mandrill import Error
+from cryptography import fernet
 
 from itsdangerous import URLSafeTimedSerializer
 from dmutils.config import init_app
@@ -18,8 +19,7 @@ from dmutils.email import (
     hash_string,
     token_created_before_password_last_changed,
     decode_invitation_token,
-    decode_password_reset_token,
-    InvalidTokenException
+    decode_password_reset_token
 )
 from dmutils.formats import DATETIME_FORMAT
 from .test_user import user_json
@@ -194,7 +194,7 @@ def test_cant_decode_token_with_wrong_salt():
         secret_key="1234567890",
         salt="1234567890")
 
-    with pytest.raises(InvalidTokenException) as error:
+    with pytest.raises(fernet.InvalidToken):
         decode_token(token, "1234567890", "failed")
 
 
@@ -205,7 +205,7 @@ def test_cant_decode_token_with_wrong_key():
         secret_key="1234567890",
         salt="1234567890")
 
-    with pytest.raises(InvalidTokenException) as error:
+    with pytest.raises(fernet.InvalidToken):
         decode_token(token, "failed", "1234567890")
 
 


### PR DESCRIPTION
inspired by AusDTO#20

Password reset/create account email tokens were previously base64
encoded and signed. Since they're part of the URL of a GET request,
they would show up in logs and google analytics, which we don't
really want. So we've replaced the use of `URLSafeTimedSerializer` with
`cryptography.fernet`. Fernet provides encryption, signing and TTL.

To implement this a few things have needed to happen.

* cryptography==1.6 is a new dependency
* generate_token now generates the new encrypted token
* decode_token, while old tokens are still in the system, has to decode
  both new and old tokens
  - it first tries to decode a signed b64 message.
  - if that raises, it then tries to decode using Fernet
  - if that raises, it raises a new dependency-agnostic
    InvalidTokenException
  - invite emails have a TTL of 7 days, so this code must remain in
    place for at least that long
* as cryptography.fernet does not distinguish invalid and expired data,
  we no longer distinguish token_expired and token_invalid errors