### PR TITLE
Generate download filename method

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '23.0.0'
+__version__ = '23.1.0'

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -22,6 +22,7 @@ SIGNATURE_PAGE_FILENAME = 'signature-page.pdf'
 SIGNED_SIGNATURE_PAGE_PREFIX = 'signed-signature-page'
 
 COUNTERSIGNED_AGREEMENT_FILENAME = 'countersigned-framework-agreement.pdf'
+COUNTERPART_FILENAME = "agreement-countersignature.pdf"
 
 
 def filter_empty_files(files):

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -266,3 +266,11 @@ def sanitise_supplier_name(supplier_name):
     while '__' in sanitised_supplier_name:
         sanitised_supplier_name = sanitised_supplier_name.replace('__', '_')
     return sanitised_supplier_name
+
+
+def generate_download_filename(supplier_id, document_name, supplier_name):
+    """
+        Used for generating supplier-friendly filenames to set as headers in s3 for files,
+        such as framework agreement documents, that suppliers need to download
+    """
+    return '{}-{}-{}'.format(sanitise_supplier_name(supplier_name), supplier_id, document_name)

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -21,7 +21,6 @@ SIGNED_AGREEMENT_PREFIX = 'signed-framework-agreement'
 SIGNATURE_PAGE_FILENAME = 'signature-page.pdf'
 SIGNED_SIGNATURE_PAGE_PREFIX = 'signed-signature-page'
 
-COUNTERSIGNED_AGREEMENT_FILENAME = 'countersigned-framework-agreement.pdf'
 COUNTERPART_FILENAME = "agreement-countersignature.pdf"
 
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -18,7 +18,7 @@ from dmutils.documents import (
     get_signed_url, get_agreement_document_path, get_document_path,
     sanitise_supplier_name, file_is_pdf, file_is_zip, file_is_image,
     file_is_csv, generate_timestamped_document_upload_path,
-    degenerate_document_path_and_return_doc_name)
+    degenerate_document_path_and_return_doc_name, generate_download_filename)
 
 
 class TestGenerateFilename(unittest.TestCase):
@@ -353,3 +353,7 @@ def test_sanitise_supplier_name():
     assert sanitise_supplier_name(u'\ / : * ? \' " < > |') == '_'
     assert sanitise_supplier_name(u'kev@the*agency') == 'kevtheagency'
     assert sanitise_supplier_name(u"Ψ is a silly character") == "is_a_silly_character"
+
+
+def test_generate_download_filename():
+    assert generate_download_filename(584425, 'result-letter.pdf', 'ICNT_Consulting_Ltd') == 'ICNT_Consulting_Ltd-584425-result-letter.pdf'   # noqa


### PR DESCRIPTION
I'm moving this method here from scripts repo because the admin frontend (and possibly other apps) also need to set a download filename for supplier documents.