### PR TITLE
Fix logger failure mode

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '23.1.0'
+__version__ = '23.1.1'

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -115,8 +115,20 @@ class CustomLogFormatter(logging.Formatter):
 
         try:
             msg = msg.format(**record.__dict__)
-        except KeyError as e:
-            logger.exception("failed to format log message: {} not found".format(e))
+        except:
+            # We know that KeyError, ValueError and IndexError are all possible things that can go
+            # wrong here - there is no guarantee that the message passed into the logger is
+            # actually suitable to be used as a format string. This is particularly so where an
+            # we are logging arbitrary exception that may reference code.
+            #
+            # We catch all exceptions rather than just those three, because _any_ failure to format the
+            # message must not result in an error, otherwise the original log message will never be
+            # returned and written to the logs, and that might be important info such as an
+            # exception.
+            #
+            # NB do not attempt to log either the exception or `msg` here, or you will
+            # find that too fails and you end up with an infinite recursion / stack overflow.
+            logger.info("failed to format log message")
         return msg
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -178,3 +178,9 @@ class TestCustomLogFormatter(object):
         result = self.dmbuffer.getvalue()
 
         assert 'failed to format log message' in result
+
+    def test_failed_log_message_formatting_still_logs(self):
+        self.logger.info("hello {")
+
+        assert 'failed to format log message' in self.dmbuffer.getvalue()
+        assert 'hello {' in self.buffer.getvalue()


### PR DESCRIPTION
 - if the log message cannot be used as a format string, that should
   not be fatal - the message must still be logged.
 - do not attempt to log the exception generated when trying to use
   the message as a format string, as that exception is frequently
   not usable as a format string either, and in that case you get
   an infinite recursion / stack overflow.
 - change the message about not being able to format the message
   into log-level INFO, as it's not really an error state in and
   of itself.
