### PR TITLE
137170159-Notify-integration

### DIFF
--- a/dmutils/email/__init__.py
+++ b/dmutils/email/__init__.py
@@ -1,0 +1,2 @@
+"""Allow accessing send email from email. Backwards compatibility."""
+from dmutils.email.dm_mandrill import send_email

--- a/dmutils/email/dm_notify.py
+++ b/dmutils/email/dm_notify.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""Digital Marketplace Notify integration."""
+from collections import OrderedDict
+
+from flask import current_app
+from notifications_python_client import NotificationsAPIClient
+from notifications_python_client.errors import HTTPError
+
+from dmutils.email.exceptions import EmailError
+from dmutils.email.helpers import hash_string
+
+
+class DMNotifyClient(object):
+    """Digital Marketplace wrapper around the Notify python client."""
+
+    _client_class = NotificationsAPIClient
+    _sent_references_cache = None
+
+    def __init__(
+            self,
+            govuk_notify_api_key,
+            govuk_notify_base_url='https://api.notifications.service.gov.uk',
+            logger=None
+    ):
+        """Set up logging and mail client."""
+        self.logger = logger or current_app.logger
+        self.client = self._client_class(govuk_notify_api_key, govuk_notify_base_url)
+
+    def get_all_notifications(self, **kwargs):
+        """Wrapper for notifications_python_client.notifications.NotificationsAPIClient::get_all_notifications"""
+        return self.client.get_all_notifications(**kwargs)['notifications']
+
+    def get_delivered_notifications(self, **kwargs):
+        """Wrapper for notifications_python_client.notifications.NotificationsAPIClient::get_all_notifications"""
+        return self.get_all_notifications(status='delivered', **kwargs)
+
+    def get_delivered_references(self, invalidate_cache=False):
+        """Get the references of all notifications that have already been delivered."""
+        if invalidate_cache:
+            self._sent_references_cache = None
+        if self._sent_references_cache is None:
+            self._sent_references_cache = set(i['reference'] for i in self.get_delivered_notifications())
+        return self._sent_references_cache
+
+    def _update_cache(self, reference):
+        """If the cache has been instantiated then cache the new reference."""
+        if self._sent_references_cache is not None:
+            self._sent_references_cache.update([reference])
+
+    def has_been_sent(self, reference):
+        """Checks for a matching reference in our list of delivered references."""
+        return reference in self.get_delivered_references()
+
+    @staticmethod
+    def get_reference(email_address, template_id, personalisation=None, **kwargs):
+        """
+        Method to return the standard reference given the variables the email is sent with.
+
+        :param email_address: Emails recipient
+        :param template_id: Emails template ID on Notify
+        :param personalisation: Template parameters
+        :param kwargs: Extra data passed to the reference eg. {'notes': 'Manual resend'}
+        :return: Hashed string 'reference' to be passed to client.send_email_notification or self.send_email
+        """
+        personalisation_string = ','.join(list(map(str, personalisation.values()))) if personalisation else ''
+        details_string = '|'.join([email_address, template_id, personalisation_string])
+        return hash_string(details_string)
+
+    @staticmethod
+    def get_error_message(email_address, error):
+        """Format a logical error message from the error response."""
+        messages = []
+        message_prefix = 'Error sending message to {email_address}: '.format(email_address=email_address)
+        message_string = '{status_code} {error}: {message}'
+
+        for message in error.message:
+            format_kwargs = {
+                'status_code': error.status_code,
+                'error': message['error'],
+                'message': message['message'],
+            }
+            messages.append(message_string.format(**format_kwargs))
+        return message_prefix + ', '.join(messages)
+
+    def send_email(self, email_address, template_id, personalisation=None, allow_resend=True):
+        """
+        Method to send an email using the Notify api.
+
+        :param email_address: String email address for recipient
+        :param template_id: Template accessible on the Notify account whose  api_key you instantiated the class with
+        :param personalisation: The template variables, dict
+        :param allow_resend: if False instantiate the delivered reference cache and ensure we are not sending duplicates
+        :return: response from the api. For more information see https://github.com/alphagov/notifications-python-client
+        """
+        reference = self.get_reference(email_address, template_id, personalisation)
+        if not allow_resend and self.has_been_sent(reference):
+            self.logger.info("Email {template_id} has already been sent to {email_address} with Notify", extra=dict(
+                email_address=hash_string(email_address),
+                template_id=template_id
+            ))
+            return
+        try:
+            response = self.client.send_email_notification(
+                email_address,
+                template_id,
+                personalisation=personalisation,
+                reference=self.get_reference(email_address, template_id, personalisation)
+            )
+        except HTTPError as e:
+            self.logger.error(self.get_error_message(hash_string(email_address), e))
+            raise EmailError(str(e))
+        self._update_cache(reference)
+        self.logger.info("Sent {email_address} template email {template_id} with Notify", extra=dict(
+            email_address=hash_string(email_address),
+            template_id=template_id
+        ))
+        return response

--- a/dmutils/email/exceptions.py
+++ b/dmutils/email/exceptions.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""Digital Marketplace normalised exception classes."""
+
+
+class EmailError(Exception):
+    pass

--- a/dmutils/email/helpers.py
+++ b/dmutils/email/helpers.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""Email helpers."""
+import base64
+import hashlib
+
+
+def hash_string(string):
+    """Hash a given string."""
+    m = hashlib.sha256(string.encode('utf-8'))
+    return base64.urlsafe_b64encode(m.digest())

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ Flask-Script==2.0.5
 workdays==1.4
 unicodecsv==0.14.1
 cryptography==1.6
+git+https://github.com/alphagov/notifications-python-client.git@4.0.0#egg=notifications-python-client==4.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [pep8]
 max-line-length = 120
+
+[pytest]
+norecursedirs = venv venv3 src

--- a/tests/email/fixtures/notifications__get_all_notifications__response.json
+++ b/tests/email/fixtures/notifications__get_all_notifications__response.json
@@ -1,0 +1,201 @@
+{
+  "links": {
+    "current": "https://api.notifications.service.gov.uk/v2/notifications",
+    "next": "https://api.notifications.service.gov.uk/v2/notifications?older_than=ac0973cd-3d1c-446d-bec5-665347beaf53"
+  },
+  "notifications": [
+    {
+      "body": "05/01/2017\n\nDear supplier, \n\nBen's Awesome Company\u2019s application to Digital Outcomes and Specialists 2 was successful.\n\nYour results were: \n\u2022 Digital outcomes - yes\nno\nmaybe\nI don't know\n\nWe\u2019ve notified all applicants about their results. A 10-day 'standstill period' will start on 17 January 2017 and end at 11.59pm (GMT) on 26 January 2017. We expect the framework to be awarded on 27 January 2017 and services to go live on the Digital Marketplace in February 2016. \n\nYou must sign and return your framework agreement before you can sell services on the Digital Marketplace. \n\nYour framework agreement is ready to sign at: \nhttps://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/digital-outcomes-and-specialists-2/agreement\n\n\nWe\u2019ll notify you when the standstill period is over. Until then, you shouldn\u2019t make any public announcements about the result of your application.\n\nYours faithfully,\nAlison Lisett\nHead of Sourcing Delivery\nCrown Commercial Service",
+      "completed_at": "2017-01-05T16:47:27.278075Z",
+      "created_at": "2017-01-05T16:47:26.042704Z",
+      "email_address": "ben.vandersteen@digital.cabinet-office.gov.uk",
+      "id": "85475586-e90f-4064-8720-5c9cc5850589",
+      "line_1": "None",
+      "line_2": "None",
+      "line_3": "None",
+      "line_4": "None",
+      "line_5": "None",
+      "line_6": "None",
+      "phone_number": "None",
+      "postcode": "None",
+      "reference": "X-zrZv_IbzjZUnhsbWlsecLbwjndTpG0ZynXOif7V-k=",
+      "sent_at": "2017-01-05T16:47:26.474093Z",
+      "status": "delivered",
+      "subject": "Your Digital Outcomes and Specialists 2 application has been successful",
+      "template": {
+        "id": "e767bb69-5927-4a18-a0e7-93e8ab99c587",
+        "uri": "https://api.notifications.service.gov.uk/service/95316ff0-e555-462d-a6e7-95d26fbfd091/template/e767bb69-5927-4a18-a0e7-93e8ab99c587",
+        "version": 16
+      },
+      "type": "email"
+    },{
+      "body": "05/01/2017\n\nDear supplier, \n\nBen's Awesome Company\u2019s application to Digital Outcomes and Specialists 2 was successful.\n\nYour results were: \nyes\nno\nmaybe\nI don't know\n\nWe\u2019ve notified all applicants about their results. A 10-day 'standstill period' will start on 17 January 2017 and end at 11.59pm (GMT) on 26 January 2017. We expect the framework to be awarded on 27 January 2017 and services to go live on the Digital Marketplace in February 2016. \n\nYou must sign and return your framework agreement before you can sell services on the Digital Marketplace. \n\nYour framework agreement is ready to sign at: \nhttps://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/digital-outcomes-and-specialists-2/agreement\n\n\nWe\u2019ll notify you when the standstill period is over. Until then, you shouldn\u2019t make any public announcements about the result of your application.\n\nYours faithfully,\nAlison Lisett\nHead of Sourcing Delivery\nCrown Commercial Service",
+      "completed_at": "2017-01-05T15:56:20.341232Z",
+      "created_at": "2017-01-05T15:56:14.740035Z",
+      "email_address": "ben.vandersteen@digital.cabinet-office.gov.uk",
+      "id": "dddc9b62-8539-43d1-907d-5853ad16f607",
+      "line_1": "None",
+      "line_2": "None",
+      "line_3": "None",
+      "line_4": "None",
+      "line_5": "None",
+      "line_6": "None",
+      "phone_number": "None",
+      "postcode": "None",
+      "reference": "a4ayc_80_OGda4BO_1o_V0etpOqiLx1JwB5S3beHW0s=",
+      "sent_at": "2017-01-05T15:56:16.053399Z",
+      "status": "delivered",
+      "subject": "Your Digital Outcomes and Specialists 2 application has been successful",
+      "template": {
+        "id": "e767bb69-5927-4a18-a0e7-93e8ab99c587",
+        "uri": "https://api.notifications.service.gov.uk/service/95316ff0-e555-462d-a6e7-95d26fbfd091/template/e767bb69-5927-4a18-a0e7-93e8ab99c587",
+        "version": 16
+      },
+      "type": "email"
+    },{
+      "body": "05/01/2017\n\nDear supplier, \n\nBen's Awesome Company\u2019s application to Digital Outcomes and Specialists 2 was successful.\n\nYour results were: \n\u2022 Digital outcomes - yes\nno\nmaybe\nI don't know\n\nWe\u2019ve notified all applicants about their results. A 10-day 'standstill period' will start on 17 January 2017 and end at 11.59pm (GMT) on 26 January 2017. We expect the framework to be awarded on 27 January 2017 and services to go live on the Digital Marketplace in February 2016. \n\nYou must sign and return your framework agreement before you can sell services on the Digital Marketplace. \n\nYour framework agreement is ready to sign at: \nhttps://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/digital-outcomes-and-specialists-2/agreement\n\n\nWe\u2019ll notify you when the standstill period is over. Until then, you shouldn\u2019t make any public announcements about the result of your application.\n\nYours faithfully,\nAlison Lisett\nHead of Sourcing Delivery\nCrown Commercial Service",
+      "completed_at": "2017-01-05T15:10:22.004915Z",
+      "created_at": "2017-01-05T15:10:19.355770Z",
+      "email_address": "ben.vandersteen@digital.cabinet-office.gov.uk",
+      "id": "e325353b-ab97-4f36-8381-c07ec36264d5",
+      "line_1": "None",
+      "line_2": "None",
+      "line_3": "None",
+      "line_4": "None",
+      "line_5": "None",
+      "line_6": "None",
+      "phone_number": "None",
+      "postcode": "None",
+      "reference": "1HNeOiZeFu7gP1lxi5tdAwGcB9i2xR-Q2jpmbuwTqzU=",
+      "sent_at": "2017-01-05T15:10:20.962141Z",
+      "status": "delivered",
+      "subject": "Your Digital Outcomes and Specialists 2 application has been successful",
+      "template": {
+        "id": "e767bb69-5927-4a18-a0e7-93e8ab99c587",
+        "uri": "https://api.notifications.service.gov.uk/service/95316ff0-e555-462d-a6e7-95d26fbfd091/template/e767bb69-5927-4a18-a0e7-93e8ab99c587",
+        "version": 16
+      },
+      "type": "email"
+    },{
+      "body": "05/01/2017\n\nDear supplier, \n\nYour Awesome Company\u2019s application to Digital Outcomes and Specialists 2 was successful.\n\nYour results were: \n\u2022 Digital outcomes - yes\nno\nmaybe\nI don't know\n\nWe\u2019ve notified all applicants about their results. A 10-day 'standstill period' will start on 17 January 2017 and end at 11.59pm (GMT) on 26 January 2017. We expect the framework to be awarded on 27 January 2017 and services to go live on the Digital Marketplace in February 2016. \n\nYou must sign and return your framework agreement before you can sell services on the Digital Marketplace. \n\nYour framework agreement is ready to sign at: \nhttps://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/digital-outcomes-and-specialists-2/agreement\n\n\nWe\u2019ll notify you when the standstill period is over. Until then, you shouldn\u2019t make any public announcements about the result of your application.\n\nYours faithfully,\nAlison Lisett\nHead of Sourcing Delivery\nCrown Commercial Service",
+      "completed_at": "2017-01-05T15:04:50.908482Z",
+      "created_at": "2017-01-05T15:04:44.813755Z",
+      "email_address": "tobi.ogunsina@digital.cabinet-office.gov.uk",
+      "id": "99b6ff9e-c556-4c55-8293-ce93189c8ab1",
+      "line_1": "None",
+      "line_2": "None",
+      "line_3": "None",
+      "line_4": "None",
+      "line_5": "None",
+      "line_6": "None",
+      "phone_number": "None",
+      "postcode": "None",
+      "reference": "TgdAhWK-24tgzgXB3s_jrRa3IjCWfeAfZAt-Rym0n84=",
+      "sent_at": "2017-01-05T15:04:50.049479Z",
+      "status": "delivered",
+      "subject": "Your Digital Outcomes and Specialists 2 application has been successful",
+      "template": {
+        "id": "e767bb69-5927-4a18-a0e7-93e8ab99c587",
+        "uri": "https://api.notifications.service.gov.uk/service/95316ff0-e555-462d-a6e7-95d26fbfd091/template/e767bb69-5927-4a18-a0e7-93e8ab99c587",
+        "version": 16
+      },
+      "type": "email"
+    },{
+      "body": "05/01/2017\n\nDear supplier, \n\nYour Awesome Company\u2019s application to Digital Outcomes and Specialists 2 was successful.\n\nYour results were: \n\u2022 Digital outcomes - yes\nno\nmaybe\nI don't know\n\nWe\u2019ve notified all applicants about their results. A 10-day 'standstill period' will start on 17 January 2017 and end at 11.59pm (GMT) on 26 January 2017. We expect the framework to be awarded on 27 January 2017 and services to go live on the Digital Marketplace in February 2016. \n\nYou must sign and return your framework agreement before you can sell services on the Digital Marketplace. \n\nYour framework agreement is ready to sign at: \nhttps://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/digital-outcomes-and-specialists-2/agreement\n\n\nWe\u2019ll notify you when the standstill period is over. Until then, you shouldn\u2019t make any public announcements about the result of your application.\n\nYours faithfully,\nAlison Lisett\nHead of Sourcing Delivery\nCrown Commercial Service",
+      "completed_at": "2017-01-05T15:04:20.789637Z",
+      "created_at": "2017-01-05T15:04:17.770267Z",
+      "email_address": "ben.vandersteen@digital.cabinet-office.gov.uk",
+      "id": "808a20f6-485b-4d2c-8be7-7e31ad1b3f46",
+      "line_1": "None",
+      "line_2": "None",
+      "line_3": "None",
+      "line_4": "None",
+      "line_5": "None",
+      "line_6": "None",
+      "phone_number": "None",
+      "postcode": "None",
+      "reference": "SyJ3d9TdH8Ycb4hPSGQdArTRIdP9Moywi1Ux_Kzav4o=",
+      "sent_at": "2017-01-05T15:04:20.004533Z",
+      "status": "delivered",
+      "subject": "Your Digital Outcomes and Specialists 2 application has been successful",
+      "template": {
+        "id": "e767bb69-5927-4a18-a0e7-93e8ab99c587",
+        "uri": "https://api.notifications.service.gov.uk/service/95316ff0-e555-462d-a6e7-95d26fbfd091/template/e767bb69-5927-4a18-a0e7-93e8ab99c587",
+        "version": 16
+      },
+      "type": "email"
+    },{
+      "body": "05/01/2017\n\nDear supplier, \n\nYour Awesome Company\u2019s application to Digital Outcomes and Specialists 2 was successful.\n\nYour results were: \n\u2022 Digital outcomes - yes\nno\nmaybe\nI don't know\n\nWe\u2019ve notified all applicants about their results. A 10-day 'standstill period' will start on 17 January 2017 and end at 11.59pm (GMT) on 26 January 2017. We expect the framework to be awarded on 27 January 2017 and services to go live on the Digital Marketplace in February 2016. \n\nYou must sign and return your framework agreement before you can sell services on the Digital Marketplace. \n\nYour framework agreement is ready to sign at: \nhttps://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/digital-outcomes-and-specialists-2/agreement\n\n\nWe\u2019ll notify you when the standstill period is over. Until then, you shouldn\u2019t make any public announcements about the result of your application.\n\nYours faithfully,\nAlison Lisett\nHead of Sourcing Delivery\nCrown Commercial Service",
+      "completed_at": "2017-01-05T15:03:52.004181Z",
+      "created_at": "2017-01-05T15:03:50.760620Z",
+      "email_address": "ben.vandersteen@digital.cabinet-office.gov.uk",
+      "id": "93dfd83c-a1f4-42b9-abae-d1fb74b39a7c",
+      "line_1": "None",
+      "line_2": "None",
+      "line_3": "None",
+      "line_4": "None",
+      "line_5": "None",
+      "line_6": "None",
+      "phone_number": "None",
+      "postcode": "None",
+      "reference": "7y0SfeN7lCuq0GFF5UsMYZofIjJ7LrvPvsePVWSv450=",
+      "sent_at": "2017-01-05T15:03:51.184121Z",
+      "status": "delivered",
+      "subject": "Your Digital Outcomes and Specialists 2 application has been successful",
+      "template": {
+        "id": "e767bb69-5927-4a18-a0e7-93e8ab99c587",
+        "uri": "https://api.notifications.service.gov.uk/service/95316ff0-e555-462d-a6e7-95d26fbfd091/template/e767bb69-5927-4a18-a0e7-93e8ab99c587",
+        "version": 16
+      },
+      "type": "email"
+    },{
+      "body": "05/01/2017\n\nDear supplier, \n\nYour Awesome Company\u2019s application to Digital Outcomes and Specialists 2 was successful.\n\nYour results were: \n\u2022 Digital outcomes - yes\nno\nmaybe\nI don't know\n\nWe\u2019ve notified all applicants about their results. A 10-day 'standstill period' will start on 17 January 2017 and end at 11.59pm (GMT) on 26 January 2017. We expect the framework to be awarded on 27 January 2017 and services to go live on the Digital Marketplace in February 2016. \n\nYou must sign and return your framework agreement before you can sell services on the Digital Marketplace. \n\nYour framework agreement is ready to sign at: \nhttps://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/digital-outcomes-and-specialists-2/agreement\n\n\nWe\u2019ll notify you when the standstill period is over. Until then, you shouldn\u2019t make any public announcements about the result of your application.\n\nYours faithfully,\nAlison Lisett\nHead of Sourcing Delivery\nCrown Commercial Service",
+      "completed_at": "2017-01-05T15:02:15.198445Z",
+      "created_at": "2017-01-05T15:02:12.337967Z",
+      "email_address": "ben.vandersteen@digital.cabinet-office.gov.uk",
+      "id": "2e80dbf4-6b92-4bae-b6de-93d8526b6e89",
+      "line_1": "None",
+      "line_2": "None",
+      "line_3": "None",
+      "line_4": "None",
+      "line_5": "None",
+      "line_6": "None",
+      "phone_number": "None",
+      "postcode": "None",
+      "reference": "5_bAEXdujbfNMwtUF0_Xb30CFrYSOHpf_PuB5vCRloM=",
+      "sent_at": "2017-01-05T15:02:14.171462Z",
+      "status": "delivered",
+      "subject": "Your Digital Outcomes and Specialists 2 application has been successful",
+      "template": {
+        "id": "e767bb69-5927-4a18-a0e7-93e8ab99c587",
+        "uri": "https://api.notifications.service.gov.uk/service/95316ff0-e555-462d-a6e7-95d26fbfd091/template/e767bb69-5927-4a18-a0e7-93e8ab99c587",
+        "version": 16
+      },
+      "type": "email"
+    },{
+      "body": "05/01/2017\n\nDear supplier, \n\nYour Awesome Company\u2019s application to Digital Outcomes and Specialists 2 was successful.\n\nYour results were: \n\u2022 Digital outcomes - yes\nno\nmaybe\nI don't know\n\nWe\u2019ve notified all applicants about their results. A 10-day 'standstill period' will start on 17 January 2017 and end at 11.59pm (GMT) on 26 January 2017. We expect the framework to be awarded on 27 January 2017 and services to go live on the Digital Marketplace in February 2016. \n\nYou must sign and return your framework agreement before you can sell services on the Digital Marketplace. \n\nYour framework agreement is ready to sign at: \nhttps://www.digitalmarketplace.service.gov.uk/suppliers/frameworks/digital-outcomes-and-specialists-2/agreement\n\n\nWe\u2019ll notify you when the standstill period is over. Until then, you shouldn\u2019t make any public announcements about the result of your application.\n\nYours faithfully,\nAlison Lisett\nHead of Sourcing Delivery\nCrown Commercial Service",
+      "completed_at": "2017-01-05T15:01:48.280326Z",
+      "created_at": "2017-01-05T15:01:44.708953Z",
+      "email_address": "robert.scott@digital.cabinet-office.gov.uk",
+      "id": "ac0973cd-3d1c-446d-bec5-665347beaf53",
+      "line_1": "None",
+      "line_2": "None",
+      "line_3": "None",
+      "line_4": "None",
+      "line_5": "None",
+      "line_6": "None",
+      "phone_number": "None",
+      "postcode": "None",
+      "reference": "eQJpm-Qsio5G-7tFAXJlF-hrIsVqGJ92JabaSQgbJFE=",
+      "sent_at": "2017-01-05T15:01:47.428623Z",
+      "status": "delivered",
+      "subject": "Your Digital Outcomes and Specialists 2 application has been successful",
+      "template": {
+        "id": "e767bb69-5927-4a18-a0e7-93e8ab99c587",
+        "uri": "https://api.notifications.service.gov.uk/service/95316ff0-e555-462d-a6e7-95d26fbfd091/template/e767bb69-5927-4a18-a0e7-93e8ab99c587",
+        "version": 16
+      },
+      "type": "email"
+    }
+  ]
+}

--- a/tests/email/test_dm_notify.py
+++ b/tests/email/test_dm_notify.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+"""Tests for the Digital Marketplace Notify client."""
+import json
+
+import mock
+import os
+from collections import OrderedDict
+import pytest
+
+from dmutils.email.dm_notify import DMNotifyClient
+
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), 'fixtures')
+
+
+@pytest.fixture
+def dm_notify_client(app):
+    """Supply initialized client."""
+    with app.app_context():
+        test_api_key = '1111111111' * 8
+        return DMNotifyClient(test_api_key)
+
+
+@pytest.fixture
+def notify_example_http_error():
+    """Return a mock object with attributes of Notify `HTTPError`."""
+    e = mock.Mock
+    e.status_code = 400
+    e.message = [
+        {u'message': u'email_address Not a valid email address', u'error': u'ValidationError'},
+        {u'message': u'template_id is not a valid UUID', u'error': u'ValidationError'}
+    ]
+    return e
+
+
+@pytest.fixture
+def notify_get_all_notifications():
+    """Return a dummy `notifications_python_client.NotificationsAPIClient.get_all_notifications` response."""
+    pth = os.path.join(FIXTURES_DIR, 'notifications__get_all_notifications__response.json')
+    with open(pth) as get_all_notifications_response:
+        return json.loads(get_all_notifications_response.read())
+
+
+@pytest.fixture
+def notify_send_email():
+    """Lifted directly from the https://github.com/alphagov/notifications-python-client README.md
+
+    Success response for `notifications_python_client.NotificationsAPIClient.send_email_notification`
+    """
+    example_response = {
+        'id': 'bfb50d92-100d-4b8b-b559-14fa3b091cda',
+        'reference': None,
+        'content': {
+            'subject': 'Licence renewal',
+            'body': 'Dear Bill, your licence is due for renewal on 3 January 2016.',
+            'from_email': 'the_service@gov.uk'
+        },
+        'uri': 'https://api.notifications.service.gov.uk/v2/notifications/ceb50d92-100d-4b8b-b559-14fa3b091cd',
+        'template': {
+             'id': 'ceb50d92-100d-4b8b-b559-14fa3b091cda',
+             'version': 1,
+             'uri': 'https://api.notificaitons.service.gov.uk/service/'
+             'your_service_id/templates/bfb50d92-100d-4b8b-b559-14fa3b091cda'
+        }
+    }
+    return example_response
+
+
+class TestDMNotifyClient(object):
+    """Tests for the Digital Marketplace Notify API Client."""
+
+    client_class_str = 'notifications_python_client.NotificationsAPIClient'
+
+    def setup(self):
+        """Set up some standard attributes for tests."""
+        self.email_address = 'example@example.com'
+        self.template_id = 'my-cool-example-template'
+        self.personalisation = OrderedDict([
+            ('foo', 'foo_p13n'),
+            ('bar', 'bar_p13n'),
+            ('baz', 'baz_p13n'),
+        ])
+        self.standard_args = {
+            'email_address': self.email_address,
+            'template_id': self.template_id,
+            'personalisation': self.personalisation
+        }
+
+    def test_get_reference(self, dm_notify_client):
+        """Test the staticmethod that creates the reference field to be sent with the request."""
+        ref = dm_notify_client.get_reference(**self.standard_args)
+        expected = (
+            b'K5fhXxlvVQ8sKPrqocizL-F2LcQ-Ee6FIFeMH0omijI='
+        )
+
+        assert ref == expected
+
+    def test_send_email_creates_reference(self, dm_notify_client, notify_send_email):
+        """Test the `send_email` function with data that should pass and run without exception."""
+        with mock.patch(self.client_class_str + '.' + 'send_email_notification') as email_mock:
+            email_mock.return_value = notify_send_email
+            dm_notify_client.send_email(self.email_address, self.template_id)
+
+            email_mock.assert_called_with(
+                self.email_address,
+                self.template_id,
+                personalisation=None,
+                reference=b'niC4qhMflcnl8MkY82N7Gqze2ZA7ed1pSBTGnxeDPj0='
+            )
+
+    def test_personalisation_passed(self, dm_notify_client, notify_send_email):
+        """Assert the expected existence of personalisation."""
+        personalisation = {'foo': 'bar'}
+        with mock.patch(self.client_class_str + '.' + 'send_email_notification') as email_mock:
+            notify_send_email.update(personalisation=personalisation)
+            dm_notify_client.send_email(
+                self.email_address,
+                self.template_id,
+                personalisation=personalisation
+            )
+            email_mock.assert_called_with(
+                self.email_address,
+                self.template_id,
+                personalisation=personalisation,
+                reference=b'jcUtmC7843cKFb0mXbz5FMJsOIGbuynAtFDCaCXRe9s='
+            )
+
+    def test_personalisation_appears_in_reference(self, dm_notify_client, notify_send_email):
+        """Assert personalisation is added to the auto generated reference."""
+        personalisation = {'foo': 'bar'}
+        with mock.patch(self.client_class_str + '.' + 'send_email_notification') as email_mock:
+            notify_send_email.update(personalisation=personalisation)
+            dm_notify_client.send_email(
+                self.email_address,
+                self.template_id,
+                personalisation=personalisation
+            )
+            email_mock.assert_called_with(
+                self.email_address,
+                self.template_id,
+                personalisation=personalisation,
+                reference=b'jcUtmC7843cKFb0mXbz5FMJsOIGbuynAtFDCaCXRe9s='
+            )
+
+    def test_get_error_message(self, dm_notify_client, notify_example_http_error):
+        """Test error message format."""
+        actual = dm_notify_client.get_error_message(self.email_address, notify_example_http_error)
+        expected = (
+            'Error sending message to example@example.com: 400 ValidationError: email_address '
+            'Not a valid email address, 400 ValidationError: template_id is not a valid UUID'
+        )
+
+        assert actual == expected
+
+    def test_cache_not_instantiated_with_allow_resend(self, dm_notify_client):
+        """The cache shouldn't be touched until we pass `allow_resend=False` to `send_email`."""
+        with mock.patch(self.client_class_str + '.' + 'send_email_notification') as email_mock:
+            assert dm_notify_client._sent_references_cache is None
+            dm_notify_client.send_email(self.email_address, self.template_id)
+            assert dm_notify_client._sent_references_cache is None
+
+    def test_cache_instantiated_without_allow_resend(
+            self,
+            dm_notify_client,
+            notify_send_email,
+            notify_get_all_notifications
+    ):
+        """Setting `allow_resend=False` on `send_email` should cause the cache to be populated."""
+        with mock.patch(self.client_class_str + '.' + 'send_email_notification') as send_email_notification_mock:
+            with mock.patch(self.client_class_str + '.' + 'get_all_notifications') as get_all_notifications_mock:
+                send_email_notification_mock.return_value = notify_send_email
+                get_all_notifications_mock.return_value = notify_get_all_notifications
+
+                assert dm_notify_client._sent_references_cache is None
+                dm_notify_client.send_email(self.email_address, self.template_id, allow_resend=False)
+
+                get_all_notifications_mock.assert_called_once_with(status='delivered')
+
+                # Dummy data from notify_get_all_notifications + the one we just sent = 9
+                assert len(dm_notify_client._sent_references_cache) == 9
+                assert dm_notify_client.has_been_sent(
+                    dm_notify_client.get_reference(self.email_address, self.template_id, None)
+                )
+
+    def test_cache_always_populated_after_first_send_without_allow_resend(self, dm_notify_client, notify_send_email):
+        """Until `allow_resend` is set to False for the first time the cache shouldn't be populated, after, it should.
+
+        After the first instance of `allow_resend=False` every reference should be added to the cache.
+        This is to stop us having to query the api on every email send with `allow_resend=False`.
+        """
+        with mock.patch(self.client_class_str + '.' + 'send_email_notification') as send_email_notification_mock:
+            with mock.patch(self.client_class_str + '.' + 'get_all_notifications') as get_all_notifications_mock:
+                send_email_notification_mock.return_value = notify_send_email
+                get_all_notifications_mock.return_value = {
+                    "links": {
+                        "current": "https://api.notifications.service.gov.uk/v2/foo",
+                        "next": "https://api.notifications.service.gov.uk/v2/bar",
+                    },
+                    "notifications": []
+                }
+
+                assert dm_notify_client._sent_references_cache is None, "Cache should be None on instantiation"
+
+                dm_notify_client.send_email(self.email_address, self.template_id)
+                assert dm_notify_client._sent_references_cache is None, "Cache should be None with allow_resend=True"
+
+                dm_notify_client.send_email(self.email_address, self.template_id, allow_resend=False)
+                assert dm_notify_client._sent_references_cache == {
+                    dm_notify_client.get_reference(self.email_address, self.template_id)
+                }, "Cache should now start populating"
+
+                dm_notify_client.send_email(self.email_address + 'foo', self.template_id + 'bar', allow_resend=False)
+                assert dm_notify_client._sent_references_cache == {
+                    dm_notify_client.get_reference(self.email_address, self.template_id),
+                    dm_notify_client.get_reference(self.email_address + 'foo', self.template_id + 'bar')
+                }, "Cache should now start populating regardless of allow_resend flag"
+
+    def test_not_allow_resend(self, dm_notify_client):
+        """Trigger identical emails and make sure only one is sent!"""
+        with mock.patch(self.client_class_str + '.' + 'send_email_notification') as send_email_notification_mock:
+            with mock.patch(self.client_class_str + '.' + 'get_all_notifications') as get_all_notifications_mock:
+                send_email_notification_mock.return_value = True
+                get_all_notifications_mock.return_value = {"notifications": []}
+                dm_notify_client.send_email(self.email_address, self.template_id, allow_resend=False)
+                dm_notify_client.send_email(self.email_address, self.template_id, allow_resend=False)
+
+                send_email_notification_mock.assert_called_once_with(
+                    self.email_address,
+                    self.template_id,
+                    personalisation=None,
+                    reference=b'niC4qhMflcnl8MkY82N7Gqze2ZA7ed1pSBTGnxeDPj0='
+                )


### PR DESCRIPTION
### Notify integration:

#### Directory reshuffle
* Move `dmutils/email.py` > `dmutils/email/dm_mandrill.py`
* Create `dm_utils/email/notify.py`
* Allow importing `dm_mandrill.send_email` from `dm_utils.email` for backwards compatibility

#### App fixes, reshuffles, refactors, tweaks
* Add `notifications-python-client.git` to `requirements.txt`
* Add `norecursedirs` to `setup.cfg` to stop py.test running tests for env packages
* Remove unnecessary method `token_created_before_password` and corresponding tests
* Move `hash_string` to new `dmutils/email/helpers.py` to use in Mandrill and Notify 
* New `stringify_dict` method in `dmutils/formats.py` to format dicts for error messages


#### Email stuff and Notify integration
* Normalise exceptions with new `dmutils/email/exceptions.py`
* Adds class `DMNotifyClient`
  * `get_all_notifications` will get a list of all the notifications from the api
  * `get_reference` hashes the email address, template id and template context to provide a reference
  * `send_email` is the method used for actually sending the api request
  * Caching sent references allows us to not send duplicate mails


#### Notify Integration Tests and Mandrill Tests
* Mirrored new directory structure in `tests` directory
* Normalise string declarations in `test_dm_mandrill.py`
* New fixture for a response from `notifications_python_client.NotificationsAPIClient.get_all_notifications`
* Fixtures for the client, an exception, a `send_email_notification` response
* Tests for functionality (Mocking methods on `notifications_python_client.NotificationsAPIClient`)

