### PR TITLE
Refactor from requirements.txt to setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "3.4"
 install:
   - pip install -r requirements_for_test.txt
-  - pip install -e .
 script:
   - ./scripts/run_tests.sh --cov=dmutils --cov-report=term-missing
 after_success:

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -1,4 +1,4 @@
-from . import logging, config, proxy_fix, formats, request_id
+from . import config, proxy_fix, formats, request_id
 from .flask_init import init_app, init_manager
 
 import flask_featureflags

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '24.0.0'
+__version__ = '24.0.1'

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -1,6 +1,4 @@
-from . import config, proxy_fix, formats, request_id
+from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
-
-import flask_featureflags
 
 __version__ = '24.0.1'

--- a/dmutils/email/dm_mandrill.py
+++ b/dmutils/email/dm_mandrill.py
@@ -61,18 +61,7 @@ def send_email(to_email_addresses, email_body, api_key, subject, from_email, fro
                 extra={'tags': tags, 'id': result[0]['_id'], 'email_hash': hash_string(result[0]['email'])})
 
 
-def decode_signed_token(token, secret_key, namespace, max_age_in_seconds=86400):
-    ts = itsdangerous.URLSafeTimedSerializer(secret_key)
-    decoded, timestamp = ts.loads(
-        token,
-        salt=namespace,
-        max_age=max_age_in_seconds,
-        return_timestamp=True
-    )
-    return decoded, timestamp
-
-
-def encrypt_data(json_data, secret_key, namespace):
+def generate_token(json_data, secret_key, namespace):
     """
     Encrypt data using a provided secret_key and namespace.
 
@@ -101,10 +90,6 @@ def encrypt_data(json_data, secret_key, namespace):
     return f.encrypt(data).decode('utf-8')
 
 
-def generate_token(data, secret_key, namespace):
-    return encrypt_data(data, secret_key, namespace)
-
-
 def _parse_fernet_timestamp(ciphertext):
     """
     Returns utc timestamp embedded in Fernet-encrypted ciphertext, converted to Python datetime object.
@@ -122,7 +107,7 @@ def _parse_fernet_timestamp(ciphertext):
     return datetime.utcfromtimestamp(epoch_timestamp)
 
 
-def decrypt_data(encrypted_data, secret_key, namespace, max_age_in_seconds):
+def decode_token(encrypted_data, secret_key, namespace, max_age_in_seconds=ONE_DAY_IN_SECONDS):
     """
     Decrypt data using a provided secret_key, namespace, and TTL (max_age_in_seconds).
 
@@ -155,23 +140,6 @@ def decrypt_data(encrypted_data, secret_key, namespace, max_age_in_seconds):
 
     timestamp = _parse_fernet_timestamp(encrypted_bytes)
     return json.loads(data.decode('utf-8')), timestamp
-
-
-def decode_token(token, secret_key, namespace, max_age_in_seconds=86400):
-    """
-    Decode a token given a secret_key and namespace.
-
-    The token may have been created by a previous version of dmutils, which only supported signed unencrypted tokens.
-    To maintain backwards compatibility during rollouts, we try and decode using the old format, and if that fails
-    assume it is is a new encrypted token.
-
-    This functionality can be removed once all rollouts have completed and the longest time-to-live of the old signed
-    tokens has expired (seven days for an invite email).
-    """
-    try:
-        return decode_signed_token(token, secret_key, namespace, max_age_in_seconds)
-    except itsdangerous.BadData:
-        return decrypt_data(token, secret_key, namespace, max_age_in_seconds)
 
 
 def decode_password_reset_token(token, data_api_client):

--- a/dmutils/email/dm_mandrill.py
+++ b/dmutils/email/dm_mandrill.py
@@ -57,30 +57,8 @@ def send_email(to_email_addresses, email_body, api_key, subject, from_email, fro
         # Mandrill errors are thrown as exceptions
         logger.error("Failed to send an email: {error}", extra={'error': e})
         raise EmailError(e)
-
     logger.info("Sent {tags} response: id={id}, email={email_hash}",
                 extra={'tags': tags, 'id': result[0]['_id'], 'email_hash': hash_string(result[0]['email'])})
-
-
-def generate_token(data, secret_key, namespace):
-    return encrypt_data(data, secret_key, namespace)
-
-
-def decode_token(token, secret_key, namespace, max_age_in_seconds=86400):
-    """
-    Decode a token given a secret_key and namespace.
-
-    The token may have been created by a previous version of dmutils, which only supported signed unencrypted tokens.
-    To maintain backwards compatibility during rollouts, we try and decode using the old format, and if that fails
-    assume it is is a new encrypted token.
-
-    This functionality can be removed once all rollouts have completed and the longest time-to-live of the old signed
-    tokens has expired (seven days for an invite email).
-    """
-    try:
-        return decode_signed_token(token, secret_key, namespace, max_age_in_seconds)
-    except itsdangerous.BadData:
-        return decrypt_data(token, secret_key, namespace, max_age_in_seconds)
 
 
 def decode_signed_token(token, secret_key, namespace, max_age_in_seconds=86400):
@@ -119,8 +97,29 @@ def encrypt_data(json_data, secret_key, namespace):
     """
     secret_key = hash_string(secret_key + namespace)
     data = json.dumps(json_data).encode('utf-8')
-    f = fernet.Fernet(secret_key)
+    f = fernet.Fernet(secret_key.encode('utf-8'))
     return f.encrypt(data).decode('utf-8')
+
+
+def generate_token(data, secret_key, namespace):
+    return encrypt_data(data, secret_key, namespace)
+
+
+def _parse_fernet_timestamp(ciphertext):
+    """
+    Returns utc timestamp embedded in Fernet-encrypted ciphertext, converted to Python datetime object.
+
+    Decryption should be attempted before using this function, as that does cryptographically strong tests on the
+    validity of the ciphertext.
+    """
+    decoded = base64.urlsafe_b64decode(ciphertext)
+
+    try:
+        epoch_timestamp = struct.unpack('>Q', decoded[1:9])[0]
+    except struct.error as e:
+        raise fernet.InvalidToken(e.message)
+
+    return datetime.utcfromtimestamp(epoch_timestamp)
 
 
 def decrypt_data(encrypted_data, secret_key, namespace, max_age_in_seconds):
@@ -149,7 +148,7 @@ def decrypt_data(encrypted_data, secret_key, namespace, max_age_in_seconds):
     """
     encrypted_bytes = encrypted_data.encode('utf-8')
     secret_key = hash_string(secret_key + namespace)
-    f = fernet.Fernet(secret_key)
+    f = fernet.Fernet(secret_key.encode('utf-8'))
 
     # this raises fernet.InvalidToken if the key does not match or if TTL is exceeded
     data = f.decrypt(encrypted_bytes, ttl=max_age_in_seconds)
@@ -158,21 +157,21 @@ def decrypt_data(encrypted_data, secret_key, namespace, max_age_in_seconds):
     return json.loads(data.decode('utf-8')), timestamp
 
 
-def _parse_fernet_timestamp(ciphertext):
+def decode_token(token, secret_key, namespace, max_age_in_seconds=86400):
     """
-    Returns utc timestamp embedded in Fernet-encrypted ciphertext, converted to Python datetime object.
+    Decode a token given a secret_key and namespace.
 
-    Decryption should be attempted before using this function, as that does cryptographically strong tests on the
-    validity of the ciphertext.
+    The token may have been created by a previous version of dmutils, which only supported signed unencrypted tokens.
+    To maintain backwards compatibility during rollouts, we try and decode using the old format, and if that fails
+    assume it is is a new encrypted token.
+
+    This functionality can be removed once all rollouts have completed and the longest time-to-live of the old signed
+    tokens has expired (seven days for an invite email).
     """
-    decoded = base64.urlsafe_b64decode(ciphertext)
-
     try:
-        epoch_timestamp = struct.unpack('>Q', decoded[1:9])[0]
-    except struct.error as e:
-        raise fernet.InvalidToken(e.message)
-
-    return datetime.utcfromtimestamp(epoch_timestamp)
+        return decode_signed_token(token, secret_key, namespace, max_age_in_seconds)
+    except itsdangerous.BadData:
+        return decrypt_data(token, secret_key, namespace, max_age_in_seconds)
 
 
 def decode_password_reset_token(token, data_api_client):

--- a/dmutils/email/helpers.py
+++ b/dmutils/email/helpers.py
@@ -7,5 +7,5 @@ import six
 
 def hash_string(string):
     """Hash a given string."""
-    m = hashlib.sha256(six.u(string).encode('utf-8'))
+    m = hashlib.sha256(six.text_type(string).encode('utf-8'))
     return base64.urlsafe_b64encode(m.digest()).decode('utf-8')

--- a/dmutils/email/helpers.py
+++ b/dmutils/email/helpers.py
@@ -2,9 +2,10 @@
 """Email helpers."""
 import base64
 import hashlib
+import six
 
 
 def hash_string(string):
     """Hash a given string."""
-    m = hashlib.sha256(string.encode('utf-8'))
-    return base64.urlsafe_b64encode(m.digest())
+    m = hashlib.sha256(six.u(string).encode('utf-8'))
+    return base64.urlsafe_b64encode(m.digest()).decode('utf-8')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,2 @@
-boto==2.38.0
-contextlib2==0.4.0
-Flask>=0.10
-six==1.9.0
-pyyaml==3.11
-python-json-logger==0.1.4
-inflection==0.2.1
-Flask-FeatureFlags==0.6
-mandrill==1.0.57
-monotonic==0.3
-pytz==2015.4
-Flask-WTF==0.12
-Flask-Script==2.0.5
-workdays==1.4
-unicodecsv==0.14.1
-cryptography==1.6
 git+https://github.com/alphagov/notifications-python-client.git@4.0.0#egg=notifications-python-client==4.0.0
+-e .

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,8 +1,9 @@
 -r requirements.txt
-pytest==2.8.7
+
+coverage==3.7.1
+freezegun==0.3.4
 mock==1.0.1
 pep8==1.6.2
-freezegun==0.3.4
-coverage==3.7.1
+pytest==2.8.7
 pytest-cov==2.2.0
 python-coveralls==2.5.0

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@ Common utils for Digital Marketplace apps.
 """
 import re
 import ast
-import pip.download
-from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
 
@@ -13,11 +11,6 @@ _version_re = re.compile(r'__version__\s+=\s+(.*)')
 with open('dmutils/__init__.py', 'rb') as f:
     version = str(ast.literal_eval(_version_re.search(
         f.read().decode('utf-8')).group(1)))
-
-requirements = list(parse_requirements('requirements.txt',
-                                       session=pip.download.PipSession()))
-
-install_requires = [str(r.req) for r in requirements]
 
 setup(
     name='digitalmarketplace-utils',
@@ -29,5 +22,23 @@ setup(
     long_description=__doc__,
     packages=find_packages(),
     include_package_data=True,
-    install_requires=install_requires
+    install_requires=[
+         'Flask-FeatureFlags==0.6',
+         'Flask-Script==2.0.5',
+         'Flask-WTF==0.12',
+         'Flask>=0.10',
+         'boto==2.38.0',
+         'contextlib2==0.4.0',
+         'cryptography==1.6',
+         'inflection==0.2.1',
+         'mandrill==1.0.57',
+         'monotonic==0.3',
+         'notifications-python-client==4.0.0',
+         'python-json-logger==0.1.4',
+         'pytz==2015.4',
+         'pyyaml==3.11',
+         'six==1.9.0',
+         'unicodecsv==0.14.1',
+         'workdays==1.4'
+    ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,3 +35,21 @@ def os_environ(request):
     request.addfinalizer(env_patch.stop)
 
     return env_patch.start()
+
+
+@pytest.fixture
+def user_json():
+    return {
+        "users": {
+            "id": 123,
+            "emailAddress": "test@example.com",
+            "name": "name",
+            "role": "supplier",
+            "locked": False,
+            "active": True,
+            "supplier": {
+                "supplierId": 321,
+                "name": "test supplier",
+            }
+        }
+    }

--- a/tests/email/test_dm_mandrill.py
+++ b/tests/email/test_dm_mandrill.py
@@ -15,7 +15,6 @@ from dmutils.config import init_app
 from dmutils.email.dm_mandrill import (
     generate_token,
     decode_token,
-    encrypt_data,
     send_email,
     decode_invitation_token,
     decode_password_reset_token,
@@ -184,19 +183,15 @@ def test_should_throw_exception_if_mandrill_fails(email_app, mandrill):
         assert str(e.value) == 'this is an error'
 
 
-def signed_token():
-    ts = URLSafeTimedSerializer('1234567890')
-    return ts.dumps({'key1': 'value1', 'key2': 'value2'}, salt='0987654321')
+def test_can_generate_and_decode_token():
 
-
-def encrypted_token():
-    return encrypt_data({'key1': 'value1', 'key2': 'value2'}, secret_key='1234567890', namespace='0987654321')
-
-
-@pytest.mark.parametrize('token', [signed_token, encrypted_token], ids=lambda x: x.__name__)
-def test_can_generate_and_decode_token(token):
     with freeze_time('2016-01-01T12:00:00Z'):
-        token, timestamp = decode_token(token(), '1234567890', '0987654321')
+        encrypted_token = generate_token(
+            {'key1': 'value1', 'key2': 'value2'},
+            secret_key='1234567890',
+            namespace='0987654321'
+        )
+        token, timestamp = decode_token(encrypted_token, '1234567890', '0987654321')
     assert token == {'key1': 'value1', 'key2': 'value2'}
     assert timestamp == datetime(2016, 1, 1, 12, 0, 0)
 

--- a/tests/email/test_dm_notify.py
+++ b/tests/email/test_dm_notify.py
@@ -90,7 +90,7 @@ class TestDMNotifyClient(object):
         """Test the staticmethod that creates the reference field to be sent with the request."""
         ref = dm_notify_client.get_reference(**self.standard_args)
         expected = (
-            b'K5fhXxlvVQ8sKPrqocizL-F2LcQ-Ee6FIFeMH0omijI='
+            'K5fhXxlvVQ8sKPrqocizL-F2LcQ-Ee6FIFeMH0omijI='
         )
 
         assert ref == expected
@@ -105,7 +105,7 @@ class TestDMNotifyClient(object):
                 self.email_address,
                 self.template_id,
                 personalisation=None,
-                reference=b'niC4qhMflcnl8MkY82N7Gqze2ZA7ed1pSBTGnxeDPj0='
+                reference='niC4qhMflcnl8MkY82N7Gqze2ZA7ed1pSBTGnxeDPj0='
             )
 
     def test_personalisation_passed(self, dm_notify_client, notify_send_email):
@@ -122,7 +122,7 @@ class TestDMNotifyClient(object):
                 self.email_address,
                 self.template_id,
                 personalisation=personalisation,
-                reference=b'jcUtmC7843cKFb0mXbz5FMJsOIGbuynAtFDCaCXRe9s='
+                reference='jcUtmC7843cKFb0mXbz5FMJsOIGbuynAtFDCaCXRe9s='
             )
 
     def test_personalisation_appears_in_reference(self, dm_notify_client, notify_send_email):
@@ -139,7 +139,7 @@ class TestDMNotifyClient(object):
                 self.email_address,
                 self.template_id,
                 personalisation=personalisation,
-                reference=b'jcUtmC7843cKFb0mXbz5FMJsOIGbuynAtFDCaCXRe9s='
+                reference='jcUtmC7843cKFb0mXbz5FMJsOIGbuynAtFDCaCXRe9s='
             )
 
     def test_get_error_message(self, dm_notify_client, notify_example_http_error):
@@ -228,5 +228,5 @@ class TestDMNotifyClient(object):
                     self.email_address,
                     self.template_id,
                     personalisation=None,
-                    reference=b'niC4qhMflcnl8MkY82N7Gqze2ZA7ed1pSBTGnxeDPj0='
+                    reference='niC4qhMflcnl8MkY82N7Gqze2ZA7ed1pSBTGnxeDPj0='
                 )

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -8,24 +8,6 @@ def user():
     return User(123, 'test@example.com', 321, 'test supplier', False, True, "Name", 'supplier')
 
 
-@pytest.fixture
-def user_json():
-    return {
-        "users": {
-            "id": 123,
-            "emailAddress": "test@example.com",
-            "name": "name",
-            "role": "supplier",
-            "locked": False,
-            "active": True,
-            "supplier": {
-                "supplierId": 321,
-                "name": "test supplier",
-            }
-        }
-    }
-
-
 def test_user_has_role():
     assert user_has_role({'users': {'role': 'admin'}}, 'admin')
 


### PR DESCRIPTION
The purpose of this change is to ensure that this module works wheninstalled by `setup.py` and to remove redundencies in the requirements/ dependencies installation.
This module is likely to be installed by `setup.py` _within_ applications and therefore should be able to handle everything via the `setup.py` 


* Refactor from requirements.txt to setup.py
* Alphabetical order requirements
* Version bump
* Unicode sandwich `dmutils.email.helpers.hash_string` function (stops bytes leaking in py3)
* Reorder imports
* Reorder functions to not be referenced before they're declared