### PR TITLE
BUGFIX-notifications-added-to-pip-upgrade

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags  # noqa
 
-__version__ = '24.0.3'
+__version__ = '24.0.4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-git+https://github.com/alphagov/notifications-python-client.git@4.0.0#egg=notifications-python-client==4.0.0
 -e .

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
          'inflection==0.2.1',
          'mandrill==1.0.57',
          'monotonic==0.3',
-         'notifications-python-client==4.0.0',
+         'notifications-python-client==4.1.0',
          'python-json-logger==0.1.4',
          'pytz==2015.4',
          'pyyaml==3.11',


### PR DESCRIPTION
Notifications Python Client has been added to pip2 so we no longer need to fetch it from github 🎉 
* Get notifications from pip not github

