### PR TITLE
Don't autogenerate bucket_short_name from bucket name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 Records breaking changes from major version bumps
 
+## 25.0.0
+
+PR: [#302](https://github.com/alphagov/digitalmarketplace-utils/pull/302)
+
+### What changed
+
+`upload_document` and `upload_service_documents` now require an explicit `upload_type`
+argument (eg 'documents' or 'submissions' for document uploads).
+
+`S3.short_bucket_name` property is removed, so there's no need to set the attribute
+on the mocks.
+
+###Example app change
+
+Old:
+```
+upload_service_documents(
+    uploader, documents_url, draft,
+    request.files, section, public=False
+)
+
+```
+
+New:
+```
+upload_service_documents(
+    uploader, 'documents', documents_url, draft,
+    request.files, section, public=False
+)
+```
+
+
 ## 24.0.0
 
 PR: [#291](https://github.com/alphagov/digitalmarketplace-utils/pull/291)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags  # noqa
 
-__version__ = '24.1.0'
+__version__ = '25.0.0'

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -60,10 +60,11 @@ def validate_documents(files):
     return errors
 
 
-def upload_document(uploader, documents_url, service, field, file_contents, public=True):
+def upload_document(uploader, upload_type, documents_url, service, field, file_contents, public=True):
     """Upload the document to S3 bucket and return the document URL
 
     :param uploader: S3 uploader object
+    :param upload_type: Upload type (eg 'documents' or 'submissions')
     :param documents_url: base assets URL used as root for creating the full
                           document URL.
     :param service: service object used to look up service and supplier id
@@ -78,11 +79,11 @@ def upload_document(uploader, documents_url, service, field, file_contents, publ
              failed
 
     """
-    assert uploader.bucket_short_name in ['documents', 'submissions']
+    assert upload_type in ['documents', 'submissions']
 
     file_path = generate_file_name(
         service['frameworkSlug'],
-        uploader.bucket_short_name,
+        upload_type,
         service['supplierId'],
         service['id'],
         field,
@@ -104,8 +105,8 @@ def upload_document(uploader, documents_url, service, field, file_contents, publ
     return full_url
 
 
-def upload_service_documents(uploader, documents_url, service, request_files, section, public=True):
-    assert uploader.bucket_short_name in ['documents', 'submissions']
+def upload_service_documents(uploader, upload_type, documents_url, service, request_files, section, public=True):
+    assert upload_type in ['documents', 'submissions']
 
     files = {field: request_files[field] for field in section.get_question_ids(type="upload")
              if field in request_files}
@@ -120,7 +121,7 @@ def upload_service_documents(uploader, documents_url, service, request_files, se
 
     for field, contents in files.items():
         url = upload_document(
-            uploader, documents_url, service, field, contents,
+            uploader, upload_type, documents_url, service, field, contents,
             public=public)
 
         if not url:
@@ -179,7 +180,7 @@ def file_is_image(file_object):
     ]
 
 
-def generate_file_name(framework_slug, bucket_short_name, supplier_id, service_id, field, filename, suffix=None):
+def generate_file_name(framework_slug, upload_type, supplier_id, service_id, field, filename, suffix=None):
     if suffix is None:
         suffix = default_file_suffix()
 
@@ -192,7 +193,7 @@ def generate_file_name(framework_slug, bucket_short_name, supplier_id, service_i
 
     return '{}/{}/{}/{}-{}-{}{}'.format(
         framework_slug,
-        bucket_short_name,
+        upload_type,
         supplier_id,
         service_id,
         ID_TO_FILE_NAME_SUFFIX[field],

--- a/dmutils/s3.py
+++ b/dmutils/s3.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 import os
-import re
 import boto
 import boto.exception
 import datetime
@@ -15,26 +14,14 @@ from .formats import DATETIME_FORMAT
 logger = logging.getLogger(__name__)
 
 FILE_SIZE_LIMIT = 5400000  # approximately 5Mb
-BUCKET_SHORT_NAME_PATTERN = re.compile(
-    r'^digitalmarketplace-([^\-]+)-([^\-]+)-(\2)$'
-)
 
 
 class S3(object):
-    def __init__(self, bucket_name=None, host='s3-eu-west-1.amazonaws.com'):
+    def __init__(self, bucket_name, host='s3-eu-west-1.amazonaws.com'):
         conn = boto.connect_s3(host=host)
 
         self.bucket_name = bucket_name
         self.bucket = conn.get_bucket(bucket_name)
-
-    @property
-    def bucket_short_name(self):
-        match = BUCKET_SHORT_NAME_PATTERN.match(self.bucket_name)
-
-        if not match:
-            raise ValueError("Cannot parse bucket name: {}".format(self.bucket_name))
-
-        return match.group(1)
 
     def save(self, path, file, acl='public-read', move_prefix=None, timestamp=None, download_filename=None,
              disposition_type='attachment'):

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -140,11 +140,12 @@ class TestValidateDocuments(unittest.TestCase):
 
 class TestUploadDocument(unittest.TestCase):
     def test_document_upload(self):
-        uploader = mock.Mock(bucket_short_name="documents")
+        uploader = mock.Mock()
         with freeze_time('2015-01-02 04:05:00'):
             self.assertEquals(
                 upload_document(
                     uploader,
+                    'documents',
                     'http://assets',
                     {'id': "123", 'supplierId': 5, 'frameworkSlug': 'g-cloud-6'},
                     "pricingDocumentURL",
@@ -160,11 +161,12 @@ class TestUploadDocument(unittest.TestCase):
         )
 
     def test_document_private_upload(self):
-        uploader = mock.Mock(bucket_short_name="documents")
+        uploader = mock.Mock()
         with freeze_time('2015-01-02 04:05:00'):
             self.assertEquals(
                 upload_document(
                     uploader,
+                    'documents',
                     'http://assets',
                     {'id': "123", 'supplierId': 5, 'frameworkSlug': 'g-cloud-6'},
                     "pricingDocumentURL",
@@ -181,23 +183,25 @@ class TestUploadDocument(unittest.TestCase):
         )
 
     def test_document_upload_s3_error(self):
-        uploader = mock.Mock(bucket_short_name="documents")
+        uploader = mock.Mock()
         uploader.save.side_effect = S3ResponseError(403, 'Forbidden')
         with freeze_time('2015-01-02 04:05:00'):
             self.assertFalse(upload_document(
                 uploader,
+                'documents',
                 'http://assets',
                 {'id': "123", 'supplierId': 5, 'frameworkSlug': 'g-cloud-6'},
                 "pricingDocumentURL",
                 mock_file('file.pdf', 1)
             ))
 
-    def test_document_upload_with_other_bucket_short_name(self):
-        uploader = mock.Mock(bucket_short_name="submissions")
+    def test_document_upload_with_other_upload_type(self):
+        uploader = mock.Mock()
         with freeze_time('2015-01-02 04:05:00'):
             self.assertEquals(
                 upload_document(
                     uploader,
+                    'submissions',
                     'http://assets',
                     {'id': "123", 'supplierId': 5, 'frameworkSlug': 'g-cloud-6'},
                     "pricingDocumentURL",
@@ -212,12 +216,13 @@ class TestUploadDocument(unittest.TestCase):
             acl='public-read'
         )
 
-    def test_document_upload_with_invalid_short_bucket_name(self):
-        uploader = mock.Mock(bucket_short_name="invalid")
+    def test_document_upload_with_invalid_upload_type(self):
+        uploader = mock.Mock()
         with pytest.raises(AssertionError):
             self.assertEquals(
                 upload_document(
                     uploader,
+                    'invalid',
                     'http://assets',
                     {'id': "123", 'supplierId': 5, 'frameworkSlug': 'g-cloud-6'},
                     "pricingDocumentURL",
@@ -238,7 +243,7 @@ class TestUploadServiceDocuments(object):
             'supplierId': '12345',
             'id': '654321',
         }
-        self.uploader = mock.Mock(bucket_short_name='documents')
+        self.uploader = mock.Mock()
         self.documents_url = 'http://localhost'
 
     def test_upload_service_documents(self):
@@ -246,7 +251,7 @@ class TestUploadServiceDocuments(object):
 
         with freeze_time('2015-10-04 14:36:05'):
             files, errors = upload_service_documents(
-                self.uploader, self.documents_url, self.service,
+                self.uploader, 'documents', self.documents_url, self.service,
                 request_files, self.section)
 
         self.uploader.save.assert_called_with(
@@ -260,7 +265,7 @@ class TestUploadServiceDocuments(object):
 
         with freeze_time('2015-10-04 14:36:05'):
             files, errors = upload_service_documents(
-                self.uploader, self.documents_url, self.service,
+                self.uploader, 'documents', self.documents_url, self.service,
                 request_files, self.section,
                 public=False)
 
@@ -274,7 +279,7 @@ class TestUploadServiceDocuments(object):
         request_files = {'pricingDocumentURL': mock_file('q1.pdf', 0)}
 
         files, errors = upload_service_documents(
-            self.uploader, self.documents_url, self.service,
+            self.uploader, 'documents', self.documents_url, self.service,
             request_files, self.section)
 
         assert len(files) == 0
@@ -284,7 +289,7 @@ class TestUploadServiceDocuments(object):
         request_files = {'serviceDefinitionDocumentURL': mock_file('q1.pdf', 100)}
 
         files, errors = upload_service_documents(
-            self.uploader, self.documents_url, self.service,
+            self.uploader, 'documents', self.documents_url, self.service,
             request_files, self.section)
 
         assert len(files) == 0
@@ -294,7 +299,7 @@ class TestUploadServiceDocuments(object):
         request_files = {'pricingDocumentURL': mock_file('q1.bad', 100)}
 
         files, errors = upload_service_documents(
-            self.uploader, self.documents_url, self.service,
+            self.uploader, 'documents', self.documents_url, self.service,
             request_files, self.section)
 
         assert files is None

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -35,19 +35,6 @@ class TestS3Uploader(object):
 
         assert S3('test-bucket').path_exists('foo') is True
 
-    def test_bucket_short_name(self):
-        assert S3('digitalmarketplace-anything-environ-environ').bucket_short_name == 'anything'
-
-    def test_bucket_short_name_invalid_format(self):
-        bad_bucket_names = [
-            'something-invalid',
-            'digitalmarketplace-something-environ-environ-other',
-            'digitalmarketplace-something-environ-other',
-        ]
-        for bad_bucket_name in bad_bucket_names:
-            with pytest.raises(ValueError):
-                S3(bad_bucket_name).bucket_short_name
-
     def test_get_signed_url(self):
         mock_bucket = FakeBucket(['documents/file.pdf'])
         self.s3_mock.get_bucket.return_value = mock_bucket


### PR DESCRIPTION
Our S3 keys always start with <framework_slug>/<upload_type>/...,
where <upload_type> (eg 'documents', 'submissions', 'agreements')
maps 1:1 to the buckets in live environments.

S3 uploader used to parse upload type directly from the bucket name,
using our bucket name pattern (digitalmarketplace-<type>-<stage>-<env>).

This approach allows us to avoid passing in the directory name
explicitly, but it creates 2 issues:

1. We need to use separate buckets for development environments,
   following the same naming convention we use for preview, staging,
   and production (eg digitalmarketplace-documents-dev-dev and
   digitalmarketplace-submissions-dev-dev). Using separate buckets
   means we can't use the S3 bucket domain name as our assets host,
   since it's different for each bucket. So in order to make all
   uploaded file links work locally we'd have to set up an nginx
   config to proxy the requests to the correct bucket, which would
   complicate our local setup and make spinning up one-off environments
   on PaaS harder.

2. When mocking the S3 objects we need to set the `.bucket_short_name`
   value on the mock. This is done 26 times in the supplier-frontend.

It's possible to fix both of those problems, but setting the upload_type
manually seems like an easier approach. It separates the bucket
selection (which is primarily driven by permissions and lifecycle
concerns) from the document upload process and allows us to use a single
bucket for development, which makes it different from live environments,
but in return simplifies the local environment setup.