### PR TITLE
Remove hard-coded lots in preparation for G9.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 Records breaking changes from major version bumps
 
+## 26.0.0
+
+PR: [#307](https://github.com/alphagov/digitalmarketplace-utils/pull/307)
+
+### What changed
+
+The harded-coded list `formats.LOTS`, that applied to G6, G7 and G8, has been removed, in
+favour of getting the lots from the API. Related functions have also been removed: `get_label_for_lot_param`
+can be replaced by `lot['name']`, and `lot_to_lot_case` is no longer used.
+
+### Example app code
+```
+all_frameworks = data_api_client.find_frameworks().get('frameworks')
+framework = framework_helpers.get_latest_live_framework(all_frameworks, 'g-cloud')
+
+for lot in framework['lots']:
+    ...
+```
+
 ## 25.0.0
 
 PR: [#302](https://github.com/alphagov/digitalmarketplace-utils/pull/302)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags  # noqa
 
-__version__ = '25.2.0'
+__version__ = '26.0.0'

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -9,29 +9,6 @@ DISPLAY_DATE_FORMAT = '%A %-d %B %Y'
 DISPLAY_TIME_FORMAT = '%H:%M:%S'
 DISPLAY_DATETIME_FORMAT = '%A %-d %B %Y at %H:%M'
 
-LOTS = [
-    {
-        'lot': 'saas',
-        'lot_case': 'SaaS',
-        'label': u'Software as a Service',
-    },
-    {
-        'lot': 'paas',
-        'lot_case': 'PaaS',
-        'label': u'Platform as a Service',
-    },
-    {
-        'lot': 'iaas',
-        'lot_case': 'IaaS',
-        'label': u'Infrastructure as a Service',
-    },
-    {
-        'lot': 'scs',
-        'lot_case': 'SCS',
-        'label': u'Specialist Cloud Services',
-    },
-]
-
 
 def timeformat(value, default_value=None):
     return _format_date(value, default_value, DISPLAY_TIME_FORMAT)
@@ -71,17 +48,3 @@ def _format_date(value, default_value, fmt, localize=True):
         return value.astimezone(EUROPE_LONDON).strftime(fmt)
     else:
         return value.strftime(fmt)
-
-
-def lot_to_lot_case(lot_to_check):
-    lot_i_found = [lot for lot in LOTS if lot['lot'] == lot_to_check]
-    if lot_i_found:
-        return lot_i_found[0]['lot_case']
-    return None
-
-
-def get_label_for_lot_param(lot_to_check):
-    lot_i_found = [lot for lot in LOTS if lot['lot'] == lot_to_check]
-    if lot_i_found:
-        return lot_i_found[0]['label']
-    return None

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,7 @@
 [pep8]
 max-line-length = 120
+exclude = ./venv*
 
 [pytest]
 norecursedirs = venv venv3 src
+

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,40 +1,10 @@
 # -*- coding: utf-8 -*-
 from dmutils.formats import (
-    get_label_for_lot_param, lot_to_lot_case,
     timeformat, shortdateformat, dateformat, datetimeformat, datetodatetimeformat
 )
 import pytz
 from datetime import datetime
 import pytest
-
-
-class TestFormats(object):
-
-    def test_returns_lot_in_lot_case(self):
-
-        cases = [
-            ("saas", "SaaS"),
-            ("iaas", "IaaS"),
-            ("paas", "PaaS"),
-            ("scs", "SCS"),
-            ("dewdew", None),
-        ]
-
-        for example, expected in cases:
-            assert lot_to_lot_case(example) == expected
-
-    def test_returns_label_for_lot(self):
-
-        cases = [
-            ("saas", "Software as a Service"),
-            ("iaas", "Infrastructure as a Service"),
-            ("paas", "Platform as a Service"),
-            ("scs", "Specialist Cloud Services"),
-            ("dewdew", None),
-        ]
-
-        for example, expected in cases:
-            assert get_label_for_lot_param(example) == expected
 
 
 def test_timeformat():


### PR DESCRIPTION
 - these functions and consts were used by the buyer app, and
   a PR for that code will follow shortly.
 - also modify setup.cfg to exclude venv from pep8.

https://trello.com/c/x6ANlaCf/339-filtering-based-on-category