### PR TITLE
Log to stdout

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags  # noqa
 
-__version__ = '25.1.0'
+__version__ = '25.2.0'

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -83,7 +83,7 @@ def init_manager(application, port, extra_directories=()):
 
     extra_files = list(get_extra_files(extra_directories))
 
-    print("Watching {} extra files".format(len(extra_files)))
+    logging.logger.debug("Watching {} extra files".format(len(extra_files)))
 
     manager.add_command(
         "runserver",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,15 +10,9 @@ from dmutils.logging import init_app
 
 @pytest.fixture
 def app():
-    return Flask(__name__)
-
-
-@pytest.yield_fixture
-def app_with_logging(app):
-    with tempfile.NamedTemporaryFile() as f:
-        app.config['DM_LOG_PATH'] = f.name
-        init_app(app)
-        yield app
+    app = Flask(__name__)
+    init_app(app)
+    return app
 
 
 @pytest.yield_fixture


### PR DESCRIPTION
This is for running the apps in containers on the PaaS.

If in development, write plain text logs to stdout so they can be read
and are useful.

If in a live environment, write json logs to stdout. These will be
picked up by supervisord and redirected to file, then streamed to
cloudwatch. The files are logrotated.