### PR TITLE
Add `DMMailChimpClient`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.egg-info/
 *.pyc
 .cache
+venv*

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags  # noqa
 
-__version__ = '26.0.0'
+__version__ = '26.1.0'

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -76,3 +76,8 @@ class DMMailChimpClient(object):
                 extra={"error": str(e)}
             )
         return False
+
+    def subscribe_new_emails_to_list(self, list_id, email_addresses):
+        for email_address in email_addresses:
+            self.subscribe_email_to_list(list_id, email_address)
+        return True

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -55,7 +55,7 @@ class DMMailChimpClient(object):
             )
         return False
 
-    def subscribe_email_to_list(self, list_id, email_address):
+    def subscribe_new_email_to_list(self, list_id, email_address):
         """ Will subscribe email address to list if they do not already exist in that list else do nothing"""
         hashed_email = self.get_email_hash(email_address)
         try:
@@ -79,5 +79,5 @@ class DMMailChimpClient(object):
 
     def subscribe_new_emails_to_list(self, list_id, email_addresses):
         for email_address in email_addresses:
-            self.subscribe_email_to_list(list_id, email_address)
+            self.subscribe_new_email_to_list(list_id, email_address)
         return True

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -69,7 +69,10 @@ class DMMailChimpClient(object):
             )
         except RequestException as e:
             self.logger.error(
-                "Mailchimp failed to send campaign id '{0}'".format(campaign_id),
+                "Mailchimp failed to add user ({}) to list ({})".format(
+                    hashed_email,
+                    list_id
+                ),
                 extra={"error": str(e)}
             )
         return False

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -4,6 +4,7 @@
 from mailchimp3 import MailChimp
 from requests.exceptions import RequestException
 from hashlib import md5
+import six
 
 
 class DMMailChimpClient(object):
@@ -19,7 +20,9 @@ class DMMailChimpClient(object):
 
     @staticmethod
     def get_email_hash(email_address):
-        return md5(email_address.lower()).hexdigest()
+        """md5 hashing of lower cased emails has been chosen by mailchimp to identify email addresses"""
+        formatted_email_address = six.text_type(email_address.lower()).encode('utf-8')
+        return md5(formatted_email_address).hexdigest()
 
     def create_campaign(self, campaign_data):
         try:

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -15,7 +15,7 @@ class DMMailChimpClient(object):
         mailchimp_api_key,
         logger
     ):
-        self.client = MailChimp(mailchimp_username, mailchimp_api_key)
+        self._client = MailChimp(mailchimp_username, mailchimp_api_key)
         self.logger = logger
 
     @staticmethod
@@ -26,7 +26,7 @@ class DMMailChimpClient(object):
 
     def create_campaign(self, campaign_data):
         try:
-            campaign = self.client.campaigns.create(campaign_data)
+            campaign = self._client.campaigns.create(campaign_data)
             return campaign['id']
         except RequestException as e:
             self.logger.error(
@@ -39,7 +39,7 @@ class DMMailChimpClient(object):
 
     def set_campaign_content(self, campaign_id, content_data):
         try:
-            return self.client.campaigns.content.update(campaign_id, content_data)
+            return self._client.campaigns.content.update(campaign_id, content_data)
         except RequestException as e:
             self.logger.error(
                 "Mailchimp failed to set content for campaign id '{0}'".format(campaign_id),
@@ -49,7 +49,7 @@ class DMMailChimpClient(object):
 
     def send_campaign(self, campaign_id):
         try:
-            self.client.campaigns.actions.send(campaign_id)
+            self._client.campaigns.actions.send(campaign_id)
             return True
         except RequestException as e:
             self.logger.error(
@@ -62,7 +62,7 @@ class DMMailChimpClient(object):
         """ Will subscribe email address to list if they do not already exist in that list else do nothing"""
         hashed_email = self.get_email_hash(email_address)
         try:
-            return self.client.lists.members.create_or_update(
+            return self._client.lists.members.create_or_update(
                 list_id,
                 hashed_email,
                 {
@@ -101,5 +101,5 @@ class DMMailChimpClient(object):
         return success
 
     def get_email_addresses_from_list(self, list_id):
-        member_data = self.client.lists.members.all(list_id, get_all=True)
+        member_data = self._client.lists.members.all(list_id, get_all=True)
         return [member["email_address"] for member in member_data["members"]]

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -19,7 +19,7 @@ class DMMailChimpClient(object):
 
     @staticmethod
     def get_email_hash(email_address):
-        return md5(email_address).hexdigest()
+        return md5(email_address.lower()).hexdigest()
 
     def create_campaign(self, campaign_data):
         try:

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""Digital Marketplace MailChimp integration."""
+
+from mailchimp3 import MailChimp
+from requests.exceptions import RequestException
+
+
+class DMMailChimpClient(object):
+
+    def __init__(
+        self,
+        mailchimp_username,
+        mailchimp_api_key,
+        logger
+    ):
+        self.client = MailChimp(mailchimp_username, mailchimp_api_key)
+        self.logger = logger
+
+    def create_campaign(self, campaign_data):
+        try:
+            campaign = self.client.campaigns.create(campaign_data)
+            return campaign['id']
+        except RequestException as e:
+            self.logger.error(
+                "Mailchimp failed to create campaign for '{0}'".format(
+                    campaign_data.get("settings").get("title")
+                ),
+                extra={"error": str(e)}
+            )
+        return False
+
+    def set_campaign_content(self, campaign_id, content_data):
+        try:
+            return self.client.campaigns.content.update(campaign_id, content_data)
+        except RequestException as e:
+            self.logger.error(
+                "Mailchimp failed to set content for campaign id '{0}'".format(campaign_id),
+                extra={"error": str(e)}
+            )
+        return False
+
+    def send_campaign(self, campaign_id):
+        try:
+            self.client.campaigns.actions.send(campaign_id)
+            return True
+        except RequestException as e:
+            self.logger.error(
+                "Mailchimp failed to send campaign id '{0}'".format(campaign_id),
+                extra={"error": str(e)}
+            )
+        return False

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -17,6 +17,10 @@ class DMMailChimpClient(object):
         self.client = MailChimp(mailchimp_username, mailchimp_api_key)
         self.logger = logger
 
+    @staticmethod
+    def get_email_hash(email_address):
+        return md5(email_address).hexdigest()
+
     def create_campaign(self, campaign_data):
         try:
             campaign = self.client.campaigns.create(campaign_data)
@@ -53,7 +57,7 @@ class DMMailChimpClient(object):
 
     def subscribe_email_to_list(self, list_id, email_address):
         """ Will subscribe email address to list if they do not already exist in that list else do nothing"""
-        hashed_email = md5(email_address).hexdigest()
+        hashed_email = self.get_email_hash(email_address)
         try:
             return self.client.lists.members.create_or_update(
                 list_id,

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -78,6 +78,8 @@ class DMMailChimpClient(object):
         return False
 
     def subscribe_new_emails_to_list(self, list_id, email_addresses):
+        success = True
         for email_address in email_addresses:
-            self.subscribe_new_email_to_list(list_id, email_address)
-        return True
+            if not self.subscribe_new_email_to_list(list_id, email_address):
+                success = False
+        return success

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -99,3 +99,7 @@ class DMMailChimpClient(object):
             if not self.subscribe_new_email_to_list(list_id, email_address):
                 success = False
         return success
+
+    def get_email_addresses_from_list(self, list_id):
+        member_data = self.client.lists.members.all(list_id, get_all=True)
+        return [member["email_address"] for member in member_data["members"]]

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,7 +2,7 @@
 
 coverage==3.7.1
 freezegun==0.3.4
-mock==1.0.1
+mock==2.0.0
 pep8==1.6.2
 pytest==2.8.7
 pytest-cov==2.2.0

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
          'contextlib2==0.4.0',
          'cryptography==1.6',
          'inflection==0.2.1',
+         'mailchimp3==2.0.11',
          'mandrill==1.0.57',
          'monotonic==0.3',
          'notifications-python-client==4.1.0',

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -76,3 +76,22 @@ def test_log_error_message_if_error_sending_campaign():
             error.assert_called_once_with(
                 "Mailchimp failed to send campaign id '1'", extra={"error": "error sending"}
             )
+
+
+def test_subscribe_email_to_list():
+    dm_mailchimp_client = DMMailChimpClient('username', 'api key', mock.MagicMock())
+    with mock.patch.object(
+            dm_mailchimp_client.client.lists.members, 'create_or_update', autospec=True) as create_or_update:
+
+        create_or_update.return_value = {"response": "data"}
+        res = dm_mailchimp_client.subscribe_email_to_list('list_id', 'example@example.com')
+
+        assert res == {"response": "data"}
+        create_or_update.assert_called_once_with(
+            'list_id',
+            '23463b99b62a72f26ed677cc556c44e8',
+            {
+                "email_address": "example@example.com",
+                "status_if_new": "subscribed"
+            }
+        )

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -78,7 +78,8 @@ def test_log_error_message_if_error_sending_campaign():
             )
 
 
-def test_subscribe_email_to_list():
+@mock.patch("dmutils.email.dm_mailchimp.DMMailChimpClient.get_email_hash", return_value="foo")
+def test_subscribe_email_to_list(get_email_hash):
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', mock.MagicMock())
     with mock.patch.object(
             dm_mailchimp_client.client.lists.members, 'create_or_update', autospec=True) as create_or_update:
@@ -89,9 +90,13 @@ def test_subscribe_email_to_list():
         assert res == {"response": "data"}
         create_or_update.assert_called_once_with(
             'list_id',
-            '23463b99b62a72f26ed677cc556c44e8',
+            "foo",
             {
                 "email_address": "example@example.com",
                 "status_if_new": "subscribed"
             }
         )
+
+
+def test_get_email_hash():
+    assert DMMailChimpClient.get_email_hash("example@example.com") == '23463b99b62a72f26ed677cc556c44e8'

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -117,6 +117,16 @@ def test_log_error_message_if_error_subscribing_email_to_list(get_email_hash):
             )
 
 
+def test_subscribe_new_emails_to_list():
+    dm_mailchimp_client = DMMailChimpClient('username', 'api key', mock.MagicMock())
+    with mock.patch.object(dm_mailchimp_client, 'subscribe_email_to_list',  autospec=True):
+        res = dm_mailchimp_client.subscribe_new_emails_to_list('list_id', ['email1@example.com', 'email2@example.com'])
+
+        assert res is True
+        calls = [mock.call('list_id', 'email1@example.com'), mock.call('list_id', 'email2@example.com')]
+        dm_mailchimp_client.subscribe_email_to_list.assert_has_calls(calls)
+
+
 def test_get_email_hash():
     assert DMMailChimpClient.get_email_hash("example@example.com") == '23463b99b62a72f26ed677cc556c44e8'
 

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -120,6 +120,7 @@ def test_log_error_message_if_error_subscribing_email_to_list(get_email_hash):
 def test_subscribe_new_emails_to_list():
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', mock.MagicMock())
     with mock.patch.object(dm_mailchimp_client, 'subscribe_new_email_to_list',  autospec=True):
+        dm_mailchimp_client.subscribe_new_email_to_list.return_value = True
         res = dm_mailchimp_client.subscribe_new_emails_to_list('list_id', ['email1@example.com', 'email2@example.com'])
         calls = [mock.call('list_id', 'email1@example.com'), mock.call('list_id', 'email2@example.com')]
 

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -168,3 +168,21 @@ def test_get_email_hash():
 def test_get_email_hash_lowers():
     """Email must be lowercased before hashing as per api documentation."""
     DMMailChimpClient.get_email_hash("foo@EXAMPLE.com") == DMMailChimpClient.get_email_hash("foo@example.com")
+
+
+def test_get_email_addresses_from_list():
+    dm_mailchimp_client = DMMailChimpClient('username', 'api key', mock.MagicMock())
+    with mock.patch.object(
+            dm_mailchimp_client.client.lists.members, 'all', autospec=True) as all_members:
+
+        all_members.return_value = {"members": [
+            {"email_address": "user1@example.com"},
+            {"email_address": "user2@example.com"}
+        ]}
+        res = dm_mailchimp_client.get_email_addresses_from_list('list_id')
+
+        assert res == ["user1@example.com", "user2@example.com"]
+        all_members.assert_called_once_with(
+            'list_id',
+            get_all=True
+        )

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -100,3 +100,8 @@ def test_subscribe_email_to_list(get_email_hash):
 
 def test_get_email_hash():
     assert DMMailChimpClient.get_email_hash("example@example.com") == '23463b99b62a72f26ed677cc556c44e8'
+
+
+def test_get_email_hash_lowers():
+    """Email must be lowercased before hashing as per api documentation."""
+    DMMailChimpClient.get_email_hash("foo@EXAMPLE.com") == DMMailChimpClient.get_email_hash("foo@example.com")

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -121,10 +121,22 @@ def test_subscribe_new_emails_to_list():
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', mock.MagicMock())
     with mock.patch.object(dm_mailchimp_client, 'subscribe_new_email_to_list',  autospec=True):
         res = dm_mailchimp_client.subscribe_new_emails_to_list('list_id', ['email1@example.com', 'email2@example.com'])
+        calls = [mock.call('list_id', 'email1@example.com'), mock.call('list_id', 'email2@example.com')]
 
         assert res is True
-        calls = [mock.call('list_id', 'email1@example.com'), mock.call('list_id', 'email2@example.com')]
         dm_mailchimp_client.subscribe_new_email_to_list.assert_has_calls(calls)
+
+
+def test_subscribe_new_emails_to_list_tries_all_emails_returns_false_on_error():
+    dm_mailchimp_client = DMMailChimpClient('username', 'api key', mock.MagicMock())
+    with mock.patch.object(
+            dm_mailchimp_client, 'subscribe_new_email_to_list', autospec=True) as subscribe_new_email_to_list:
+        subscribe_new_email_to_list.side_effect = [False, True]
+        res = dm_mailchimp_client.subscribe_new_emails_to_list('list_id', ['foo', 'email2@example.com'])
+        calls = [mock.call('list_id', 'foo'), mock.call('list_id', 'email2@example.com')]
+
+        assert res is False
+        subscribe_new_email_to_list.assert_has_calls(calls)
 
 
 def test_get_email_hash():

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -79,13 +79,13 @@ def test_log_error_message_if_error_sending_campaign():
 
 
 @mock.patch("dmutils.email.dm_mailchimp.DMMailChimpClient.get_email_hash", return_value="foo")
-def test_subscribe_email_to_list(get_email_hash):
+def test_subscribe_new_email_to_list(get_email_hash):
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', mock.MagicMock())
     with mock.patch.object(
             dm_mailchimp_client.client.lists.members, 'create_or_update', autospec=True) as create_or_update:
 
         create_or_update.return_value = {"response": "data"}
-        res = dm_mailchimp_client.subscribe_email_to_list('list_id', 'example@example.com')
+        res = dm_mailchimp_client.subscribe_new_email_to_list('list_id', 'example@example.com')
 
         assert res == {"response": "data"}
         create_or_update.assert_called_once_with(
@@ -105,7 +105,7 @@ def test_log_error_message_if_error_subscribing_email_to_list(get_email_hash):
             dm_mailchimp_client.client.lists.members, 'create_or_update',  autospec=True) as create_or_update:
         create_or_update.side_effect = RequestException("error sending")
         with mock.patch.object(dm_mailchimp_client.logger, 'error', autospec=True) as error:
-            res = dm_mailchimp_client.subscribe_email_to_list('list_id', 'example@example.com')
+            res = dm_mailchimp_client.subscribe_new_email_to_list('list_id', 'example@example.com')
 
             assert res is False
             error.assert_called_once_with(
@@ -119,12 +119,12 @@ def test_log_error_message_if_error_subscribing_email_to_list(get_email_hash):
 
 def test_subscribe_new_emails_to_list():
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', mock.MagicMock())
-    with mock.patch.object(dm_mailchimp_client, 'subscribe_email_to_list',  autospec=True):
+    with mock.patch.object(dm_mailchimp_client, 'subscribe_new_email_to_list',  autospec=True):
         res = dm_mailchimp_client.subscribe_new_emails_to_list('list_id', ['email1@example.com', 'email2@example.com'])
 
         assert res is True
         calls = [mock.call('list_id', 'email1@example.com'), mock.call('list_id', 'email2@example.com')]
-        dm_mailchimp_client.subscribe_email_to_list.assert_has_calls(calls)
+        dm_mailchimp_client.subscribe_new_email_to_list.assert_has_calls(calls)
 
 
 def test_get_email_hash():

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -9,7 +9,7 @@ from logging import Logger
 
 def test_create_campaign():
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', 'logger')
-    with mock.patch.object(dm_mailchimp_client.client.campaigns, 'create', autospec=True) as create:
+    with mock.patch.object(dm_mailchimp_client._client.campaigns, 'create', autospec=True) as create:
         create.return_value = {"id": "100"}
         res = dm_mailchimp_client.create_campaign({"example": "data"})
 
@@ -19,7 +19,7 @@ def test_create_campaign():
 
 def test_log_error_message_if_error_creating_campaign():
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', mock.MagicMock())
-    with mock.patch.object(dm_mailchimp_client.client.campaigns, 'create', autospec=True) as create:
+    with mock.patch.object(dm_mailchimp_client._client.campaigns, 'create', autospec=True) as create:
         create.side_effect = RequestException("error message")
         with mock.patch.object(dm_mailchimp_client.logger, 'error', autospec=True) as error:
             res = dm_mailchimp_client.create_campaign({"example": "data", 'settings': {'title': 'Foo'}})
@@ -32,20 +32,20 @@ def test_log_error_message_if_error_creating_campaign():
 
 def test_set_campaign_content():
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', 'logger')
-    with mock.patch.object(dm_mailchimp_client.client.campaigns.content, 'update', autospec=True) as update:
+    with mock.patch.object(dm_mailchimp_client._client.campaigns.content, 'update', autospec=True) as update:
         campaign_id = '1'
         html_content = {'html': '<p>One or two words</p>'}
         update.return_value = html_content
         res = dm_mailchimp_client.set_campaign_content(campaign_id, html_content)
 
         assert res == html_content
-        dm_mailchimp_client.client.campaigns.content.update.assert_called_once_with(campaign_id, html_content)
+        dm_mailchimp_client._client.campaigns.content.update.assert_called_once_with(campaign_id, html_content)
 
 
 @mock.patch("logging.Logger", autospec=True)
 def test_log_error_message_if_error_setting_campaign_content(logger):
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', logger)
-    with mock.patch.object(dm_mailchimp_client.client.campaigns.content, 'update', autospec=True) as update:
+    with mock.patch.object(dm_mailchimp_client._client.campaigns.content, 'update', autospec=True) as update:
         update.side_effect = RequestException("error message")
 
         res = dm_mailchimp_client.set_campaign_content('1', {"html": "some html"})
@@ -59,7 +59,7 @@ def test_log_error_message_if_error_setting_campaign_content(logger):
 def test_send_campaign():
     campaign_id = "1"
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', mock.MagicMock())
-    with mock.patch.object(dm_mailchimp_client.client.campaigns.actions, 'send', autospec=True) as send:
+    with mock.patch.object(dm_mailchimp_client._client.campaigns.actions, 'send', autospec=True) as send:
         res = dm_mailchimp_client.send_campaign(campaign_id)
 
         assert res is True
@@ -69,7 +69,7 @@ def test_send_campaign():
 @mock.patch("logging.Logger", autospec=True)
 def test_log_error_message_if_error_sending_campaign(logger):
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', logger)
-    with mock.patch.object(dm_mailchimp_client.client.campaigns.actions, 'send',  autospec=True) as send:
+    with mock.patch.object(dm_mailchimp_client._client.campaigns.actions, 'send',  autospec=True) as send:
         send.side_effect = RequestException("error sending")
 
         res = dm_mailchimp_client.send_campaign("1")
@@ -84,7 +84,7 @@ def test_log_error_message_if_error_sending_campaign(logger):
 def test_subscribe_new_email_to_list(get_email_hash):
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', mock.MagicMock())
     with mock.patch.object(
-            dm_mailchimp_client.client.lists.members, 'create_or_update', autospec=True) as create_or_update:
+            dm_mailchimp_client._client.lists.members, 'create_or_update', autospec=True) as create_or_update:
 
         create_or_update.return_value = {"response": "data"}
         res = dm_mailchimp_client.subscribe_new_email_to_list('list_id', 'example@example.com')
@@ -105,7 +105,7 @@ def test_subscribe_new_email_to_list(get_email_hash):
 def test_log_error_message_if_error_subscribing_email_to_list(get_email_hash, logger):
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', logger)
     with mock.patch.object(
-            dm_mailchimp_client.client.lists.members, 'create_or_update',  autospec=True) as create_or_update:
+            dm_mailchimp_client._client.lists.members, 'create_or_update',  autospec=True) as create_or_update:
         response = mock.Mock()
         response.json.return_value = {"detail": "Unexpected error."}
         create_or_update.side_effect = RequestException("error sending", response=response)
@@ -124,7 +124,7 @@ def test_log_error_message_if_error_subscribing_email_to_list(get_email_hash, lo
 def test_returns_true_if_expected_error_subscribing_email_to_list(get_email_hash, logger):
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', logger)
     with mock.patch.object(
-            dm_mailchimp_client.client.lists.members, 'create_or_update',  autospec=True) as create_or_update:
+            dm_mailchimp_client._client.lists.members, 'create_or_update',  autospec=True) as create_or_update:
         response = mock.Mock()
         response.json.return_value = {"detail": "foo looks fake or invalid, please enter a real email address."}
         create_or_update.side_effect = RequestException("error sending", response=response)
@@ -173,7 +173,7 @@ def test_get_email_hash_lowers():
 def test_get_email_addresses_from_list():
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', mock.MagicMock())
     with mock.patch.object(
-            dm_mailchimp_client.client.lists.members, 'all', autospec=True) as all_members:
+            dm_mailchimp_client._client.lists.members, 'all', autospec=True) as all_members:
 
         all_members.return_value = {"members": [
             {"email_address": "user1@example.com"},

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""Tests for the Digital Marketplace MailChimp integration."""
+import mock
+
+from dmutils.email.dm_mailchimp import DMMailChimpClient
+from requests import RequestException
+
+
+def test_create_campaign():
+    dm_mailchimp_client = DMMailChimpClient('username', 'api key', 'logger')
+    with mock.patch.object(dm_mailchimp_client.client.campaigns, 'create', autospec=True) as create:
+        create.return_value = {"id": "100"}
+        res = dm_mailchimp_client.create_campaign({"example": "data"})
+
+        assert res == "100"
+        create.assert_called_once_with({"example": "data"})
+
+
+def test_log_error_message_if_error_creating_campaign():
+    dm_mailchimp_client = DMMailChimpClient('username', 'api key', mock.MagicMock())
+    with mock.patch.object(dm_mailchimp_client.client.campaigns, 'create', autospec=True) as create:
+        create.side_effect = RequestException("error message")
+        with mock.patch.object(dm_mailchimp_client.logger, 'error', autospec=True) as error:
+            res = dm_mailchimp_client.create_campaign({"example": "data", 'settings': {'title': 'Foo'}})
+
+            assert res is False
+            error.assert_called_once_with(
+                "Mailchimp failed to create campaign for 'campaign title'", extra={"error": "error message"}
+            )
+
+
+def test_set_campaign_content():
+    dm_mailchimp_client = DMMailChimpClient('username', 'api key', 'logger')
+    with mock.patch.object(dm_mailchimp_client.client.campaigns.content, 'update', autospec=True) as update:
+        campaign_id = '1'
+        html_content = {'html': '<p>One or two words</p>'}
+        update.return_value = html_content
+        res = dm_mailchimp_client.set_campaign_content(campaign_id, html_content)
+
+        assert res == html_content
+        dm_mailchimp_client.client.campaigns.content.update.assert_called_once_with(campaign_id, html_content)
+
+
+def test_log_error_message_if_error_setting_campaign_content():
+    dm_mailchimp_client = DMMailChimpClient('username', 'api key', mock.MagicMock())
+    with mock.patch.object(dm_mailchimp_client.client.campaigns.content, 'update', autospec=True) as update:
+        update.side_effect = RequestException("error message")
+
+        with mock.patch.object(dm_mailchimp_client.logger, 'error', autospec=True) as error:
+            res = dm_mailchimp_client.set_campaign_content('1', {"html": "some html"})
+
+            assert res is False
+            error.assert_called_once_with(
+                "Mailchimp failed to set content for campaign id '1'", extra={"error": "error message"}
+            )
+
+
+def test_send_campaign():
+    campaign_id = "1"
+    dm_mailchimp_client = DMMailChimpClient('username', 'api key', mock.MagicMock())
+    with mock.patch.object(dm_mailchimp_client.client.campaigns.actions, 'send', autospec=True) as send:
+        res = dm_mailchimp_client.send_campaign(campaign_id)
+
+        assert res is True
+        send.assert_called_once_with(campaign_id)
+
+
+def test_log_error_message_if_error_sending_campaign():
+    dm_mailchimp_client = DMMailChimpClient('username', 'api key', mock.MagicMock())
+    with mock.patch.object(dm_mailchimp_client.client.campaigns.actions, 'send',  autospec=True) as send:
+        send.side_effect = RequestException("error sending")
+        with mock.patch.object(dm_mailchimp_client.logger, 'error', autospec=True) as error:
+            res = dm_mailchimp_client.send_campaign("1")
+
+            assert res is False
+            error.assert_called_once_with(
+                "Mailchimp failed to send campaign id '1'", extra={"error": "error sending"}
+            )


### PR DESCRIPTION
Trello: https://trello.com/c/XOCeuOYW/254-update-mailchimp-user-list-everyday

Adds `DMMailChimpClient` class which is then used our script to update mailchimp user lists for DOS opportunities

We previously had some of this functionality in the scripts repo but we have decided to move it into utils in a more class based approach (like we do for our notify client wrapper) and added the additional functionality to subscribe emails to a mailchimp list.