### PR TITLE
Capitalise filter++

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags  # noqa
 
-__version__ = '26.2.0'
+__version__ = '26.2.1'

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -54,14 +54,15 @@ def nbsp(text):
 
 
 def capitalize_first(maybe_text):
-    """If it's a string capitalise the first character
+    """If it's a string capitalise the first character, unless it looks like a URL
 
     :param maybe_text: Could be anything
     :return: If maybe_text is a string it will be returned with an initial capital letter, otherwise unchanged
     """
     if maybe_text and isinstance(maybe_text, string_types):
-        return maybe_text[0].capitalize() + maybe_text[1:]
+        if not maybe_text.startswith('http'):
+            return maybe_text[0].capitalize() + maybe_text[1:]
     elif isinstance(maybe_text, (list, tuple)):
         return [capitalize_first(item) for item in maybe_text]
-    else:
-        return maybe_text
+
+    return maybe_text

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -59,6 +59,9 @@ def capitalize_first(maybe_text):
     :param maybe_text: Could be anything
     :return: If maybe_text is a string it will be returned with an initial capital letter, otherwise unchanged
     """
-    return maybe_text[0].capitalize() + maybe_text[1:] \
-        if maybe_text and isinstance(maybe_text, string_types) \
-        else maybe_text
+    if maybe_text and isinstance(maybe_text, string_types):
+        return maybe_text[0].capitalize() + maybe_text[1:]
+    elif isinstance(maybe_text, (list, tuple)):
+        return [capitalize_first(item) for item in maybe_text]
+    else:
+        return maybe_text

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -116,4 +116,5 @@ def test_capitalize_first_for_non_strings():
     assert capitalize_first(False) is False
     assert capitalize_first(['list', 'of', 'strings']) == ['List', 'Of', 'Strings']
     assert capitalize_first([{'list': 'of'}, 'things']) == [{'list': 'of'}, 'Things']
-    assert capitalize_first({"this": "thing"}) == {"this": "thing"}
+    assert capitalize_first({'this': 'thing'}) == {'this': 'thing'}
+    assert capitalize_first('https://www.example.com') == 'https://www.example.com'

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -114,5 +114,6 @@ def test_capitalize_first_for_non_strings():
     assert capitalize_first(None) is None
     assert capitalize_first(True) is True
     assert capitalize_first(False) is False
-    assert capitalize_first(['list', 'of', 'strings']) == ['list', 'of', 'strings']
+    assert capitalize_first(['list', 'of', 'strings']) == ['List', 'Of', 'Strings']
+    assert capitalize_first([{'list': 'of'}, 'things']) == [{'list': 'of'}, 'Things']
     assert capitalize_first({"this": "thing"}) == {"this": "thing"}


### PR DESCRIPTION
Final tweak for this card: https://trello.com/c/05zayTOU/442-service-page-radio-button-responses-alternative-labels

 * When capitalising the first letter of supplier responses we should also capitalise items in lists.

And also does point 1 on this card while I was in there: https://trello.com/c/HVAOKOwe/476-service-page-uris-in-data-fields 

* When a service page includes a URI and it starts at the first character, the 'h' of HTTP (only) is capitalized, this looks weird.
