### PR TITLE
Remove unused imports from `dm_mandrill.py` and tests

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags  # noqa
 
-__version__ = '26.2.1'
+__version__ = '26.2.2'

--- a/dmutils/email/dm_mandrill.py
+++ b/dmutils/email/dm_mandrill.py
@@ -5,7 +5,6 @@ import json
 import struct
 from datetime import datetime
 
-import itsdangerous
 import six
 from cryptography import fernet
 from flask import current_app

--- a/tests/email/test_dm_mandrill.py
+++ b/tests/email/test_dm_mandrill.py
@@ -5,10 +5,8 @@ from datetime import datetime
 
 import mock
 import pytest
-import six
 from cryptography import fernet
 from freezegun import freeze_time
-from itsdangerous import URLSafeTimedSerializer
 from mandrill import Error
 
 from dmutils.config import init_app


### PR DESCRIPTION
itsdangerous was still being imported even though no longer used. It was
used for encoding/decoding tokens for emails. Due to an issue with these
appearing in the logs and being easily decoded, we now encrpyt the
tokens using the cryptography library.