### PR TITLE
Add filter to preserve line breaks in HTML output

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '27.0.0'
+__version__ = '27.1.0'

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -74,9 +74,7 @@ _single_newline_re = re.compile(r'(\r\n)')
 
 
 @evalcontextfilter
-def preserve_line_breaks(eval_ctx, value, question_type):
-    if question_type and question_type != 'textbox_large':
-        return value
+def preserve_line_breaks(eval_ctx, value):
 
     # Turn potential markdown objects into string
     value = u'{}'.format(escape(value))

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -68,7 +68,7 @@ def capitalize_first(maybe_text):
     return maybe_text
 
 # find repeated sequences of '\r\n\', optionally separated by a space character
-_multiple_newlines_re = re.compile(r'(\r\n *){2,}')
+_multiple_newlines_re = re.compile(r'(\r\n[ \t\f\v]*){2,}')
 # find \r\n sequences
 _single_newline_re = re.compile(r'(\r\n)')
 

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -67,7 +67,7 @@ def capitalize_first(maybe_text):
 
     return maybe_text
 
-# find repeated sequences of '\r\n\', optionally separated by a space character
+# find repeated sequences of '\r\n\', optionally separated by other non-newline whitespace space characters
 _multiple_newlines_re = re.compile(r'(\r\n[ \t\f\v]*){2,}')
 # find \r\n sequences
 _single_newline_re = re.compile(r'(\r\n)')
@@ -76,7 +76,8 @@ _single_newline_re = re.compile(r'(\r\n)')
 @evalcontextfilter
 def preserve_line_breaks(eval_ctx, value):
 
-    # Turn potential markdown objects into string
+    # `escape()` returns Markdown objects in python2
+    # We want to cast the output value back into unicode strings
     value = u'{}'.format(escape(value))
 
     # limit sequences of "\r\n\r\n ..."s to two

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -79,7 +79,7 @@ def preserve_line_breaks(eval_ctx, value, question_type):
         return value
 
     # Turn potential markdown objects into string
-    value = '{}'.format(escape(value))
+    value = u'{}'.format(escape(value))
 
     # limit sequences of "\r\n\r\n ..."s to two
     value = _multiple_newlines_re.sub(u'\r\n\r\n', value)

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 import re
-from flask import Markup, escape
 from six import string_types
 from jinja2 import evalcontextfilter, Markup, escape
 
@@ -69,17 +68,18 @@ def capitalize_first(maybe_text):
     return maybe_text
 
 # find repeated sequences of '\r\n\', optionally separated by a space character
-_multiple_newlines_re = re.compile(r'(\r\n ?){2,}')
+_multiple_newlines_re = re.compile(r'(\r\n *){2,}')
 # find \r\n sequences
 _single_newline_re = re.compile(r'(\r\n)')
 
 
 @evalcontextfilter
-def preserve_line_breaks(eval_ctx, value, question_type=None):
+def preserve_line_breaks(eval_ctx, value, question_type):
     if question_type and question_type != 'textbox_large':
         return value
 
-    value = str(escape(value))
+    # Turn potential markdown objects into string
+    value = '{}'.format(escape(value))
 
     # limit sequences of "\r\n\r\n ..."s to two
     value = _multiple_newlines_re.sub(u'\r\n\r\n', value)

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -51,6 +51,7 @@ def init_app(
     application.add_template_filter(filters.format_links)
     application.add_template_filter(filters.nbsp)
     application.add_template_filter(filters.smartjoin)
+    application.add_template_filter(filters.preserve_line_breaks)
     # Make select formats available in templates.
     application.add_template_filter(formats.dateformat)
     application.add_template_filter(formats.datetimeformat)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -123,18 +123,15 @@ def test_capitalize_first_for_non_strings():
     assert capitalize_first('https://www.example.com') == 'https://www.example.com'
 
 
-@pytest.mark.parametrize("_autoescape", (False, True))  # Shouldn't matter
+@pytest.mark.parametrize("_autoescape", (False, True))
 def test_preserve_line_breaks(_autoescape):
     eval_ctx_mock = mock.Mock(autoescape=_autoescape)
-    assert preserve_line_breaks(eval_ctx_mock, '\r\n', 'textbox_large') == '<br>'
-    assert preserve_line_breaks(eval_ctx_mock, '\r\n\r\n', 'textbox_large') == '<br><br>'
-    assert preserve_line_breaks(eval_ctx_mock, '\r\n \r\n \r\n', 'textbox_large') == '<br><br>'
-    assert preserve_line_breaks(eval_ctx_mock, '\r\n\r\n\r\n\r\n\r\n\r\n', 'textbox_large') == '<br><br>'
-    assert preserve_line_breaks(eval_ctx_mock, '', 'textbox_large') == ''
-    assert preserve_line_breaks(eval_ctx_mock, '\r\n<h2>', 'textbox_large') == '<br>&lt;h2&gt;'
-    assert preserve_line_breaks(eval_ctx_mock, '\n', 'textbox_large') == '\n'
-    assert preserve_line_breaks(eval_ctx_mock, '\r\n', 'not_textbox_large') == '\r\n'
-    assert preserve_line_breaks(eval_ctx_mock,
-                                'You’ll be eating 🍕', 'textbox_large') == 'You’ll be eating 🍕'
-    assert preserve_line_breaks(eval_ctx_mock,
-                                '\r\n\r\n  \r\n\r\n  \t\v \r\n\r\n', 'textbox_large') == '<br><br>'
+    assert preserve_line_breaks(eval_ctx_mock, '\r\n') == '<br>'
+    assert preserve_line_breaks(eval_ctx_mock, '\r\n\r\n') == '<br><br>'
+    assert preserve_line_breaks(eval_ctx_mock, '\r\n \r\n \r\n') == '<br><br>'
+    assert preserve_line_breaks(eval_ctx_mock, '\r\n\r\n\r\n\r\n\r\n\r\n') == '<br><br>'
+    assert preserve_line_breaks(eval_ctx_mock, '') == ''
+    assert preserve_line_breaks(eval_ctx_mock, '\r\n<h2>') == '<br>&lt;h2&gt;'
+    assert preserve_line_breaks(eval_ctx_mock, '\n') == '\n'
+    assert preserve_line_breaks(eval_ctx_mock, 'You’ll be eating 🍕') == 'You’ll be eating 🍕'
+    assert preserve_line_breaks(eval_ctx_mock, '\r\n\r\n  \r\n\r\n  \t\v \r\n\r\n') == '<br><br>'

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -135,4 +135,4 @@ def test_preserve_line_breaks(bool):
     assert preserve_line_breaks(mock.Mock(autoescape=bool), '\n', 'textbox_large') == '\n'
     assert preserve_line_breaks(mock.Mock(autoescape=bool), '\r\n', 'not_textbox_large') == '\r\n'
     assert preserve_line_breaks(mock.Mock(autoescape=bool),
-                                '\r\n\r\n  \r\n\r\n  \r\n\r\n', 'textbox_large') == '<br><br>'
+                                '\r\n\r\n  \r\n\r\n  \t\v \r\n\r\n', 'textbox_large') == '<br><br>'

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -125,6 +125,7 @@ def test_capitalize_first_for_non_strings():
 
 @pytest.mark.parametrize("_autoescape", (False, True))
 def test_preserve_line_breaks(_autoescape):
+    # We expect the same output regardless of the eval context `autoescape` value
     eval_ctx_mock = mock.Mock(autoescape=_autoescape)
     assert preserve_line_breaks(eval_ctx_mock, '\r\n') == '<br>'
     assert preserve_line_breaks(eval_ctx_mock, '\r\n\r\n') == '<br><br>'

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import mock
+
 from flask import Markup
 
-from dmutils.filters import capitalize_first, format_links, nbsp, smartjoin
+from dmutils.filters import capitalize_first, format_links, nbsp, smartjoin, preserve_line_breaks
 
 
 def test_smartjoin_for_more_than_one_item():
@@ -118,3 +120,12 @@ def test_capitalize_first_for_non_strings():
     assert capitalize_first([{'list': 'of'}, 'things']) == [{'list': 'of'}, 'Things']
     assert capitalize_first({'this': 'thing'}) == {'this': 'thing'}
     assert capitalize_first('https://www.example.com') == 'https://www.example.com'
+
+
+def test_preserve_line_breaks():
+    assert preserve_line_breaks(mock.Mock(autoescape=False), '\r\n') == '<br>'
+    assert preserve_line_breaks(mock.Mock(autoescape=False), '\r\n\r\n') == '<br><br>'
+    assert preserve_line_breaks(mock.Mock(autoescape=False), '\r\n \r\n \r\n') == '<br><br>'
+    assert preserve_line_breaks(mock.Mock(autoescape=False), '\r\n\r\n\r\n\r\n\r\n\r\n') == '<br><br>'
+    assert preserve_line_breaks(mock.Mock(autoescape=False), '') == ''
+    assert preserve_line_breaks(mock.Mock(autoescape=False), '\r\n<h2>') == '<br>&lt;h2&gt;'

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import mock
+import pytest
 
 from flask import Markup
 
@@ -122,10 +123,16 @@ def test_capitalize_first_for_non_strings():
     assert capitalize_first('https://www.example.com') == 'https://www.example.com'
 
 
-def test_preserve_line_breaks():
-    assert preserve_line_breaks(mock.Mock(autoescape=False), '\r\n') == '<br>'
-    assert preserve_line_breaks(mock.Mock(autoescape=False), '\r\n\r\n') == '<br><br>'
-    assert preserve_line_breaks(mock.Mock(autoescape=False), '\r\n \r\n \r\n') == '<br><br>'
-    assert preserve_line_breaks(mock.Mock(autoescape=False), '\r\n\r\n\r\n\r\n\r\n\r\n') == '<br><br>'
-    assert preserve_line_breaks(mock.Mock(autoescape=False), '') == ''
-    assert preserve_line_breaks(mock.Mock(autoescape=False), '\r\n<h2>') == '<br>&lt;h2&gt;'
+@pytest.mark.parametrize("bool", (False, True,))  # Shouldn't matter
+def test_preserve_line_breaks(bool):
+    assert preserve_line_breaks(mock.Mock(autoescape=bool), '\r\n', 'textbox_large') == '<br>'
+    assert preserve_line_breaks(mock.Mock(autoescape=bool), '\r\n\r\n', 'textbox_large') == '<br><br>'
+    assert preserve_line_breaks(mock.Mock(autoescape=bool), '\r\n \r\n \r\n', 'textbox_large') == '<br><br>'
+    assert preserve_line_breaks(mock.Mock(autoescape=bool), '\r\n\r\n\r\n\r\n\r\n\r\n', 'textbox_large') == '<br><br>'
+    assert preserve_line_breaks(mock.Mock(autoescape=bool), '', 'textbox_large') == ''
+    assert preserve_line_breaks(mock.Mock(autoescape=bool), '\r\n<h2>', 'textbox_large') == '<br>&lt;h2&gt;'
+    assert preserve_line_breaks(mock.Mock(autoescape=bool), 'You’ll be working', 'textbox_large') == 'You’ll be working'
+    assert preserve_line_breaks(mock.Mock(autoescape=bool), '\n', 'textbox_large') == '\n'
+    assert preserve_line_breaks(mock.Mock(autoescape=bool), '\r\n', 'not_textbox_large') == '\r\n'
+    assert preserve_line_breaks(mock.Mock(autoescape=bool),
+                                '\r\n\r\n  \r\n\r\n  \r\n\r\n', 'textbox_large') == '<br><br>'

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -131,8 +131,9 @@ def test_preserve_line_breaks(bool):
     assert preserve_line_breaks(mock.Mock(autoescape=bool), '\r\n\r\n\r\n\r\n\r\n\r\n', 'textbox_large') == '<br><br>'
     assert preserve_line_breaks(mock.Mock(autoescape=bool), '', 'textbox_large') == ''
     assert preserve_line_breaks(mock.Mock(autoescape=bool), '\r\n<h2>', 'textbox_large') == '<br>&lt;h2&gt;'
-    assert preserve_line_breaks(mock.Mock(autoescape=bool), 'You’ll be working', 'textbox_large') == 'You’ll be working'
     assert preserve_line_breaks(mock.Mock(autoescape=bool), '\n', 'textbox_large') == '\n'
     assert preserve_line_breaks(mock.Mock(autoescape=bool), '\r\n', 'not_textbox_large') == '\r\n'
+    assert preserve_line_breaks(mock.Mock(autoescape=bool),
+                                'You’ll be eating 🍕', 'textbox_large') == 'You’ll be eating 🍕'
     assert preserve_line_breaks(mock.Mock(autoescape=bool),
                                 '\r\n\r\n  \r\n\r\n  \t\v \r\n\r\n', 'textbox_large') == '<br><br>'

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -123,17 +123,18 @@ def test_capitalize_first_for_non_strings():
     assert capitalize_first('https://www.example.com') == 'https://www.example.com'
 
 
-@pytest.mark.parametrize("bool", (False, True,))  # Shouldn't matter
-def test_preserve_line_breaks(bool):
-    assert preserve_line_breaks(mock.Mock(autoescape=bool), '\r\n', 'textbox_large') == '<br>'
-    assert preserve_line_breaks(mock.Mock(autoescape=bool), '\r\n\r\n', 'textbox_large') == '<br><br>'
-    assert preserve_line_breaks(mock.Mock(autoescape=bool), '\r\n \r\n \r\n', 'textbox_large') == '<br><br>'
-    assert preserve_line_breaks(mock.Mock(autoescape=bool), '\r\n\r\n\r\n\r\n\r\n\r\n', 'textbox_large') == '<br><br>'
-    assert preserve_line_breaks(mock.Mock(autoescape=bool), '', 'textbox_large') == ''
-    assert preserve_line_breaks(mock.Mock(autoescape=bool), '\r\n<h2>', 'textbox_large') == '<br>&lt;h2&gt;'
-    assert preserve_line_breaks(mock.Mock(autoescape=bool), '\n', 'textbox_large') == '\n'
-    assert preserve_line_breaks(mock.Mock(autoescape=bool), '\r\n', 'not_textbox_large') == '\r\n'
-    assert preserve_line_breaks(mock.Mock(autoescape=bool),
+@pytest.mark.parametrize("_autoescape", (False, True))  # Shouldn't matter
+def test_preserve_line_breaks(_autoescape):
+    eval_ctx_mock = mock.Mock(autoescape=_autoescape)
+    assert preserve_line_breaks(eval_ctx_mock, '\r\n', 'textbox_large') == '<br>'
+    assert preserve_line_breaks(eval_ctx_mock, '\r\n\r\n', 'textbox_large') == '<br><br>'
+    assert preserve_line_breaks(eval_ctx_mock, '\r\n \r\n \r\n', 'textbox_large') == '<br><br>'
+    assert preserve_line_breaks(eval_ctx_mock, '\r\n\r\n\r\n\r\n\r\n\r\n', 'textbox_large') == '<br><br>'
+    assert preserve_line_breaks(eval_ctx_mock, '', 'textbox_large') == ''
+    assert preserve_line_breaks(eval_ctx_mock, '\r\n<h2>', 'textbox_large') == '<br>&lt;h2&gt;'
+    assert preserve_line_breaks(eval_ctx_mock, '\n', 'textbox_large') == '\n'
+    assert preserve_line_breaks(eval_ctx_mock, '\r\n', 'not_textbox_large') == '\r\n'
+    assert preserve_line_breaks(eval_ctx_mock,
                                 'You’ll be eating 🍕', 'textbox_large') == 'You’ll be eating 🍕'
-    assert preserve_line_breaks(mock.Mock(autoescape=bool),
+    assert preserve_line_breaks(eval_ctx_mock,
                                 '\r\n\r\n  \r\n\r\n  \t\v \r\n\r\n', 'textbox_large') == '<br><br>'


### PR DESCRIPTION
Only works on textbox_large elements and only keeps a maximum of two line breaks.