### PR TITLE
Fix 'http header value must be a string' uwsgi PY3 error

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '27.1.0'
+__version__ = '27.1.1'

--- a/dmutils/request_id.py
+++ b/dmutils/request_id.py
@@ -34,7 +34,7 @@ class ResponseHeaderMiddleware(object):
             if self.request_id_header not in dict(headers).keys():
                 headers = headers + [(
                     self.request_id_header,
-                    request.request_id.encode('utf-8')
+                    str(request.request_id)
                 )]
 
             return start_response(status, headers, exc_info)

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -60,7 +60,7 @@ def test_request_id_is_set_on_response(app):
 
     with app.app_context():
         response = client.get('/', headers={'DM-REQUEST-ID': 'generated'})
-        assert response.headers['DM-Request-ID'] == 'generated'.encode('utf-8')
+        assert response.headers['DM-Request-ID'] == 'generated'
 
 
 def test_request_id_is_set_on_error_response(app):
@@ -74,4 +74,4 @@ def test_request_id_is_set_on_error_response(app):
     with app.app_context():
         response = client.get('/', headers={'DM-REQUEST-ID': 'generated'})
         assert response.status_code == 500
-        assert response.headers['DM-Request-ID'] == 'generated'.encode('utf-8')
+        assert response.headers['DM-Request-ID'] == 'generated'


### PR DESCRIPTION
`.encode` was added to fix an issue with Apache mod_wsgi not
encoding the headers added in the middleware, which we no longer
use.

It's raising an error when running with uwsgi and Python 3.