### PR TITLE
Date/time formats adhere to style guide

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '27.1.2'
+__version__ = '27.2.0'

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -58,6 +58,7 @@ def init_app(
     application.add_template_filter(formats.datetodatetimeformat)
     application.add_template_filter(formats.shortdateformat)
     application.add_template_filter(formats.timeformat)
+    application.add_template_filter(formats.utcdatetimeformat)
 
     @application.context_processor
     def inject_global_template_variables():

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -22,12 +22,20 @@ def dateformat(value, default_value=None):
     return _format_date(value, default_value, DISPLAY_DATE_FORMAT, localize=False)
 
 
-def datetimeformat(value, default_value=None):
+def datetimeformat(value, default_value=None, localize=True):
     # en_GB locale uses uppercase AM/PM which contravenes our style guide
-    formatted_date = _format_date(value, default_value, DISPLAY_DATETIME_FORMAT)
+    formatted_date = _format_date(value, default_value, DISPLAY_DATETIME_FORMAT, localize=localize)
     if formatted_date:
         return formatted_date.replace('AM', 'am').replace('PM', 'pm').replace(" 0", " ")
     return formatted_date
+
+
+def utcdatetimeformat(value, default_value=None):
+    local_format = datetimeformat(value, default_value)
+    if local_format and "12:59am" in local_format:
+        # Force UTC+00 if the date has rolled over to the next day
+        return datetimeformat(value, default_value, localize=False)
+    return local_format
 
 
 def datetodatetimeformat(value):

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -7,7 +7,7 @@ DATE_FORMAT = "%Y-%m-%d"
 DISPLAY_SHORT_DATE_FORMAT = '%-d %B'
 DISPLAY_DATE_FORMAT = '%A %-d %B %Y'
 DISPLAY_TIME_FORMAT = '%H:%M:%S'
-DISPLAY_DATETIME_FORMAT = '%A %-d %B %Y at %H:%M'
+DISPLAY_DATETIME_FORMAT = '%A %-d %B %Y at %I:%M%p'
 
 
 def timeformat(value, default_value=None):
@@ -23,7 +23,11 @@ def dateformat(value, default_value=None):
 
 
 def datetimeformat(value, default_value=None):
-    return _format_date(value, default_value, DISPLAY_DATETIME_FORMAT)
+    # en_GB locale uses uppercase AM/PM which contravenes our style guide
+    formatted_date = _format_date(value, default_value, DISPLAY_DATETIME_FORMAT)
+    if formatted_date:
+        return formatted_date.replace('AM', 'am').replace('PM', 'pm').replace(" 0", " ")
+    return formatted_date
 
 
 def datetodatetimeformat(value):

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -64,12 +64,18 @@ def test_dateformat():
 
 def test_datetimeformat():
     cases = [
-        (datetime(2012, 11, 10, 9, 8, 7, 6), "Saturday 10 November 2012 at 09:08"),
-        ("2012-11-10T09:08:07.0Z", "Saturday 10 November 2012 at 09:08"),
-        (datetime(2012, 8, 10, 9, 8, 7, 6), "Friday 10 August 2012 at 10:08"),
-        ("2012-08-10T09:08:07.0Z", "Friday 10 August 2012 at 10:08"),
-        (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "Friday 10 August 2012 at 10:08"),
-        (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), "Wednesday 1 August 2012 at 10:08"),
+        (datetime(2012, 11, 10, 9, 8, 7, 6), "Saturday 10 November 2012 at 9:08am"),
+        ("2012-11-10T09:08:07.0Z", "Saturday 10 November 2012 at 9:08am"),
+        (datetime(2012, 8, 10, 9, 8, 7, 6), "Friday 10 August 2012 at 10:08am"),
+        ("2012-08-10T09:08:07.0Z", "Friday 10 August 2012 at 10:08am"),
+        (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "Friday 10 August 2012 at 10:08am"),
+        (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), "Wednesday 1 August 2012 at 10:08am"),
+        (datetime(2012, 8, 1, 22, 59, 7, 6, tzinfo=pytz.utc), "Wednesday 1 August 2012 at 11:59pm"),
+        # Daylight savings edge case
+        (datetime(2012, 3, 25, 0, 59, 7, 6, tzinfo=pytz.utc), "Sunday 25 March 2012 at 12:59am"),
+        (datetime(2012, 3, 25, 1, 59, 7, 6, tzinfo=pytz.utc), "Sunday 25 March 2012 at 2:59am"),
+        # Fall back to default if no valid date supplied
+        (None, None),
     ]
 
     def check_datetimeformat(dt, formatted_datetime):

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from dmutils.formats import (
-    timeformat, shortdateformat, dateformat, datetimeformat, datetodatetimeformat
+    timeformat, shortdateformat, dateformat, datetimeformat, datetodatetimeformat,
+    utcdatetimeformat
 )
 import pytz
 from datetime import datetime
@@ -80,6 +81,23 @@ def test_datetimeformat():
 
     def check_datetimeformat(dt, formatted_datetime):
         assert datetimeformat(dt) == formatted_datetime
+
+    for dt, formatted_datetime in cases:
+        yield check_datetimeformat, dt, formatted_datetime
+
+
+def test_utcdatetimeformat():
+    cases = [
+        # UTC+00 date: display as normal
+        (datetime(2012, 3, 24, 23, 59, 7, 6, tzinfo=pytz.utc), "Saturday 24 March 2012 at 11:59pm"),
+        # UTC+01 date: force to UTC+00 if date would rollover to the next day
+        (datetime(2012, 3, 25, 23, 59, 7, 6, tzinfo=pytz.utc), "Sunday 25 March 2012 at 11:59pm"),
+        # Fall back to default if no valid date supplied
+        (None, None),
+    ]
+
+    def check_datetimeformat(dt, formatted_datetime):
+        assert utcdatetimeformat(dt) == formatted_datetime
 
     for dt, formatted_datetime in cases:
         yield check_datetimeformat, dt, formatted_datetime


### PR DESCRIPTION
Date/time string formats should adhere to the style guide (https://docs.google.com/document/d/1Buo3WGkN2YVUBtlWe7Qvc6bgAcpmKW_GwjHv5Hxs-iQ/edit?ts=595e430f#):
- Use the 12 hr clock (e.g. 11.59pm)
- Remove any leading zeroes from the hour (e.g. 1.59pm instead of 01.59pm)
- Use lower case am/pm

Also added edge case tests for daylight savings/midnight timestamps.

This will support the display of date/time for supplier application deadlines (see ticket: https://trello.com/c/8CJAv25W/714-show-time-opportunity-closes)
