### PR TITLE
Upgrade cryptography to 1.9

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '27.1.1'
+__version__ = '27.1.2'

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
          'Flask>=0.10',
          'boto3==1.4.4',
          'contextlib2==0.4.0',
-         'cryptography==1.6',
+         'cryptography==1.9',
          'inflection==0.2.1',
          'mailchimp3==2.0.11',
          'mandrill==1.0.57',


### PR DESCRIPTION
cryptography 1.6 technically doesn't support Python 3.6 and the install fails on OS X, so upgrading it to 1.9.