### PR TITLE
Append timezone to UTC-forced dates

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '27.2.0'
+__version__ = '27.2.1'

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -31,11 +31,18 @@ def datetimeformat(value, default_value=None, localize=True):
 
 
 def utcdatetimeformat(value, default_value=None):
+    """
+    Use this filter to format deadline timestamps that are stored in the database as
+    23:59:59 (UTC+00), when the localisation would otherwise display the date as 12.59am
+     on the next day (due to daylight savings), potentially causing confusion for buyers/suppliers.
+    """
     local_format = datetimeformat(value, default_value)
-    if local_format and "12:59am" in local_format:
-        # Force UTC+00 if the date has rolled over to the next day
-        return datetimeformat(value, default_value, localize=False)
-    return local_format
+    if local_format:
+        if "11:59pm" not in local_format:
+            # Force UTC+00 if the date has rolled over to the next day and append timezone
+            return "{} GMT".format(datetimeformat(value, default_value, localize=False))
+        return "{} GMT".format(local_format)
+    return None
 
 
 def datetodatetimeformat(value):

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -89,9 +89,9 @@ def test_datetimeformat():
 def test_utcdatetimeformat():
     cases = [
         # UTC+00 date: display as normal
-        (datetime(2012, 3, 24, 23, 59, 7, 6, tzinfo=pytz.utc), "Saturday 24 March 2012 at 11:59pm"),
+        (datetime(2012, 3, 24, 23, 59, 7, 6, tzinfo=pytz.utc), "Saturday 24 March 2012 at 11:59pm GMT"),
         # UTC+01 date: force to UTC+00 if date would rollover to the next day
-        (datetime(2012, 3, 25, 23, 59, 7, 6, tzinfo=pytz.utc), "Sunday 25 March 2012 at 11:59pm"),
+        (datetime(2012, 3, 25, 23, 59, 7, 6, tzinfo=pytz.utc), "Sunday 25 March 2012 at 11:59pm GMT"),
         # Fall back to default if no valid date supplied
         (None, None),
     ]


### PR DESCRIPTION
Appends `GMT` to all date strings that have been forced to UTC+00.

We also now force GMT for any time that is not 11.59pm, not just for 12.59am times. This should probably be reviewed if we start storing non-naive datestamps in the DB.

Ticket: https://trello.com/c/8CJAv25W/714-show-time-opportunity-closes