### PR TITLE
Fix Python3 format_links filter

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '27.2.1'
+__version__ = '27.2.2'

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -15,17 +15,24 @@ def smartjoin(input):
 
 
 def format_links(text):
+    """
+    Filter that searches a given string (or other string-like object) for any URIs
+    and wraps them with either an anchor link or a span, depending on whether the link contains a valid protocol.
+    Python3's re library returns matches with type string rather than the arg's type, which
+    causes problems for Markup() objects containing tags to be escaped later. Therefore
+    we need to cast the matches and formatted links back to the original type before returning the value.
+    """
     url_match = re.compile(r"""(
                                 (?:https?://|www\.)    # start with http:// or www.
                                 (?:[^\s<>"'/?#]+)      # domain doesn't have these characters
                                 (?:[^\s<>"']+)         # post-domain part of URL doesn't have these characters
                                 [^\s<>,"'\.]           # no dot at end
                                 )""", re.X)
-    matched_urls = url_match.findall(text)
+    matched_urls = [type(text)(substr) for substr in url_match.findall(text)]
     if matched_urls:
         link = '<a href="{0}" class="break-link" rel="external">{0}</a>'
         plaintext_link = '<span class="break-link">{0}</span>'
-        text_array = url_match.split(text)
+        text_array = [type(text)(substr) for substr in url_match.split(text)]
         formatted_text_array = []
         for partial_text in text_array:
             if partial_text in matched_urls:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -45,6 +45,18 @@ def test_format_link_with_text():
     assert format_links(text) == formatted_text
 
 
+def test_format_link_handles_markup_objects_with_protocol():
+    text = Markup('<td class="summary-item-field">\n\n<span>Hurray - http://www.example.com is great</span></td>')
+    formatted_text = Markup('<td class="summary-item-field">\n\n<span>Hurray - <a href="http://www.example.com" class="break-link" rel="external">http://www.example.com</a> is great</span></td>')  # noqa
+    assert format_links(text) == formatted_text
+
+
+def test_format_link_handles_markup_objects_without_protocol():
+    text = Markup('<td class="summary-item-field">\n\n<span>Hurray - www.example.com is great</span></td>')
+    formatted_text = Markup('<td class="summary-item-field">\n\n<span>Hurray - <span class="break-link">www.example.com</span> is great</span></td>')  # noqa
+    assert format_links(text) == formatted_text
+
+
 def test_format_link_and_text_escapes_extra_html():
     text = 'This is the <strong>link</strong>: http://www.example.com'
     formatted_text = 'This is the &lt;strong&gt;link&lt;/strong&gt;: <a href="http://www.example.com" class="break-link" rel="external">http://www.example.com</a>'  # noqa


### PR DESCRIPTION
Bug: The `format_links` template filter was converting Markup content to strings and 'helpfully' escaping it for us. 

To fix: we explicitly cast the value to its original type, rather than returning the string output by re. (Thanks @allait for this idea).

Once this is merged we can bump the version number on the buyer-frontend and briefs-frontend, where this filter is used.