### PR TITLE
Return role from expired token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 Records breaking changes from major version bumps
 
+## 28.0.0
+
+PR:
+
+### What changed
+
+`decode_invitation_token()` will now return a dict with data if the token is expired, rather than just returning `None`. If the token is invalid it will still return `None`.
+The data it returns is `{ 'expired': True, 'role': '<user role from token>' }`. This is useful when creating new users as we still capture the role if the token is invalid, and render appropriate helpful templates.
+
+### Example app changes
+Old:
+```
+if token is None:
+    return render_template('generic-error-page.html')
+```
+New:
+```
+if token is None:
+    return render_template('invalid-token-error-page.html')
+elif token.get('expired'):
+    return render_template('create-{}-user-error-page.html'.format(token['role']))
+```
 
 ## 27.0.0
 
@@ -27,13 +49,13 @@ PR: [#306](https://github.com/alphagov/digitalmarketplace-utils/pull/306)
 Old:
 ```
 # get_key used to return None if path param was None
- 
+
 key = some_bucket.get_key(path_that_might_be_none)
 ```
 New:
 ```
 # get_key will now raise an error if path param is None
- 
+
 key = some_bucket.get_key(path_that_might_be_none) if path_that_might_be_none else None
 ```
 

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '27.2.2'
+__version__ = '28.0.0'

--- a/tests/email/test_dm_mandrill.py
+++ b/tests/email/test_dm_mandrill.py
@@ -292,23 +292,23 @@ def test_decode_password_reset_token_does_not_work_if_password_changed_later_tha
 def test_decode_invitation_token_decodes_ok(email_app):
     with email_app.app_context():
         # works with arbitrary fields
-        data = {'email_address': 'test-user@email.com', 'supplier_id': 1234, 'foo': 'bar'}
+        data = {'email_address': 'test-user@email.com', 'supplier_id': 1234, 'foo': 'bar', 'role': 'supplier'}
         token = generate_token(data, 'Key', 'Salt')
         assert decode_invitation_token(token) == data
 
 
 def test_decode_invitation_token_does_not_work_if_bad_token(email_app):
     with email_app.app_context():
-        data = {'email_address': 'test-user@email.com', 'supplier_name': 'A. Supplier'}
+        data = {'email_address': 'test-user@email.com', 'supplier_name': 'A. Supplier', 'role': 'supplier'}
         token = generate_token(data, email_app.config['SHARED_EMAIL_KEY'], email_app.config['INVITE_EMAIL_SALT'])[1:]
 
         assert decode_invitation_token(token) is None
 
 
-def test_decode_invitation_token_does_not_work_if_token_expired(email_app):
+def test_decode_invitation_token_returns_expired_true_and_role_if_token_expired(email_app):
     with freeze_time('2015-01-02 03:04:05'):
-        data = {'email_address': 'test-user@email.com', 'supplier_name': 'A. Supplier'}
+        data = {'email_address': 'test-user@email.com', 'supplier_name': 'A. Supplier', 'role': 'supplier'}
         token = generate_token(data, email_app.config['SHARED_EMAIL_KEY'], email_app.config['INVITE_EMAIL_SALT'])
     with email_app.app_context():
 
-        assert decode_invitation_token(token) is None
+        assert decode_invitation_token(token) == {'expired': True, 'role': 'supplier'}


### PR DESCRIPTION
Currently we don't differentiate between an expired token and a bad
one. Both just return `None`.

It would be more helpful when creating users in the user-frontend
app if we could determine the role that was being attempted to create with
an expired token. That way we can give appropriate advice.

If the token is bad it's probably a copy paste error, and we're less
concerned about giving more helpful advise other than it being a bad
token.