### PR TITLE
Standardise token error messages

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '28.0.0'
+__version__ = '28.0.1'

--- a/dmutils/email/dm_mandrill.py
+++ b/dmutils/email/dm_mandrill.py
@@ -193,7 +193,7 @@ def decode_invitation_token(encoded_token):
                                     extra={'error': six.text_type(error)})
 
             return {
-                'expired': True,
+                'error': 'token_expired',
                 'role': token['role']
             }
 
@@ -201,4 +201,4 @@ def decode_invitation_token(encoded_token):
             current_app.logger.info("Invitation reset attempt with invalid token. error {invalid_token_error}",
                                     extra={'error': six.text_type(invalid_token_error)})
 
-            return None
+            return {'error': 'token_invalid'}

--- a/tests/email/test_dm_mandrill.py
+++ b/tests/email/test_dm_mandrill.py
@@ -297,18 +297,18 @@ def test_decode_invitation_token_decodes_ok(email_app):
         assert decode_invitation_token(token) == data
 
 
-def test_decode_invitation_token_does_not_work_if_bad_token(email_app):
+def test_decode_invitation_token_returns_an_error_if_token_invalid(email_app):
     with email_app.app_context():
         data = {'email_address': 'test-user@email.com', 'supplier_name': 'A. Supplier', 'role': 'supplier'}
         token = generate_token(data, email_app.config['SHARED_EMAIL_KEY'], email_app.config['INVITE_EMAIL_SALT'])[1:]
 
-        assert decode_invitation_token(token) is None
+        assert decode_invitation_token(token) == {'error': 'token_invalid'}
 
 
-def test_decode_invitation_token_returns_expired_true_and_role_if_token_expired(email_app):
+def test_decode_invitation_token_returns_an_error_and_role_if_token_expired(email_app):
     with freeze_time('2015-01-02 03:04:05'):
         data = {'email_address': 'test-user@email.com', 'supplier_name': 'A. Supplier', 'role': 'supplier'}
         token = generate_token(data, email_app.config['SHARED_EMAIL_KEY'], email_app.config['INVITE_EMAIL_SALT'])
     with email_app.app_context():
 
-        assert decode_invitation_token(token) == {'expired': True, 'role': 'supplier'}
+        assert decode_invitation_token(token) == {'error': 'token_expired', 'role': 'supplier'}


### PR DESCRIPTION
If a token is invalid or expired it should return an error message in a
consistent way. Password reset tokens are returning a dict with an
`error` key. This updates the create user tokens to return errors in a
similar way.