### PR TITLE
Support old style tokens

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '28.0.1'
+__version__ = '28.0.2'

--- a/dmutils/email/dm_mandrill.py
+++ b/dmutils/email/dm_mandrill.py
@@ -178,6 +178,10 @@ def decode_invitation_token(encoded_token):
             current_app.config['INVITE_EMAIL_SALT'],
             SEVEN_DAYS_IN_SECONDS
         )
+        if 'role' not in token:
+            token.update({
+                'role': 'supplier' if token.get('supplier_id') else 'buyer'
+            })
         return token
 
     except fernet.InvalidToken as error:
@@ -194,7 +198,7 @@ def decode_invitation_token(encoded_token):
 
             return {
                 'error': 'token_expired',
-                'role': token['role']
+                'role': token.get('role') or ('supplier' if token.get('supplier_id') else 'buyer')
             }
 
         except fernet.InvalidToken as invalid_token_error:


### PR DESCRIPTION
A role key has been added to the user create invite tokens. We need to
support the old style tokens for a period of one week until they all
expire. Adding the role here means we don't need to change the code in
the user-frontend.