### PR TITLE
forms: add EmailField

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '28.0.3'
+__version__ = '28.1.0'

--- a/dmutils/forms.py
+++ b/dmutils/forms.py
@@ -1,4 +1,8 @@
+from itertools import chain
+import re
+
 from wtforms import StringField
+from wtforms.validators import Regexp
 
 
 class StripWhitespaceStringField(StringField):
@@ -6,6 +10,19 @@ class StripWhitespaceStringField(StringField):
 
         kwargs['filters'] = kwargs.get('filters', []) + [strip_whitespace]
         super(StringField, self).__init__(label, **kwargs)
+
+
+class EmailField(StripWhitespaceStringField):
+    _email_re = re.compile(r"^[^@\s]+@[^@\.\s]+(\.[^@\.\s]+)+$")
+
+    def __init__(self, label=None, **kwargs):
+        kwargs["validators"] = tuple(chain(
+            kwargs.pop("validators", ()),
+            (
+                Regexp(self._email_re, message="Please enter a valid email address"),
+            ),
+        ))
+        super(EmailField, self).__init__(label, **kwargs)
 
 
 def strip_whitespace(value):

--- a/dmutils/forms.py
+++ b/dmutils/forms.py
@@ -7,8 +7,12 @@ from wtforms.validators import Regexp
 
 class StripWhitespaceStringField(StringField):
     def __init__(self, label=None, **kwargs):
-
-        kwargs['filters'] = kwargs.get('filters', []) + [strip_whitespace]
+        kwargs['filters'] = tuple(chain(
+            kwargs.get('filters', ()),
+            (
+                strip_whitespace,
+            ),
+        ))
         super(StringField, self).__init__(label, **kwargs)
 
 

--- a/dmutils/forms.py
+++ b/dmutils/forms.py
@@ -17,13 +17,11 @@ class StripWhitespaceStringField(StringField):
 
 
 class EmailField(StripWhitespaceStringField):
-    _email_re = re.compile(r"^[^@\s]+@[^@\.\s]+(\.[^@\.\s]+)+$")
-
     def __init__(self, label=None, **kwargs):
         kwargs["validators"] = tuple(chain(
             kwargs.pop("validators", ()),
             (
-                Regexp(self._email_re, message="Please enter a valid email address"),
+                EmailValidator(),
             ),
         ))
         super(EmailField, self).__init__(label, **kwargs)
@@ -33,3 +31,11 @@ def strip_whitespace(value):
     if value is not None and hasattr(value, 'strip'):
         return value.strip()
     return value
+
+
+class EmailValidator(Regexp):
+    _email_re = re.compile(r"^[^@\s]+@[^@\.\s]+(\.[^@\.\s]+)+$")
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("message", "Please enter a valid email address.")
+        return super(EmailValidator, self).__init__(self._email_re, **kwargs)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,5 @@ pep8==1.6.2
 pytest==2.8.7
 pytest-cov==2.2.0
 python-coveralls==2.5.0
+Flask==0.10.1
+Flask-WTF==0.12

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -98,3 +98,14 @@ class TestEmailFieldCombination(object):
                 optional_field_email != self._invalid_address and
                 unspecified_field_email == self._valid_address
             )
+
+            if required_field_email == self._invalid_address:
+                assert form.errors["required_email"] == ["Please enter a valid email address."]
+            elif required_field_email == "":
+                assert form.errors["required_email"] == ["No really, we want this"]
+
+            if optional_field_email == self._invalid_address:
+                assert form.errors["optional_email"] == ["Please enter a valid email address."]
+
+            if unspecified_field_email in (self._invalid_address, ""):
+                assert form.errors["unspecified_email"] == ["Please enter a valid email address."]

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,0 +1,100 @@
+from itertools import product
+
+from flask.ext.wtf import Form
+from wtforms.validators import ValidationError, DataRequired, Optional
+from werkzeug.datastructures import ImmutableMultiDict
+import pytest
+
+from dmutils.forms import EmailField
+
+
+class EmailFieldFormatTestForm(Form):
+    test_email = EmailField("An Electronic Mailing Address")
+
+
+class TestEmailFieldFormat(object):
+    @pytest.mark.parametrize("email_address", (
+        "oiufewnew",
+        "",
+        None,
+        "cissy@edy@how.th",
+        "@major.tweedy",
+        "ned.l?mbert@x.",
+        "bu ck@41.com",
+        "malachi@.o.flynn.net",
+        "@",
+        "first.w@t.ch.",
+        "second.w@t..h",
+    ))
+    def test_invalid_emails(self, app, email_address):
+        with app.app_context():
+            form = EmailFieldFormatTestForm(
+                formdata=ImmutableMultiDict((
+                    ("test_email", email_address,),
+                )),
+                csrf_enabled=False,
+            )
+
+            assert form.validate() is False
+            assert "test_email" in form.errors
+
+    @pytest.mark.parametrize("email_address", (
+        "x@y.z",
+        "-second@wat.ch",
+        "123@321.12",
+        "   helter-Skelter_pelter-Welter@Who.do-you.call.him\t",
+        "a..............b@strangeface.fellowthatsolike_sawhimbefore.Chapwithawen",
+        ".man_in_the_street.@other.man.in.the.street   \n",
+        "-@-.-",  # probably not actually valid
+    ))
+    def test_valid_emails(self, app, email_address):
+        with app.app_context():
+            form = EmailFieldFormatTestForm(
+                formdata=ImmutableMultiDict((
+                    ("test_email", email_address,),
+                )),
+                csrf_enabled=False,
+            )
+
+            assert form.validate()
+            assert form.data["test_email"] == email_address.strip()
+
+
+class EmailFieldCombinationTestForm(Form):
+    required_email = EmailField(
+        "Required Electronic Mailing Address",
+        validators=[DataRequired(message="No really, we want this")],
+    )
+    optional_email = EmailField(
+        "Optional Electronic Mailing Address",
+        validators=[Optional()],
+    )
+    unspecified_email = EmailField("Voluntary Electronic Mailing Address")
+
+
+class TestEmailFieldCombination(object):
+    _invalid_address = "@inv@li..d.."
+    _valid_address = "v@li.d"
+
+    _possibilities = (_valid_address, _invalid_address, "")
+
+    @pytest.mark.parametrize(
+        "required_field_email,optional_field_email,unspecified_field_email",
+        product(_possibilities, repeat=3),
+    )
+    def test(self, app, required_field_email, optional_field_email, unspecified_field_email):
+        with app.app_context():
+            form = EmailFieldCombinationTestForm(
+                formdata=ImmutableMultiDict((
+                    ("required_email", required_field_email,),
+                    ("optional_email", optional_field_email,),
+                    ("unspecified_email", unspecified_field_email,),
+                )),
+                csrf_enabled=False,
+            )
+
+            assert form.validate() is bool(
+                required_field_email == self._valid_address and
+                optional_field_email != self._invalid_address and
+                unspecified_field_email == self._valid_address
+            )


### PR DESCRIPTION
Vaguely connected story: https://trello.com/c/V8bUSjq8/77-implement-an-email-sign-up-capability-for-suppliers-2

We have many uses of the following code copypasta'd around the dm:

```
email = StripWhitespaceStringField('Contact email', validators=[
    DataRequired(message="You must provide an email address"),
    Regexp("^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$", message="Please enter a valid email address")
])
```

Ignoring the fact that the regex isn't quite right (e.g. not a raw string literal!) it's not very nice to have this in bits around the place. So I've added an `EmailField` here centrally which we can try and get right - in that vein I've added a bunch of tests. Running these tests you'll note causes us to now depend on `Flask` and `Flask-WTF`.

Arguably we should be depending on at least wtforms anyway (and not just as a dev dependency) because it is *required* for some of the functionality of the package, we just happen to be using it from projects that already pull those deps in anyway. Anyway, probably not too important.

Note also I didn't include the `DataRequired` validation for this field as we want to allow maximum reuse (with optional fields too).