### PR TITLE
DMMailChimpClient: make subscribe_new_email_to_list more robust to exceptions

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '28.0.2'
+__version__ = '28.0.3'

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -75,7 +75,9 @@ class DMMailChimpClient(object):
             # mailchimp to never add them to mailchimp lists. In this case, we resort to allowing a failed API call (but
             # log) as a user of this method would unlikely be able to do anything as we have no control over this
             # behaviour.
-            if "looks fake or invalid, please enter a real email address." in e.response.json()["detail"]:
+            if getattr(e, "response", None) and (
+                "looks fake or invalid, please enter a real email address." in e.response.json()["detail"]
+            ):
                 self.logger.error(
                     "Expected error: Mailchimp failed to add user ({}) to list ({}). API error: The email address looks fake or invalid, please enter a real email address.".format(  # noqa
                         hashed_email,


### PR DESCRIPTION
Not all `RequestException`s have a usable `response` attribute (e.g. if they never managed to make their connection) so this much be checked before trying to access `.json()`