### PR TITLE
Log notify message ID from DMNotifyClient

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '28.1.0'
+__version__ = '28.2.0'

--- a/dmutils/email/__init__.py
+++ b/dmutils/email/__init__.py
@@ -2,3 +2,6 @@
 from dmutils.email.dm_mandrill import (
     send_email, generate_token, decode_invitation_token, decode_password_reset_token
 )
+
+from .exceptions import EmailError
+from .dm_notify import DMNotifyClient

--- a/dmutils/email/dm_notify.py
+++ b/dmutils/email/dm_notify.py
@@ -117,9 +117,10 @@ class DMNotifyClient(object):
             raise EmailError(str(e))
         self._update_cache(reference)
         self.logger.info(
-            "Sent {email_address} email with ref {ref} (template {template_id}) through Notify",
+            "Sent email with ref {ref} to {email_address} (id: {notify_id}, template: {template_id}) through Notify",
             extra=dict(
                 email_address=hash_string(email_address),
+                notify_id=response['id'],
                 template_id=template_id,
                 ref=reference,
             ),

--- a/dmutils/email/dm_notify.py
+++ b/dmutils/email/dm_notify.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Digital Marketplace Notify integration."""
-from collections import OrderedDict
-
 from flask import current_app
 from notifications_python_client import NotificationsAPIClient
 from notifications_python_client.errors import HTTPError
@@ -96,11 +94,11 @@ class DMNotifyClient(object):
         reference = reference or self.get_reference(email_address, template_id, personalisation)
         if not allow_resend and self.has_been_sent(reference):
             self.logger.info(
-                "Email with ref {ref} (template {template_id}) has already been sent to {email_address} through Notify",
+                "Email {reference} (template {template_id}) has already been sent to {email_address} through Notify",
                 extra=dict(
                     email_address=hash_string(email_address),
                     template_id=template_id,
-                    ref=reference,
+                    reference=reference,
                 ),
             )
             return
@@ -116,12 +114,12 @@ class DMNotifyClient(object):
             raise EmailError(str(e))
         self._update_cache(reference)
         self.logger.info(
-            "Sent email with ref {ref} to {email_address} (id: {notify_id}, template: {template_id}) through Notify",
+            "Sent email {reference} to {email_address} (id: {notify_id}, template: {template_id}) through Notify",
             extra=dict(
                 email_address=hash_string(email_address),
                 notify_id=response['id'],
                 template_id=template_id,
-                ref=reference,
+                reference=reference,
             ),
         )
         return response

--- a/dmutils/email/dm_notify.py
+++ b/dmutils/email/dm_notify.py
@@ -52,14 +52,13 @@ class DMNotifyClient(object):
         return reference in self.get_delivered_references()
 
     @staticmethod
-    def get_reference(email_address, template_id, personalisation=None, **kwargs):
+    def get_reference(email_address, template_id, personalisation=None):
         """
         Method to return the standard reference given the variables the email is sent with.
 
         :param email_address: Emails recipient
         :param template_id: Emails template ID on Notify
         :param personalisation: Template parameters
-        :param kwargs: Extra data passed to the reference eg. {'notes': 'Manual resend'}
         :return: Hashed string 'reference' to be passed to client.send_email_notification or self.send_email
         """
         personalisation_string = u','.join(
@@ -84,7 +83,7 @@ class DMNotifyClient(object):
             messages.append(message_string.format(**format_kwargs))
         return message_prefix + u', '.join(messages)
 
-    def send_email(self, email_address, template_id, personalisation=None, allow_resend=True):
+    def send_email(self, email_address, template_id, personalisation=None, allow_resend=True, reference=None):
         """
         Method to send an email using the Notify api.
 
@@ -94,7 +93,7 @@ class DMNotifyClient(object):
         :param allow_resend: if False instantiate the delivered reference cache and ensure we are not sending duplicates
         :return: response from the api. For more information see https://github.com/alphagov/notifications-python-client
         """
-        reference = self.get_reference(email_address, template_id, personalisation)
+        reference = reference or self.get_reference(email_address, template_id, personalisation)
         if not allow_resend and self.has_been_sent(reference):
             self.logger.info(
                 "Email with ref {ref} (template {template_id}) has already been sent to {email_address} through Notify",

--- a/tests/email/test_dm_notify.py
+++ b/tests/email/test_dm_notify.py
@@ -110,6 +110,18 @@ class TestDMNotifyClient(object):
                 reference='niC4qhMflcnl8MkY82N7Gqze2ZA7ed1pSBTGnxeDPj0='
             )
 
+    def test_send_email_with_external_reference(self, dm_notify_client, notify_send_email):
+        with mock.patch(self.client_class_str + '.' + 'send_email_notification') as email_mock:
+            email_mock.return_value = notify_send_email
+            dm_notify_client.send_email(self.email_address, self.template_id, reference='abc')
+
+            email_mock.assert_called_with(
+                self.email_address,
+                self.template_id,
+                personalisation=None,
+                reference='abc'
+            )
+
     def test_personalisation_passed(self, dm_notify_client, notify_send_email):
         """Assert the expected existence of personalisation."""
         personalisation = {u'f\u00a3oo': u'bar\u00a3'}

--- a/tests/email/test_dm_notify.py
+++ b/tests/email/test_dm_notify.py
@@ -222,7 +222,7 @@ class TestDMNotifyClient(object):
         """Trigger identical emails and make sure only one is sent!"""
         with mock.patch(self.client_class_str + '.' + 'send_email_notification') as send_email_notification_mock:
             with mock.patch(self.client_class_str + '.' + 'get_all_notifications') as get_all_notifications_mock:
-                send_email_notification_mock.return_value = True
+                send_email_notification_mock.return_value = {'id': 'example-id'}
                 get_all_notifications_mock.return_value = {"notifications": []}
                 dm_notify_client.send_email(self.email_address, self.template_id, allow_resend=False)
                 dm_notify_client.send_email(self.email_address, self.template_id, allow_resend=False)


### PR DESCRIPTION
Notification IDs can be used to lookup the message details in the
Notify interface and they should be safe to log since they require
permissions on Notify to view.

This also moves EmailError and DMNotifyClient imports to `dmutils.email`
to make them easier to access.