### PR TITLE
Fix a typo in invalid token error message

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '28.2.0'
+__version__ = '28.2.1'

--- a/dmutils/email/dm_mandrill.py
+++ b/dmutils/email/dm_mandrill.py
@@ -202,7 +202,7 @@ def decode_invitation_token(encoded_token):
             }
 
         except fernet.InvalidToken as invalid_token_error:
-            current_app.logger.info("Invitation reset attempt with invalid token. error {invalid_token_error}",
+            current_app.logger.info("Invitation reset attempt with invalid token. error {error}",
                                     extra={'error': six.text_type(invalid_token_error)})
 
             return {'error': 'token_invalid'}


### PR DESCRIPTION
`{invalid_error_token}` in format string causes an exception since it doesn't match the `'error'` key in `extra` dict.