### PR TITLE
Move ODS module from briefs-frontend and add general DownloadFileView

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 .cache
 venv*
+.hypothesis

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '28.7.0'
+__version__ = '28.8.0'

--- a/dmutils/csv_generator.py
+++ b/dmutils/csv_generator.py
@@ -18,9 +18,9 @@ class _StringPipe(object):
         return retval
 
 
-def iter_csv(row_iter):
+def iter_csv(row_iter, **kwargs):
     pipe = _StringPipe()
-    writer = unicodecsv.writer(pipe)
+    writer = unicodecsv.writer(pipe, **kwargs)
     for row in row_iter:
         writer.writerow(row)
         yield pipe.read()

--- a/dmutils/ods.py
+++ b/dmutils/ods.py
@@ -1,0 +1,102 @@
+from odf.element import Element
+from odf.namespaces import OFFICENS
+from odf.opendocument import OpenDocumentSpreadsheet
+from odf.style import Style
+from odf.table import Table, TableColumn, TableRow, TableCell, CoveredTableCell
+from odf.text import P, A  # noqa (used by frontend apps)
+
+
+class Row(object):
+    def __init__(self, **kwargs):
+        self._row = TableRow(**kwargs)
+
+    def write_cell(self, value, **kwargs):
+        if "numbercolumnsspanned" in kwargs or "numberrowsspanned" in kwargs:
+            kwargs.setdefault("numberrowsspanned", "1")
+            kwargs.setdefault("numbercolumnsspanned", "1")
+
+        cell = TableCell(**kwargs)
+        cell.setAttrNS(OFFICENS, "value-type", "string")
+
+        if isinstance(value, Element):
+            para = P()
+            para.addElement(value)
+            cell.addElement(para)
+        else:
+            for line in value.split("\n"):
+                cell.addElement(P(text=line))
+
+        self._row.addElement(cell)
+
+    def write_cells(self, cells, **kwargs):
+        for cell in cells:
+            self.write_cell(value=cell, **kwargs)
+
+    def write_covered_cell(self):
+        self._row.addElement(CoveredTableCell())
+
+
+class Sheet(object):
+    def __init__(self, name):
+        self._table = Table(name=name)
+        self._rows = {}
+
+    def create_row(self, name, **kwargs):
+        """Create an empty row to manually insert cells"""
+        self._rows[name] = Row(**kwargs)
+        self._table.addElement(self._rows[name]._row)
+
+        return self._rows[name]
+
+    def write_row(self, name, cells, row_styles={}, cell_styles={}):
+        """Create a new row and populate it with the given cells"""
+        row = self.create_row(name, **row_styles)
+        row.write_cells(cells, **cell_styles)
+
+    def get_row(self, name):
+        return self._rows[name]
+
+    def create_column(self, **kwargs):
+        column = TableColumn(**kwargs)
+
+        self._table.addElement(column)
+
+    def read_cell(self, x, y):
+        try:
+            cell = self._table.getElementsByType(TableRow)[y].childNodes[x]
+        except IndexError:
+            return ''
+
+        result = []
+
+        for element in cell.childNodes:
+            result.append("".join([v.data for v in element.childNodes]))
+
+        return "\n".join(result)
+
+
+class SpreadSheet(object):
+    def __init__(self):
+        self._document = OpenDocumentSpreadsheet()
+        self._sheets = {}
+
+    def sheet(self, name):
+        if name not in self._sheets:
+            self._sheets[name] = Sheet(name)
+            self._document.spreadsheet.addElement(self._sheets[name]._table)
+
+        return self._sheets[name]
+
+    def add_style(self, name, family, styles, **kwargs):
+        style = Style(name=name, family=family, **kwargs)
+
+        for v in styles:
+            style.addElement(v)
+
+        self._document.automaticstyles.addElement(style)
+
+    def add_font(self, fontface):
+        self._document.fontfacedecls.addElement(fontface)
+
+    def save(self, buf):
+        return self._document.save(buf)

--- a/dmutils/views.py
+++ b/dmutils/views.py
@@ -1,0 +1,225 @@
+from abc import ABCMeta, abstractmethod
+import csv
+import enum
+from flask import abort, request, Response
+from flask.views import View
+from io import BytesIO
+from odf.style import TextProperties, TableRowProperties, TableColumnProperties, TableCellProperties, FontFace
+import six
+
+from dmutils import csv_generator
+from dmutils import ods
+
+
+@six.add_metaclass(ABCMeta)
+class DownloadFileView(View):
+    """An abstract base class appropriate for subclassing in the frontend apps when the user needs to be able to
+    download some data as a CSV or ODS file. All abstract methods must be implemented on the subclass (although example
+    implementations are included here with the kind of return value expected); all other methods should be able to
+    be left alone to support handling and dispatching the request."""
+
+    FILETYPES = enum.Enum('Filetypes', ['CSV', 'ODS'])
+
+    def __init__(self, **kwargs):
+        self.request = request
+
+        self.data_api_client = None
+        self.search_api_client = None
+        self.content_loader = None
+
+        super(View, self).__init__(**kwargs)
+
+    @abstractmethod
+    def _init_hook(self, **kwargs):
+        """Hook into the start of the request to associate required clients/loaders with the instance and perform any
+        other logic required for the start of the request."""
+        self.data_api_client = None
+        self.search_api_client = None
+        self.content_loader = None
+
+    def _post_request_hook(self, response=None, file_context=None, **kwargs):
+        """A hook that can be used to implement any logic that should be run after the main download file process,
+        and immediately before sending the response to the user."""
+        pass
+
+    @abstractmethod
+    def get_file_context(self, **kwargs):
+        """Must return a dictionary containing any data required by the generation routines.
+
+        Required keys:
+         * `filename`: without a file extension
+         * `sheetname`: the name of the first sheet in the ODS file (assumption: single sheeted spreadsheet)"""
+        return {'filename': 'my-download', 'sheetname': 'Sheet 1'}
+
+    @abstractmethod
+    def determine_filetype(self, file_context=None, **kwargs):
+        """Logic to tell the View which filetype to generate; must return a choice from DownloadFileView.FILETYPES"""
+        return DownloadFileView.FILETYPES.ODS
+
+    @abstractmethod
+    def generate_csv_rows(self, file_context):
+        """Must return a nested iterable of rows+cells, eg [[heading1, heading2], [data1, data2], ...]"""
+        return [['Heading 1', 'Heading 2'], ['Row 1, Column 1', 'Row 1, Column 2']]
+
+    @abstractmethod
+    def populate_styled_ods_with_data(self, spreadsheet, file_context):
+        """Takes an empty dmutils.ods.SpreadSheet (with required fonts/styles already added) and populates the required
+        data into it."""
+        sheet = spreadsheet.sheet(file_context['sheetname'])
+        sheet.write_row(name='header', cells=['Heading 1', 'Heading 2'])
+        sheet.write_row(name='row1', cells=['Row 1, Column 1', 'Row 1, Column 2'])
+
+    @staticmethod
+    def create_blank_ods_with_styles():
+        """Create a dmutils.ods.SpreadSheet pre-configured with some default styles, ready for population with data
+        appropriate for the subclass View. Modifications here (except adding styles) are likely breaking changes."""
+        spreadsheet = ods.SpreadSheet()
+
+        # Add the font we will use for the entire spreadsheet.
+        spreadsheet.add_font(FontFace(name="Arial", fontfamily="Arial"))
+
+        # Add some default styles for columns.
+        spreadsheet.add_style("col-default", "table-column", (
+            TableColumnProperties(breakbefore="auto"),
+        ), parentstylename="Default")
+
+        spreadsheet.add_style("col-wide", "table-column", (
+            TableColumnProperties(columnwidth="150pt", breakbefore="auto"),
+        ), parentstylename="Default")
+
+        spreadsheet.add_style("col-extra-wide", "table-column", (
+            TableColumnProperties(columnwidth="300pt", breakbefore="auto"),
+        ), parentstylename="Default")
+
+        # Add some default styles for rows.
+        spreadsheet.add_style("row-default", "table-row", (
+            TableRowProperties(breakbefore="auto", useoptimalrowheight="false"),
+        ), parentstylename="Default")
+
+        spreadsheet.add_style("row-tall", "table-row", (
+            TableRowProperties(breakbefore="auto", rowheight="30pt", useoptimalrowheight="false"),
+        ), parentstylename="Default")
+
+        spreadsheet.add_style("row-tall-optimal", "table-row", (
+            TableRowProperties(breakbefore="auto", rowheight="30pt", useoptimalrowheight="true"),
+        ), parentstylename="Default")
+
+        # Add some default styles for cells.
+        spreadsheet.add_style("cell-default", "table-cell", (
+            TableCellProperties(wrapoption="wrap", verticalalign="top"),
+            TextProperties(fontfamily="Arial", fontnameasian="Arial", fontnamecomplex="Arial", fontsize="11pt"),
+        ), parentstylename="Default")
+
+        spreadsheet.add_style("cell-header", "table-cell", (
+            TableCellProperties(wrapoption="wrap", verticalalign="top"),
+            TextProperties(fontfamily="Arial", fontnameasian="Arial", fontnamecomplex="Arial", fontsize="11pt",
+                           fontweight="bold"),
+        ), parentstylename="Default")
+
+        return spreadsheet
+
+    def create_response(self, file_context, file_type):
+        if file_type == DownloadFileView.FILETYPES.CSV:
+            body = csv_generator.iter_csv(self.generate_csv_rows(file_context), quoting=csv.QUOTE_ALL)
+
+            mimetype = 'text/csv; header=present'
+
+        elif file_type == DownloadFileView.FILETYPES.ODS:
+            buffer = BytesIO()
+
+            ods = self.create_blank_ods_with_styles()
+            self.populate_styled_ods_with_data(ods, file_context)
+            ods.save(buffer)
+
+            body = buffer.getvalue()
+
+            mimetype = 'application/vnd.oasis.opendocument.spreadsheet'
+
+        else:
+            abort(400)
+
+        content_disposition = 'attachment;filename={}.{}'.format(file_context['filename'], file_type.name.lower())
+
+        return Response(
+            body,
+            mimetype=mimetype,
+            headers={
+                "Content-Disposition": content_disposition,
+                "Content-Type": mimetype
+            }
+        ), 200
+
+    def dispatch_request(self, **kwargs):
+        self._init_hook(**kwargs)
+
+        file_context = self.get_file_context(**kwargs)
+        file_type = self.determine_filetype(file_context, **kwargs)
+
+        if not isinstance(file_type, enum.Enum) or file_type.name not in DownloadFileView.FILETYPES.__members__:
+            abort(400)
+
+        response = self.create_response(file_context, file_type)
+
+        self._post_request_hook(response, **kwargs)
+        return response
+
+
+@six.add_metaclass(ABCMeta)
+class SimpleDownloadFileView(DownloadFileView):
+    """A slightly simplier version of the DownloadFileView where it is possible to have a single source of data
+    for all download filetypes. If you want a fairly simple structure to your spreadsheet (in effect, a single sheet,
+    with self-contained rows where cells don't span rows or columns), you can implement only `get_file_data_and_styles`
+    to work with all supported filetypes."""
+    @abstractmethod
+    def get_file_data_and_column_styles(self, file_context):
+        """Example implementation with basic styling"""
+        file_rows = []
+
+        # Assign the column styles
+        column_styles = [
+            {'stylename': 'col-default', 'defaultcellstylename': 'cell-default'},  # Header 1
+            {'stylename': 'col-default', 'defaultcellstylename': 'cell-default'},  # Header 2
+        ]
+
+        # Headers
+        file_rows.append({
+            'cells': ['Header 1', 'Header 2'],
+            'meta': {'name': 'header',
+                     'row_styles': {'stylename': 'row-default'},
+                     'cell_styles': {'stylename': 'cell-header'}},
+        })
+
+        # Data
+        rows = [['Row 1, Column 1', 'Row 1, Column 2'], ['Row 2, Column 1', 'Row 2, Column 2']]
+        for i, row in enumerate(rows):
+            file_rows.append({
+                'cells': row,
+                'meta': {'name': 'row-{}'.format(i),
+                         'row_styles': {'stylename': 'row-default'},
+                         'cell_styles': {'stylename': 'cell-default'}},
+            })
+
+        return file_rows, column_styles
+
+    def generate_csv_rows(self, file_context):
+        """Must return a nested iterable of iterables containing the data to be written out to csv"""
+        file_rows, _ = self.get_file_data_and_column_styles(file_context)
+
+        return [row['cells'] for row in file_rows]
+
+    def populate_styled_ods_with_data(self, spreadsheet, file_context):
+        """Must return an instance of dmutils.ods.SpreadSheet populated with the required data."""
+        file_rows, column_styles = self.get_file_data_and_column_styles(file_context)
+        sheet = spreadsheet.sheet(file_context.get('sheetname', 'Sheet 1'))
+
+        # Add the column styles
+        for column_style in column_styles:
+            sheet.create_column(**column_style)
+
+        # Add the data
+        for file_row in file_rows:
+            row_name = file_row['meta'].get('name')
+            write_row_kwargs = file_row['meta'].copy()
+            del write_row_kwargs['name']
+
+            sheet.write_row(name=row_name, cells=file_row['cells'], **write_row_kwargs)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ coverage==3.7.1
 flake8==2.6.2
 flake8-putty==0.4.0
 freezegun==0.3.4
+hypothesis==3.6.1
 mock==2.0.0
 moto==0.4.31
 pytest==2.8.7

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
          'mandrill==1.0.57',
          'monotonic==0.3',
          'notifications-python-client==4.1.0',
+         'odfpy==1.3.3',
          'python-json-logger==0.1.4',
          'pytz==2015.4',
          'pyyaml==3.11',

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,12 @@
+def get_file_data_and_column_styles():
+    return ([{'cells': ['head 1', 'head 2'], 'meta': {'name': 'header'}},
+             {'cells': ['data 1.1', 'data 1.2'], 'meta': {'name': 'row-1'}},
+             {'cells': ['data 2.1', 'data 2.2'], 'meta': {'name': 'row-2',
+                                                          'row_styles': 'row-default'}},
+             {'cells': ['data 3.1', 'data 3.2'], 'meta': {'name': 'row-3', 'row_styles': 'row-default',
+                                                          'cell_styles': 'cell-default'}}],
+            [{'stylename': 'col-default'}, {'stylename': 'col-wide'}])
+
+
+def get_expected_csv_response_for_download_file_view():
+    return '"Heading 1","Heading 2"\r\n"Row 1, Column 1","Row 1, Column 2"\r\n'

--- a/tests/test_ods.py
+++ b/tests/test_ods.py
@@ -1,0 +1,214 @@
+import mock
+import functools
+
+import dmutils.ods as ods
+
+from hypothesis import strategies as st
+from hypothesis import given, example
+
+po = functools.partial(mock.patch.object, autospec=True)
+
+
+class TestRow(object):
+
+    @given(st.dictionaries(st.text(), st.text()))
+    def test___init__(self, kwargs):
+        with po(ods, 'TableRow') as TableRow:
+            instance = ods.Row(**kwargs)
+
+        TableRow.assert_called_once_with(**kwargs)
+
+        assert instance._row == TableRow.return_value
+
+    @given(st.text(), st.dictionaries(st.text(), st.text()))
+    @example("", {"numberrowsspanned": '1'})
+    @example("", {"numbercolumnsspanned": '1'})
+    def test_write_cell(self, value, kwargs):
+        instance = ods.Row()
+
+        instance._row = mock.MagicMock(spec_set=instance._row)
+
+        expected = dict(**kwargs)
+
+        if "numbercolumnsspanned" in kwargs:
+            expected.setdefault("numberrowsspanned", "1")
+
+        if "numberrowsspanned" in kwargs:
+            expected.setdefault("numbercolumnsspanned", "1")
+
+        ps = [mock.Mock() for v in value.split("\n")]
+
+        with po(ods, 'TableCell') as TableCell:
+            with po(ods, 'P') as P:
+                P.side_effect = iter(ps)
+                instance.write_cell(value, **kwargs)
+
+        TableCell.assert_called_once_with(**expected)
+
+        cell = TableCell.return_value
+        cell.setAttrNS.assert_called_once_with(ods.OFFICENS, 'value-type',
+                                               'string')
+
+        P.assert_has_calls([mock.call(text=line) for line in value.split("\n")])
+
+        cell.addElement.assert_has_calls([mock.call(e) for e in ps], True)
+
+        instance._row.addElement.assert_called_once_with(cell)
+
+    def test_write_covered_cell(self):
+        instance = ods.Row()
+
+        instance._row = mock.MagicMock(spec_set=instance._row)
+
+        with po(ods, 'CoveredTableCell') as CoveredTableCell:
+            instance.write_covered_cell()
+
+        cell = CoveredTableCell.return_value
+
+        instance._row.addElement.assert_called_once_with(cell)
+
+
+class TestSheet(object):
+    @given(st.text())
+    def test___init__(self, name):
+        with po(ods, 'Table') as Table:
+            instance = ods.Sheet(name)
+
+        Table.assert_called_once_with(name=name)
+
+        assert instance._table == Table.return_value
+
+        assert instance._rows == {}
+
+    @given(st.text().map(ods.Sheet), st.text(),
+           st.dictionaries(st.text(), st.text()))
+    def test_create_row(self, instance, name, kwargs):
+        instance._table = mock.MagicMock(spec_set=instance._table)
+
+        with mock.patch.object(ods, 'Row') as Row:
+            result = instance.create_row(name, **kwargs)
+
+        Row.assert_called_once_with(**kwargs)
+
+        assert instance._rows[name] == Row.return_value
+
+        assert result == Row.return_value
+
+        instance._table.addElement\
+                .assert_called_once_with(Row.return_value._row)
+
+    @given(st.text().map(ods.Sheet), st.text())
+    def test_get_row(self, instance, name):
+        instance._rows[name] = expected = mock.Mock()
+
+        with po(ods, 'Row'):
+            assert expected == instance.get_row(name)
+
+    @given(st.text().map(ods.Sheet), st.dictionaries(st.text(), st.text()))
+    def test_create_column(self, instance, kwargs):
+        instance._table = mock.MagicMock(spec_set=instance._table)
+
+        with po(ods, 'TableColumn') as TableColumn:
+            instance.create_column(**kwargs)
+
+        TableColumn.assert_called_once_with(**kwargs)
+
+        instance._table.addElement\
+                .assert_called_once_with(TableColumn.return_value)
+
+    @given(st.text().map(ods.Sheet),
+           st.tuples(st.integers(min_value=0, max_value=15),
+                     st.integers(min_value=0, max_value=15))
+             .flatmap(lambda x: st.lists(st.lists(st.one_of(st.text(),
+                                                            st.none()),
+                                                  min_size=x[0], max_size=x[0]),
+                                         min_size=x[0], max_size=x[0])),
+           st.integers(min_value=-5, max_value=20),
+           st.integers(min_value=-5, max_value=20))
+    def test_read_cell(self, instance, data, x, y):
+        for i, values in enumerate(data):
+            instance.create_column()
+            row = instance.create_row('row{}'.format(i))
+
+            for value in values:
+                if value is None:
+                    row.write_covered_cell()
+                else:
+                    row.write_cell(value)
+
+        try:
+            expect = data[y][x]
+        except IndexError:
+            expect = ''
+
+        assert instance.read_cell(x, y) == (expect or '')
+
+
+class TestSpreadSheet(object):
+    def test___init__(self):
+        with po(ods, 'OpenDocumentSpreadsheet') as OpenDocumentSpreadsheet:
+            instance = ods.SpreadSheet()
+
+        OpenDocumentSpreadsheet.assert_called_once_with()
+
+        assert instance._document == OpenDocumentSpreadsheet.return_value
+        assert instance._sheets == {}
+
+    @given(st.text())
+    def test_sheet(self, name):
+        instance = ods.SpreadSheet()
+        instance._document = mock.MagicMock(spec_set=instance._document)
+
+        with mock.patch.object(ods, 'Sheet') as Sheet:
+            result1 = instance.sheet(name)
+            result2 = instance.sheet(name)
+
+        assert result1 == Sheet.return_value
+        assert result2 == Sheet.return_value
+        assert instance._sheets[name] == Sheet.return_value
+
+        Sheet.assert_called_once_with(name)
+
+        instance._document.spreadsheet.addElement\
+                .assert_called_once_with(Sheet.return_value._table)
+
+    @given(st.text(), st.text(), st.integers(min_value=0, max_value=10),
+           st.dictionaries(st.text(), st.text()))
+    def test_add_style(self, name, family, count, kwargs):
+        styles = [mock.Mock() for v in range(count)]
+
+        instance = ods.SpreadSheet()
+        instance._document = mock.MagicMock(spec_set=instance._document)
+
+        with po(ods, 'Style') as Style:
+            instance.add_style(name, family, styles, **kwargs)
+
+        Style.assert_called_once_with(name=name, family=family, **kwargs)
+
+        Style.return_value.addElement\
+             .assert_has_calls([mock.call(style) for style in styles], True)
+
+        instance._document.automaticstyles.addElement\
+                .assert_called_once_with(Style.return_value)
+
+    def test_add_font(self):
+        instance = ods.SpreadSheet()
+        instance._document = mock.MagicMock(spec_set=instance._document)
+
+        fontface = mock.Mock()
+
+        instance.add_font(fontface)
+
+        instance._document.fontfacedecls.addElement\
+                .assert_called_once_with(fontface)
+
+    def save(self):
+        instance = ods.SpreadSheet()
+        instance._document = mock.MagicMock(spec_set=instance._document)
+
+        buf = mock.Mock()
+        fontface = mock.Mock()
+
+        instance.add_font(fontface)
+
+        instance._document.save.assert_called_once_with(buf)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,185 @@
+from builtins import str, bytes  # py2/3 compatible unicode-str
+from flask import Response
+import six
+from werkzeug.exceptions import BadRequest
+
+import mock
+import pytest
+
+from dmutils.views import DownloadFileView, SimpleDownloadFileView
+
+import fixtures
+
+
+class TestDownloadFileView():
+    def setup(self):
+        self._saved__abstract_methods__ = DownloadFileView.__abstractmethods__
+        DownloadFileView.__abstractmethods__ = set()
+
+        self.kwargs = {'arg1': 'foo', 'arg2': 'bar'}
+        self.view = DownloadFileView()
+
+        self._patch_determine_filetype = mock.patch.object(self.view, 'determine_filetype', autospec=True)
+        self._patch_determine_filetype.start()
+        self.view.determine_filetype.return_value = DownloadFileView.FILETYPES.ODS
+
+        self._patch_get_file_context = mock.patch.object(self.view, 'get_file_context', autospec=True)
+        self._patch_get_file_context.start()
+
+        self._patch_create_response = mock.patch.object(self.view, 'create_response', autospec=True)
+        self._patch_create_response.start()
+        self.view.create_response.return_value = (Response(), 200)
+
+        self._patch_init_hook = mock.patch.object(self.view, '_init_hook', autospec=True)
+        self._patch_init_hook.start()
+
+        self._patch_post_request_hook = mock.patch.object(self.view, '_post_request_hook', autospec=True)
+        self._patch_post_request_hook.start()
+
+    def teardown(self):
+        DownloadFileView.__abstractmethods__ = DownloadFileView.__abstractmethods__
+
+        for patch in [self._patch_determine_filetype, self._patch_get_file_context, self._patch_create_response,
+                      self._patch_init_hook, self._patch_post_request_hook]:
+            try:
+                patch.stop()
+            except RuntimeError:
+                pass
+
+    def test_abstract_methods_required_for_instantiation(self):
+        DownloadFileView.__abstractmethods__ = self._saved__abstract_methods__
+
+        with pytest.raises(TypeError) as e:
+            DownloadFileView()
+
+        assert str(e.value) == "Can't instantiate abstract class DownloadFileView with abstract methods " \
+                               "_init_hook, determine_filetype, generate_csv_rows, get_file_context, " \
+                               "populate_styled_ods_with_data"
+
+    def test_create_blank_ods_with_styles(self):
+        """Assert that, at a minimum, the styles exist."""
+        spreadsheet = self.view.create_blank_ods_with_styles()
+
+        style_names = ['col-default', 'col-wide', 'col-extra-wide',
+                       'row-default', 'row-tall', 'row-tall-optimal',
+                       'cell-default', 'cell-header']
+        for style_name in style_names:
+            assert spreadsheet._document.getStyleByName(six.text_type(style_name)) is not None
+
+    def test_create_response_csv(self):
+        kwargs = {'filename': 'test'}
+        mimetype = "text/csv"
+        content_type = "text/csv; header=present; charset=utf-8"
+
+        self._patch_create_response.stop()
+
+        res, status_code = self.view.create_response(kwargs, DownloadFileView.FILETYPES['CSV'])
+
+        assert res.get_data(as_text=True) == fixtures.get_expected_csv_response_for_download_file_view()
+        assert res.mimetype == mimetype
+        assert res.headers['Content-Type'] == content_type
+        assert res.headers['Content-Disposition'] == 'attachment;filename={}.csv'.format(kwargs['filename'])
+        assert status_code == 200
+
+    def test_create_response_ods(self):
+        spreadsheet = self.view.create_blank_ods_with_styles()
+        self._patch_create_blank_ods_with_styles = mock.patch.object(self.view, 'create_blank_ods_with_styles',
+                                                                     autospec=True)
+        self._patch_create_blank_ods_with_styles.start()
+        self.view.create_blank_ods_with_styles.return_value = spreadsheet
+
+        kwargs = {'filename': 'test', 'sheetname': 'sheet'}
+        mimetype = "application/vnd.oasis.opendocument.spreadsheet"
+        content_type = mimetype
+
+        self._patch_create_response.stop()
+
+        res, status_code = self.view.create_response(kwargs, DownloadFileView.FILETYPES['ODS'])
+
+        # Can't test res.get_data() directly because the result is not fixed (i.e. some aspect of the file changes
+        # based on creation time, so let's test the cells themselves.
+        assert type(res) == Response
+        assert bytes(mimetype, encoding='utf-8') in res.get_data()
+        assert len(res.get_data()) >= 1700 and len(res.get_data()) <= 1800
+
+        sheet = spreadsheet._sheets['sheet']
+        assert sheet.read_cell(0, 0) == 'Heading 1'
+        assert sheet.read_cell(1, 0) == 'Heading 2'
+        assert sheet.read_cell(0, 1) == 'Row 1, Column 1'
+        assert sheet.read_cell(1, 1) == 'Row 1, Column 2'
+
+        assert res.mimetype == mimetype
+        assert res.headers['Content-Type'] == content_type
+        assert res.headers['Content-Disposition'] == 'attachment;filename={}.ods'.format(kwargs['filename'])
+        assert status_code == 200
+
+    def test_dispatch_request(self):
+        result = self.view.dispatch_request(**self.kwargs)
+        assert result is self.view.create_response.return_value
+
+        assert self.view._init_hook.call_args_list == [mock.call(**self.kwargs)]
+        assert self.view._post_request_hook.call_args_list == [mock.call(result, **self.kwargs)]
+
+        assert self.view.get_file_context.call_args_list == [mock.call(**self.kwargs)]
+        assert self.view.determine_filetype.call_args_list == [mock.call(self.view.get_file_context.return_value,
+                                                                         **self.kwargs)]
+
+    def test_dispatch_request_400s_on_unknown_filetype(self):
+        self.view.determine_filetype.return_value = 'DOCX'
+
+        with pytest.raises(BadRequest) as e:
+            self.view.dispatch_request(**self.kwargs)
+
+        assert e.value.code == 400
+
+
+class TestSimpleDownloadFileView:
+    def setup(self):
+        self.fixture_data_styles = fixtures.get_file_data_and_column_styles()
+
+        self._saved__abstract_methods__ = SimpleDownloadFileView.__abstractmethods__
+        SimpleDownloadFileView.__abstractmethods__ = set()
+
+        self.view = SimpleDownloadFileView()
+
+        self._patch_get_file_data_and_column_styles = mock.patch.object(self.view, 'get_file_data_and_column_styles',
+                                                                        autospec=True)
+        self._patch_get_file_data_and_column_styles.start()
+        self.view.get_file_data_and_column_styles.return_value = self.fixture_data_styles
+
+    def teardown(self):
+        SimpleDownloadFileView.__abstractmethods__ = SimpleDownloadFileView.__abstractmethods__
+
+        for patch in [self._patch_get_file_data_and_column_styles]:
+            try:
+                patch.stop()
+            except RuntimeError:
+                pass
+
+    def test_abstract_methods_required_for_instantiation(self):
+        SimpleDownloadFileView.__abstractmethods__ = self._saved__abstract_methods__
+
+        with pytest.raises(TypeError) as e:
+            SimpleDownloadFileView()
+
+        assert str(e.value) == "Can't instantiate abstract class SimpleDownloadFileView with abstract methods " \
+                               "_init_hook, determine_filetype, get_file_context, get_file_data_and_column_styles"
+
+    def test_generate_csv_rows(self):
+
+        csv_rows = self.view.generate_csv_rows({})
+        assert csv_rows == [row['cells'] for row in self.fixture_data_styles[0]]
+
+    def test_populate_styled_ods_with_data(self):
+        spreadsheet_mock = mock.Mock()
+        spreadsheet_mock.sheet.return_value = sheet_mock = mock.Mock()
+
+        self.view.populate_styled_ods_with_data(spreadsheet_mock, {})
+
+        call_args_list = [mock.call(**styles) for styles in self.fixture_data_styles[1]]
+        assert sheet_mock.create_column.call_count == len(self.fixture_data_styles[1])
+        assert sheet_mock.create_column.call_args_list == call_args_list
+
+        call_args_list = [mock.call(cells=row['cells'], **row.get('meta', {})) for row in self.fixture_data_styles[0]]
+        assert sheet_mock.write_row.call_count == len(self.fixture_data_styles[0])
+        assert sheet_mock.write_row.call_args_list == call_args_list


### PR DESCRIPTION
## Summary
The briefs-frontend has a module to help construct ODS files. We now need to make ODSs in the buyer-frontend for service shortlist downloads, so let's move it to utils.

I've also added a generic `DownloadFileView` that is subclassed in the buyer-frontend (and should be reasonably compatible with the briefs-frontend download view, which I will put up in a separate PR later). This draws out the duplication from the view and lets the subclass only implement the logic and structure required for the csv/ods files, while the parent handles receiving the request and returning the response. Hooks are included for the start and end of the request to allow further logic to be executed at these stages (the shortlist download needs to record the action if the response succeeds).

Bumps version to 28.6.0.

## Blocked by
* [x] Need to write tests for the DownloadFileView.

## Required by
https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/615
https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/32

## Other associated PRs
https://github.com/alphagov/digitalmarketplace-api/pull/656
~~https://github.com/alphagov/digitalmarketplace-apiclient/pull/98~~
~~https://github.com/alphagov/digitalmarketplace-frameworks/pull/473~~

## Ticket
https://trello.com/c/igRhA3Bt/711-shortlist-file-download