### PR TITLE
Create user account email class

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '28.3.0'
+__version__ = '28.4.0'

--- a/dmutils/email/__init__.py
+++ b/dmutils/email/__init__.py
@@ -6,3 +6,4 @@ from dmutils.email.tokens import (
 
 from .exceptions import EmailError
 from .dm_notify import DMNotifyClient
+from .user_account_email import UserAccountEmail

--- a/dmutils/email/__init__.py
+++ b/dmutils/email/__init__.py
@@ -6,4 +6,4 @@ from dmutils.email.tokens import (
 
 from .exceptions import EmailError
 from .dm_notify import DMNotifyClient
-from .user_account_email import UserAccountEmail
+from .user_account_email import send_user_account_email

--- a/dmutils/email/user_account_email.py
+++ b/dmutils/email/user_account_email.py
@@ -1,0 +1,40 @@
+from flask import current_app, session, abort
+from . import DMNotifyClient, generate_token, EmailError
+from .helpers import hash_string
+
+
+class UserAccountEmail():
+
+    def __init__(self, token_data, template_id):
+        self.role = token_data['role']
+        self.email_address = token_data['email_address']
+        self.token = self._generate_create_token(token_data)
+        self.template_id = template_id
+
+    def send_email(self, personalisation):
+        notify_client = DMNotifyClient(current_app.config['DM_NOTIFY_API_KEY'])
+
+        try:
+            notify_client.send_email(
+                self.email_address,
+                template_id=self.template_id,
+                personalisation=personalisation,
+                reference='create-user-account-{}'.format(hash_string(self.email_address))
+            )
+            session['email_sent_to'] = self.email_address
+        except EmailError as e:
+            current_app.logger.error(
+                "{code}: Create user email for email_hash {email_hash} failed to send. Error: {error}",
+                extra={
+                    'error': str(e),
+                    'email_hash': hash_string(self.email_address),
+                    'code': '{}create.fail'.format(self.role)
+                })
+            abort(503, response="Failed to send user creation email.")
+
+    def _generate_create_token(self, token_data):
+        return generate_token(
+            token_data,
+            current_app.config['SHARED_EMAIL_KEY'],
+            current_app.config['INVITE_EMAIL_SALT']
+        )

--- a/dmutils/email/user_account_email.py
+++ b/dmutils/email/user_account_email.py
@@ -1,40 +1,42 @@
-from flask import current_app, session, abort
+from flask import current_app, session, abort, url_for
 from . import DMNotifyClient, generate_token, EmailError
 from .helpers import hash_string
 
 
-class UserAccountEmail():
+def send_user_account_email(role, email_address, template_id, extra_token_data={}, personalisation={}):
+    notify_client = DMNotifyClient(current_app.config['DM_NOTIFY_API_KEY'])
 
-    def __init__(self, token_data, template_id):
-        self.role = token_data['role']
-        self.email_address = token_data['email_address']
-        self.token = self._generate_create_token(token_data)
-        self.template_id = template_id
+    token_data = {
+        'role': role,
+        'email_address': email_address
+    }
+    token_data.update(extra_token_data)
 
-    def send_email(self, personalisation):
-        notify_client = DMNotifyClient(current_app.config['DM_NOTIFY_API_KEY'])
+    token = generate_token(
+        token_data,
+        current_app.config['SHARED_EMAIL_KEY'],
+        current_app.config['INVITE_EMAIL_SALT']
+    )
 
-        try:
-            notify_client.send_email(
-                self.email_address,
-                template_id=self.template_id,
-                personalisation=personalisation,
-                reference='create-user-account-{}'.format(hash_string(self.email_address))
-            )
-            session['email_sent_to'] = self.email_address
-        except EmailError as e:
-            current_app.logger.error(
-                "{code}: Create user email for email_hash {email_hash} failed to send. Error: {error}",
-                extra={
-                    'error': str(e),
-                    'email_hash': hash_string(self.email_address),
-                    'code': '{}create.fail'.format(self.role)
-                })
-            abort(503, response="Failed to send user creation email.")
+    link_url = url_for('external.create_user', encoded_token=token, _external=True)
 
-    def _generate_create_token(self, token_data):
-        return generate_token(
-            token_data,
-            current_app.config['SHARED_EMAIL_KEY'],
-            current_app.config['INVITE_EMAIL_SALT']
+    personalisation_with_link = personalisation.copy()
+    personalisation_with_link.update({'url': link_url})
+
+    try:
+        notify_client.send_email(
+            email_address,
+            template_id=template_id,
+            personalisation=personalisation_with_link,
+            reference='create-user-account-{}'.format(hash_string(email_address))
         )
+        session['email_sent_to'] = email_address
+    except EmailError as e:
+        current_app.logger.error(
+            "{code}: Create user email for email_hash {email_hash} failed to send. Error: {error}",
+            extra={
+                'error': str(e),
+                'email_hash': hash_string(email_address),
+                'code': '{}create.fail'.format(role)
+            })
+        abort(503, response="Failed to send user creation email.")

--- a/dmutils/external.py
+++ b/dmutils/external.py
@@ -1,0 +1,18 @@
+from flask import Blueprint
+
+external = Blueprint('external', __name__)
+
+
+@external.route('/suppliers/opportunities/<int:brief_id>/responses/result')
+def view_response_result(brief_id):
+    raise NotImplementedError()
+
+
+@external.route('/suppliers/opportunities/frameworks/<framework_slug>')
+def opportunities_dashboard(framework_slug):
+    raise NotImplementedError()
+
+
+@external.route('/user/create/<encoded_token>')
+def create_user(encoded_token):
+    raise NotImplementedError()

--- a/tests/email/test_user_account_email.py
+++ b/tests/email/test_user_account_email.py
@@ -1,0 +1,86 @@
+import mock
+import pytest
+from flask import session
+
+from dmutils.config import init_app
+from dmutils.email import UserAccountEmail, EmailError
+from dmutils.email.tokens import decode_invitation_token
+
+
+@pytest.yield_fixture
+def email_app(app):
+    init_app(app)
+    app.config['SHARED_EMAIL_KEY'] = 'shared_email_key'
+    app.config['INVITE_EMAIL_SALT'] = 'invite_email_salt'
+    app.config['SECRET_KEY'] = 'secet_key'
+    app.config['DM_NOTIFY_API_KEY'] = 'dm_notify_api_key'
+    app.config['NOTIFY_TEMPLATES'] = {'create_user_account': 'this-would-be-the-id-of-the-template'}
+    yield app
+
+
+class TestUserAccountEmail():
+
+    def test_UserAccountEmail_object_creates_token_on_instantiation(self, email_app):
+        with email_app.app_context():
+            token_data = {
+                'role': 'buyer',
+                'email_address': 'test@example.gov.uk'
+            }
+
+            create_user_email = UserAccountEmail(token_data, 'notify-template-id')
+
+            assert decode_invitation_token(create_user_email.token) == {
+                'role': 'buyer',
+                'email_address': 'test@example.gov.uk'
+            }
+
+    @mock.patch('dmutils.email.user_account_email.DMNotifyClient')
+    def test_send_email_correctly_calls_notify_client(self, DMNotifyClient, email_app):
+        with email_app.test_request_context():
+            notify_client_mock = mock.Mock()
+            DMNotifyClient.return_value = notify_client_mock
+
+            token_data = {
+                'role': 'buyer',
+                'email_address': 'test@example.gov.uk'
+            }
+
+            create_buyer_email = UserAccountEmail(token_data, 'notify-template-id')
+            create_buyer_email.send_email({'url': 'http://link.to/create-user'})
+
+            notify_client_mock.send_email.assert_called_once_with(
+                'test@example.gov.uk',
+                template_id='notify-template-id',
+                personalisation={
+                    'url': 'http://link.to/create-user'
+                },
+                reference='create-user-account-KmmJkEa5sLyv7vuxG3xja3S3fnnM6Rgq5EZY0S_kCjE='
+            )
+            assert session['email_sent_to'] == 'test@example.gov.uk'
+
+    @mock.patch('dmutils.email.user_account_email.current_app')
+    @mock.patch('dmutils.email.user_account_email.abort')
+    @mock.patch('dmutils.email.user_account_email.DMNotifyClient')
+    def test_abort_with_503_if_send_email_fails_with_EmailError(self, DMNotifyClient, abort, current_app, email_app):
+        with email_app.test_request_context():
+            notify_client_mock = mock.Mock()
+            notify_client_mock.send_email.side_effect = EmailError('OMG!')
+            DMNotifyClient.return_value = notify_client_mock
+
+            token_data = {
+                'role': 'buyer',
+                'email_address': 'test@example.gov.uk'
+            }
+
+            create_buyer_email = UserAccountEmail(token_data, 'notify-template-id')
+            create_buyer_email.send_email({'url': 'http://link.to/create-user'})
+
+            current_app.logger.error.assert_called_once_with(
+                "{code}: Create user email for email_hash {email_hash} failed to send. Error: {error}",
+                extra={
+                    'error': 'OMG!',
+                    'email_hash': 'KmmJkEa5sLyv7vuxG3xja3S3fnnM6Rgq5EZY0S_kCjE=',
+                    'code': 'buyercreate.fail'
+                }
+            )
+            abort.assert_called_once_with(503, response="Failed to send user creation email.")

--- a/tests/email/test_user_account_email.py
+++ b/tests/email/test_user_account_email.py
@@ -1,15 +1,17 @@
 import mock
 import pytest
-from flask import session
+from flask import session, current_app
 
 from dmutils.config import init_app
-from dmutils.email import UserAccountEmail, EmailError
+from dmutils.email import send_user_account_email, EmailError
 from dmutils.email.tokens import decode_invitation_token
+from dmutils.external import external as external_blueprint
 
 
 @pytest.yield_fixture
 def email_app(app):
     init_app(app)
+    app.register_blueprint(external_blueprint)
     app.config['SHARED_EMAIL_KEY'] = 'shared_email_key'
     app.config['INVITE_EMAIL_SALT'] = 'invite_email_salt'
     app.config['SECRET_KEY'] = 'secet_key'
@@ -18,41 +20,70 @@ def email_app(app):
     yield app
 
 
-class TestUserAccountEmail():
+class TestSendUserAccountEmail():
 
-    def test_UserAccountEmail_object_creates_token_on_instantiation(self, email_app):
-        with email_app.app_context():
-            token_data = {
-                'role': 'buyer',
-                'email_address': 'test@example.gov.uk'
-            }
-
-            create_user_email = UserAccountEmail(token_data, 'notify-template-id')
-
-            assert decode_invitation_token(create_user_email.token) == {
-                'role': 'buyer',
-                'email_address': 'test@example.gov.uk'
-            }
-
+    @mock.patch('dmutils.email.user_account_email.generate_token')
     @mock.patch('dmutils.email.user_account_email.DMNotifyClient')
-    def test_send_email_correctly_calls_notify_client(self, DMNotifyClient, email_app):
+    def test_correctly_calls_notify_client_for_buyer(
+        self, DMNotifyClient, generate_token, email_app
+    ):
         with email_app.test_request_context():
+            generate_token.return_value = 'mocked-token'
+            notify_client_mock = mock.Mock()
+            DMNotifyClient.return_value = notify_client_mock
+
+            send_user_account_email(
+                'buyer',
+                'test@example.gov.uk',
+                current_app.config['NOTIFY_TEMPLATES']['create_user_account']
+             )
+
+            notify_client_mock.send_email.assert_called_once_with(
+                'test@example.gov.uk',
+                template_id='this-would-be-the-id-of-the-template',
+                personalisation={
+                    'url': 'http://localhost/user/create/mocked-token'
+                },
+                reference='create-user-account-KmmJkEa5sLyv7vuxG3xja3S3fnnM6Rgq5EZY0S_kCjE='
+            )
+            assert session['email_sent_to'] == 'test@example.gov.uk'
+
+    @mock.patch('dmutils.email.user_account_email.generate_token')
+    @mock.patch('dmutils.email.user_account_email.DMNotifyClient')
+    def test_correctly_calls_notify_client_for_supplier(
+        self, DMNotifyClient, generate_token, email_app
+    ):
+        with email_app.test_request_context():
+            generate_token.return_value = 'mocked-token'
             notify_client_mock = mock.Mock()
             DMNotifyClient.return_value = notify_client_mock
 
             token_data = {
-                'role': 'buyer',
+                'role': 'supplier',
                 'email_address': 'test@example.gov.uk'
             }
 
-            create_buyer_email = UserAccountEmail(token_data, 'notify-template-id')
-            create_buyer_email.send_email({'url': 'http://link.to/create-user'})
+            send_user_account_email(
+                'supplier',
+                'test@example.gov.uk',
+                current_app.config['NOTIFY_TEMPLATES']['create_user_account'],
+                extra_token_data={
+                    'supplier_id': 12345,
+                    'supplier_name': 'Digital Marketplace'
+                },
+                personalisation={
+                    'user': 'Digital Marketplace Team',
+                    'supplier': 'Digital Marketplace'
+                }
+             )
 
             notify_client_mock.send_email.assert_called_once_with(
                 'test@example.gov.uk',
-                template_id='notify-template-id',
+                template_id=current_app.config['NOTIFY_TEMPLATES']['create_user_account'],
                 personalisation={
-                    'url': 'http://link.to/create-user'
+                    'url': 'http://localhost/user/create/mocked-token',
+                    'user': 'Digital Marketplace Team',
+                    'supplier': 'Digital Marketplace'
                 },
                 reference='create-user-account-KmmJkEa5sLyv7vuxG3xja3S3fnnM6Rgq5EZY0S_kCjE='
             )
@@ -67,13 +98,11 @@ class TestUserAccountEmail():
             notify_client_mock.send_email.side_effect = EmailError('OMG!')
             DMNotifyClient.return_value = notify_client_mock
 
-            token_data = {
-                'role': 'buyer',
-                'email_address': 'test@example.gov.uk'
-            }
-
-            create_buyer_email = UserAccountEmail(token_data, 'notify-template-id')
-            create_buyer_email.send_email({'url': 'http://link.to/create-user'})
+            send_user_account_email(
+                'buyer',
+                'test@example.gov.uk',
+                current_app.config['NOTIFY_TEMPLATES']['create_user_account']
+             )
 
             current_app.logger.error.assert_called_once_with(
                 "{code}: Create user email for email_hash {email_hash} failed to send. Error: {error}",


### PR DESCRIPTION
The code for emailing a creation or invite email to a buyer or supplier
is really similar. We're also moving these emails to Notify which also
simplifies the process (no need for templates).

This class can be imported by the frontend apps and used to generate and
send the tokens and emails for user creation/invitiation.