### PR TITLE
Flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,15 @@
+[flake8]
+# Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
+# D203: 1 blank line required before class docstring
+# F401: 'identifier' imported but unused
+# E402: module level import not at top of file
+# C901: too complex
+# W503: line break before binary operator
+exclude = venv*,__pycache__,node_modules,bower_components
+ignore = D203,W503
+max-complexity = 7
+max-line-length = 120
+putty-ignore =
+    **/__init__.py : +F401
+    app/__init__.py, app/main/__init__.py, app/status/__init__.py : +E402
+    app/main/views/*.py : +C901

--- a/.flake8
+++ b/.flake8
@@ -7,9 +7,7 @@
 # W503: line break before binary operator
 exclude = venv*,__pycache__,node_modules,bower_components
 ignore = D203,W503
-max-complexity = 7
+max-complexity = 10
 max-line-length = 120
 putty-ignore =
     **/__init__.py : +F401
-    app/__init__.py, app/main/__init__.py, app/status/__init__.py : +E402
-    app/main/views/*.py : +C901

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,27 @@
 SHELL := /bin/bash
 VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
 
+.PHONY: virtualenv
 virtualenv:
 	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv -p python3 venv || true
 
+.PHONY: requirements-dev
 requirements-dev: virtualenv requirements-dev.txt
 	${VIRTUALENV_ROOT}/bin/pip install -r requirements-dev.txt
 
-test: show_environment test_pep8 test_python
+.PHONY: test
+test: show-environment test-flake8 test-python
 
-test_pep8: virtualenv
-	${VIRTUALENV_ROOT}/bin/pep8 .
+.PHONY: test-flake8
+test-flake8: virtualenv
+	${VIRTUALENV_ROOT}/bin/flake8 .
 
-test_python: virtualenv
+.PHONY: test-python
+test-python: virtualenv
 	${VIRTUALENV_ROOT}/bin/py.test ${PYTEST_ARGS}
 
-show_environment:
+.PHONY: show-environment
+show-environment:
 	@echo "Environment variables in use:"
 	@env | grep DM_ || true
 
-.PHONY: virtualenv requirements-dev test_pep8 test_python show_environment

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '28.5.0'
+__version__ = '28.6.0'

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 import logging
 import sys
 import re
-from itertools import product
 
 from flask import request, current_app
 from flask.ctx import has_request_context

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,11 @@
 -r requirements.txt
 
 coverage==3.7.1
+flake8==2.6.2
+flake8-putty==0.4.0
 freezegun==0.3.4
 mock==2.0.0
 moto==0.4.31
-pep8==1.6.2
 pytest==2.8.7
 pytest-cov==2.2.0
 python-coveralls==2.5.0

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -14,7 +14,7 @@ function display_result {
   fi
 }
 
-pep8 .
+flake8 .
 display_result $? 1 "Code style check"
 
 py.test $@

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[pep8]
-max-line-length = 120
-exclude = ./venv*
-
 [pytest]
 norecursedirs = venv* src
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-import tempfile
-
 import pytest
 from flask import Flask
 import mock

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -4,7 +4,6 @@ import mock
 
 from dmutils.email.dm_mailchimp import DMMailChimpClient
 from requests import RequestException
-from logging import Logger
 
 
 def test_create_campaign():
@@ -69,7 +68,7 @@ def test_send_campaign():
 @mock.patch("logging.Logger", autospec=True)
 def test_log_error_message_if_error_sending_campaign(logger):
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', logger)
-    with mock.patch.object(dm_mailchimp_client._client.campaigns.actions, 'send',  autospec=True) as send:
+    with mock.patch.object(dm_mailchimp_client._client.campaigns.actions, 'send', autospec=True) as send:
         send.side_effect = RequestException("error sending")
 
         res = dm_mailchimp_client.send_campaign("1")
@@ -105,7 +104,7 @@ def test_subscribe_new_email_to_list(get_email_hash):
 def test_log_error_message_if_error_subscribing_email_to_list(get_email_hash, logger):
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', logger)
     with mock.patch.object(
-            dm_mailchimp_client._client.lists.members, 'create_or_update',  autospec=True) as create_or_update:
+            dm_mailchimp_client._client.lists.members, 'create_or_update', autospec=True) as create_or_update:
         response = mock.Mock()
         response.json.return_value = {"detail": "Unexpected error."}
         create_or_update.side_effect = RequestException("error sending", response=response)
@@ -124,7 +123,7 @@ def test_log_error_message_if_error_subscribing_email_to_list(get_email_hash, lo
 def test_returns_true_if_expected_error_subscribing_email_to_list(get_email_hash, logger):
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', logger)
     with mock.patch.object(
-            dm_mailchimp_client._client.lists.members, 'create_or_update',  autospec=True) as create_or_update:
+            dm_mailchimp_client._client.lists.members, 'create_or_update', autospec=True) as create_or_update:
         response = mock.Mock()
         response.json.return_value = {"detail": "foo looks fake or invalid, please enter a real email address."}
         create_or_update.side_effect = RequestException("error sending", response=response)
@@ -140,7 +139,7 @@ def test_returns_true_if_expected_error_subscribing_email_to_list(get_email_hash
 
 def test_subscribe_new_emails_to_list():
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', mock.MagicMock())
-    with mock.patch.object(dm_mailchimp_client, 'subscribe_new_email_to_list',  autospec=True):
+    with mock.patch.object(dm_mailchimp_client, 'subscribe_new_email_to_list', autospec=True):
         dm_mailchimp_client.subscribe_new_email_to_list.return_value = True
         res = dm_mailchimp_client.subscribe_new_emails_to_list('list_id', ['email1@example.com', 'email2@example.com'])
         calls = [mock.call('list_id', 'email1@example.com'), mock.call('list_id', 'email2@example.com')]

--- a/tests/email/test_dm_notify.py
+++ b/tests/email/test_dm_notify.py
@@ -169,7 +169,7 @@ class TestDMNotifyClient(object):
 
     def test_cache_not_instantiated_with_allow_resend(self, dm_notify_client):
         """The cache shouldn't be touched until we pass `allow_resend=False` to `send_email`."""
-        with mock.patch(self.client_class_str + '.' + 'send_email_notification') as email_mock:
+        with mock.patch(self.client_class_str + '.' + 'send_email_notification'):
             assert dm_notify_client._sent_references_cache is None
             dm_notify_client.send_email(self.email_address, self.template_id)
             assert dm_notify_client._sent_references_cache is None

--- a/tests/email/test_user_account_email.py
+++ b/tests/email/test_user_account_email.py
@@ -4,7 +4,6 @@ from flask import session, current_app
 
 from dmutils.config import init_app
 from dmutils.email import send_user_account_email, EmailError
-from dmutils.email.tokens import decode_invitation_token
 from dmutils.external import external as external_blueprint
 
 
@@ -57,11 +56,6 @@ class TestSendUserAccountEmail():
             generate_token.return_value = 'mocked-token'
             notify_client_mock = mock.Mock()
             DMNotifyClient.return_value = notify_client_mock
-
-            token_data = {
-                'role': 'supplier',
-                'email_address': 'test@example.gov.uk'
-            }
 
             send_user_account_email(
                 'supplier',

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,4 @@
 from datetime import datetime
-import mock
-
-
 from six import BytesIO
 
 

--- a/tests/test_asset_fingerprint.py
+++ b/tests/test_asset_fingerprint.py
@@ -91,5 +91,5 @@ class TestAssetFingerprint(object):
 
 class TestAssetFingerprintWithUnicode(object):
     def test_can_read_self(self):
-        string_with_unicode_character = 'Ralph’s apostrophe'
+        """This string must contain Ralph’s apostrophe. We then try to load this file with the asset fingerprinter."""
         AssetFingerprinter(filesystem_path='tests/').get_url('test_asset_fingerprint.py')

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,8 +1,7 @@
 # coding: utf-8
-import pytest
-import mock
-import workdays
 import datetime
+import mock
+
 import dmutils.dates as dates_package
 
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -64,7 +64,7 @@ class TestValidateDocuments(unittest.TestCase):
     def test_filter_empty_files(self):
         file1 = MockFile(b"*", 'file1')
         file2 = MockFile(b"", 'file2')
-        file3 = MockFile(b"*"*10, 'file3')
+        file3 = MockFile(b"*" * 10, 'file3')
         self.assertEquals(
             filter_empty_files({'f1': file1, 'f2': file2, 'f3': file3}),
             {'f1': file1, 'f3': file3}
@@ -74,7 +74,7 @@ class TestValidateDocuments(unittest.TestCase):
         self.assertTrue(file_is_less_than_5mb(MockFile(b"*", 'file1')))
 
     def test_file_is_more_than_5mb(self):
-        self.assertFalse(file_is_less_than_5mb(MockFile(b"*"*5400001, 'file1')))
+        self.assertFalse(file_is_less_than_5mb(MockFile(b"*" * 5400001, 'file1')))
 
     def test_file_is_open_document_format(self):
         self.assertTrue(file_is_open_document_format(MockFile(b"*", 'file1.pdf')))
@@ -114,20 +114,20 @@ class TestValidateDocuments(unittest.TestCase):
 
     def test_validate_documents_not_less_than_5mb(self):
         self.assertEqual(
-            validate_documents({'file1': MockFile(b"*"*5400001, 'file1.pdf')}),
+            validate_documents({'file1': MockFile(b"*" * 5400001, 'file1.pdf')}),
             {'file1': 'file_is_less_than_5mb'}
         )
 
     def test_validate_documents_not_open_document_above_5mb(self):
         self.assertEqual(
-            validate_documents({'file1': MockFile(b"*"*5400001, 'file1.doc')}),
+            validate_documents({'file1': MockFile(b"*" * 5400001, 'file1.doc')}),
             {'file1': 'file_is_open_document_format'}
         )
 
     def test_validate_multiple_documents(self):
         self.assertEqual(
             validate_documents({
-                'file1': MockFile(b"*"*5400001, 'file1.pdf'),
+                'file1': MockFile(b"*" * 5400001, 'file1.pdf'),
                 'file2': MockFile(b"*", 'file1.pdf'),
                 'file3': MockFile(b"*", 'file1.doc'),
             }),
@@ -249,7 +249,7 @@ class TestUploadServiceDocuments(object):
         self.documents_url = 'http://localhost'
 
     def test_upload_service_documents(self):
-        request_files = {'pricingDocumentURL': MockFile(b"*"*100, 'q1.pdf')}
+        request_files = {'pricingDocumentURL': MockFile(b"*" * 100, 'q1.pdf')}
 
         with freeze_time('2015-10-04 14:36:05'):
             files, errors = upload_service_documents(
@@ -263,7 +263,7 @@ class TestUploadServiceDocuments(object):
         assert len(errors) == 0
 
     def test_upload_private_service_documents(self):
-        request_files = {'pricingDocumentURL': MockFile(b"*"*100, 'q1.pdf')}
+        request_files = {'pricingDocumentURL': MockFile(b"*" * 100, 'q1.pdf')}
 
         with freeze_time('2015-10-04 14:36:05'):
             files, errors = upload_service_documents(
@@ -288,7 +288,7 @@ class TestUploadServiceDocuments(object):
         assert len(errors) == 0
 
     def test_only_files_in_section_are_uploaded(self):
-        request_files = {'serviceDefinitionDocumentURL': MockFile(b"*"*100, 'q1.pdf')}
+        request_files = {'serviceDefinitionDocumentURL': MockFile(b"*" * 100, 'q1.pdf')}
 
         files, errors = upload_service_documents(
             self.uploader, 'documents', self.documents_url, self.service,
@@ -298,7 +298,7 @@ class TestUploadServiceDocuments(object):
         assert len(errors) == 0
 
     def test_upload_with_validation_errors(self):
-        request_files = {'pricingDocumentURL': MockFile(b"*"*100, 'q1.bad')}
+        request_files = {'pricingDocumentURL': MockFile(b"*" * 100, 'q1.bad')}
 
         files, errors = upload_service_documents(
             self.uploader, 'documents', self.documents_url, self.service,

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,7 +1,7 @@
 from itertools import product
 
 from flask.ext.wtf import Form
-from wtforms.validators import ValidationError, DataRequired, Optional
+from wtforms.validators import DataRequired, Optional
 from werkzeug.datastructures import ImmutableMultiDict
 import pytest
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from flask import Flask
 import tempfile
 import logging
 try:

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -254,17 +254,8 @@ class TestS3Uploader(object):
     ))
     @freeze_time('2016-10-02')
     def test_save_file(
-        self,
-        empty_bucket,
-        path,
-        expected_path,
-        expected_ct,
-        expected_filename,
-        expected_ext,
-        timestamp,
-        expected_timestamp,
-        download_filename,
-        expected_cd,
+        self, empty_bucket, path, expected_path, expected_ct, expected_filename, expected_ext, timestamp,
+        expected_timestamp, download_filename, expected_cd
     ):
         returned_key_dict = S3("dear-liza").save(
             path,

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -60,13 +60,12 @@ def bucket_with_weird_file(request, empty_bucket):
     if timestamp is not None:
         metadata["timestamp"] = timestamp
 
-    bucket = empty_bucket
     obj = empty_bucket.Object(".!!!.dear.pdf")
 
     # note how none of these file properties match each other
 
     obj.put(
-        Body=(u"\u00a3"*13).encode("utf-8"),
+        Body=(u"\u00a3" * 13).encode("utf-8"),
         Metadata=metadata,
         ContentType="image/jpeg",
         ContentDisposition='attachment; filename="blahs_on_blahs.png"',
@@ -79,9 +78,9 @@ def bucket_with_multiple_files(request, empty_bucket):
     bucket = empty_bucket
     for i in range(5):
         empty_bucket.Object("with/A{}/paper.dear.odt".format(i)).put(
-            Body=b"abcdefgh"*(i+1),
+            Body=b"abcdefgh" * (i + 1),
             Metadata={
-                "timestamp": datetime.datetime(2014, 10, ((i*11) % 28)+1).strftime(DATETIME_FORMAT),
+                "timestamp": datetime.datetime(2014, 10, ((i * 11) % 28) + 1).strftime(DATETIME_FORMAT),
             } if i != 3 else {},
         )
     # a "directory" which shouldn't show up in listings
@@ -255,18 +254,18 @@ class TestS3Uploader(object):
     ))
     @freeze_time('2016-10-02')
     def test_save_file(
-            self,
-            empty_bucket,
-            path,
-            expected_path,
-            expected_ct,
-            expected_filename,
-            expected_ext,
-            timestamp,
-            expected_timestamp,
-            download_filename,
-            expected_cd,
-            ):
+        self,
+        empty_bucket,
+        path,
+        expected_path,
+        expected_ct,
+        expected_filename,
+        expected_ext,
+        timestamp,
+        expected_timestamp,
+        download_filename,
+        expected_cd,
+    ):
         returned_key_dict = S3("dear-liza").save(
             path,
             file_=BytesIO(b"one two three"),
@@ -328,7 +327,7 @@ class TestS3Uploader(object):
 
 
 def test_get_file_size_binary_file():
-    test_file = BytesIO(b"*"*5399999)
+    test_file = BytesIO(b"*" * 5399999)
     # put fd somewhere interesting
     test_file.seek(234)
 
@@ -341,7 +340,7 @@ def test_get_file_size_text_file():
     from io import TextIOWrapper
     test_inner_file = BytesIO()
     test_file = TextIOWrapper(test_inner_file, encoding="utf-8")
-    test_file.write(u"\u0001F3A9 "*123)
+    test_file.write(u"\u0001F3A9 " * 123)
     test_file.seek(0)
     # read 9 *unicode chars* to advance fd to somewhere interesting
     test_file.read(9)


### PR DESCRIPTION
## 29.0.0

PR: [#338](https://github.com/alphagov/digitalmarketplace-utils/pull/338)

### What changed

* Code checker is changed from PEP8 to Flake8
* Makefile commands now use hyphen ('-') not underscore ('_') to delimit words


```
test_pep8 > test-flake8
show_environment > show-environment
test_python > test-python
```
* New file Flake8 config file `.flake8`
* New dependencies in `requirements-dev.txt`
* Flake8 changes implemented (including unused imports)


Actual changes:
[flake8-report.txt](https://github.com/alphagov/digitalmarketplace-utils/files/1333075/flake8-report.txt)
