### PR TITLE
Add milliseconds to the log time format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 Records breaking changes from major version bumps
 
+## 29.0.0
+
+PR: [#339](https://github.com/alphagov/digitalmarketplace-utils/pull/339)
+
+### What changed
+
+Log time format has changed, so the library update has to be bundled with the
+new base docker image version or AWS logs agent will fail to pick up the correct
+log event timestamps.
+
+### Example app changes
+Old Dockerfile:
+```
+FROM digitalmarketplace/base-api:2.0.1
+```
+New Dockerfile:
+```
+FROM digitalmarketplace/base-api:2.0.5
+```
+
 ## 28.0.0
 
 PR:

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '28.8.0'
+__version__ = '29.0.0'

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -10,7 +10,6 @@ from pythonjsonlogger.jsonlogger import JsonFormatter as BaseJSONFormatter
 
 LOG_FORMAT = '%(asctime)s %(app_name)s %(name)s %(levelname)s ' \
              '%(request_id)s "%(message)s" [in %(pathname)s:%(lineno)d]'
-TIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
 
 logger = logging.getLogger(__name__)
 
@@ -56,9 +55,9 @@ def configure_handler(handler, app, formatter):
 
 def get_handler(app):
     if app.config.get('DM_PLAIN_TEXT_LOGS'):
-        formatter = CustomLogFormatter(LOG_FORMAT, TIME_FORMAT)
+        formatter = CustomLogFormatter(LOG_FORMAT)
     else:
-        formatter = JSONFormatter(LOG_FORMAT, TIME_FORMAT)
+        formatter = JSONFormatter(LOG_FORMAT)
 
     if app.config.get('DM_LOG_PATH'):
         handler = logging.FileHandler(app.config['DM_LOG_PATH'])

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -11,7 +11,7 @@ import mock
 
 from dmutils import request_id
 from dmutils.logging import init_app, RequestIdFilter, JSONFormatter, CustomLogFormatter
-from dmutils.logging import LOG_FORMAT, TIME_FORMAT
+from dmutils.logging import LOG_FORMAT
 
 
 def test_request_id_filter_not_in_app_context():
@@ -97,7 +97,7 @@ class TestJSONFormatter(object):
         return logger, buffer
 
     def setup(self):
-        self.formatter = JSONFormatter(LOG_FORMAT, TIME_FORMAT)
+        self.formatter = JSONFormatter(LOG_FORMAT)
         self.logger, self.buffer = self._create_logger('logging-test', self.formatter)
         self.dmlogger, self.dmbuffer = self._create_logger('dmutils', self.formatter)
 
@@ -157,7 +157,7 @@ class TestCustomLogFormatter(object):
         return logger, buffer
 
     def setup(self):
-        self.formatter = CustomLogFormatter(LOG_FORMAT, TIME_FORMAT)
+        self.formatter = CustomLogFormatter(LOG_FORMAT)
         self.logger, self.buffer = self._create_logger('logging-test', self.formatter)
         self.dmlogger, self.dmbuffer = self._create_logger('dmutils', self.formatter)
 


### PR DESCRIPTION
Allows keeping the order of events when logs are streamed to Kibana.

Removing TIME_FORMAT argument from log formatters makes python use the default `formatTime` logic that adds `record.msec` to the formatted string. The default time format is the same as the one we define, except it uses a space instead of `T` to separate date from time. Since we don't rely on splitting fields with whitespace in JSON logs this shouldn't be a problem.