### PR TITLE
Update dependency to use our fork of odfpy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Records breaking changes from major version bumps
 
+## 31.0.0
+
+PR: [#343](https://github.com/alphagov/digitalmarketplace-utils/pull/343)
+
+Major version bump because we require users of this library to upgrade
+to a version of the odfpy that is not in pypi.
+
+ACTION: update your `requirements-app.txt`, copying the github URI in this
+repo's `requirements.txt`.
+
 ## 30.0.0
 
 PR: [#341](https://github.com/alphagov/digitalmarketplace-utils/pull/341)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '30.0.0'
+__version__ = '31.0.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev
 -e .

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
          'mandrill==1.0.57',
          'monotonic==0.3',
          'notifications-python-client==4.1.0',
-         'odfpy==1.3.3',
+         'odfpy==1.3.6dev',
          'python-json-logger==0.1.4',
          'pytz==2015.4',
          'pyyaml==3.11',


### PR DESCRIPTION
 - this is to fix a bug in the odfpy library where it can produce non-well-formed XML.

 - note that in order for this requirement to be satisfied you will have to manually update your requirements files to include the location of the forked library.

https://trello.com/c/EgBoNeW9/145-certain-control-characters-in-suppliers-evidence-corrupts-the-ods-that-buyers-download

** We may not want to land this change **

[We decided to land this change nonetheless.]

Reasons to not land this change:

 - it's actually a breaking change. When we attempt to bring this version of dm-utils into a frontend, we will find we can't actually install it until the relevant `requirements-app.txt` is updated and the `requirements.txt` is rebuilt.

 - Once you realise you have to update the requirements.txt, there are two options: include the deprecated "--process-dependency-links" flag, or copy in the full git repo details to allow pip to find our new version of odfpy. I think I prefer the latter - adding to the number of warnings doesn't seem ideal.

 - There's an alternative: we can just change the setup.py here to allow a range (e.g >1.3.6), and then add the repo details into the frontend app(s) requirements.txt files necessary. If we're going to do that anyway, why bother making an incompatible version of dm-utils at all?

ISTM that the alternative approach fits with what seems to pass for current pip 'philosophy', which is that libraries should use setup.py _only_ to declare which versions of their dependencies they are API-compatible with. And then it's (apparently) supposed to be up to people writing applications to pull all of these things together into sensible sets of dependencies (and sources) that are then expressed in a `requirements.txt` file. There's some flaws in that in terms of usability, but that's my understanding - can share references if anyone really wants.



