### PR TITLE
Change from flake8-putty to per-file-ignores

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,5 +9,5 @@ exclude = venv*,__pycache__,node_modules,bower_components
 ignore = D203,W503
 max-complexity = 10
 max-line-length = 120
-putty-ignore =
-    **/__init__.py : +F401
+per-file-ignores =
+    **/__init__.py : F401

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -74,6 +74,7 @@ def capitalize_first(maybe_text):
 
     return maybe_text
 
+
 # find repeated sequences of '\r\n\', optionally separated by other non-newline whitespace space characters
 _multiple_newlines_re = re.compile(r'(\r\n[ \t\f\v]*){2,}')
 # find \r\n sequences

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -107,7 +107,7 @@ class CustomLogFormatter(logging.Formatter):
 
         try:
             msg = msg.format(**record.__dict__)
-        except:
+        except:  # noqa
             # We know that KeyError, ValueError and IndexError are all possible things that can go
             # wrong here - there is no guarantee that the message passed into the logger is
             # actually suitable to be used as a format string. This is particularly so where an

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 -r requirements.txt
 
 coverage==3.7.1
-flake8==2.6.2
-flake8-putty==0.4.0
+flake8==3.5.0
+flake8-per-file-ignores==0.4.0
 freezegun==0.3.4
 hypothesis==3.6.1
 mock==2.0.0


### PR DESCRIPTION
This allows us to upgrade to flake8==3.5.0 which brings with it support
for Python 3 syntax such as f-strings and type annotations.