### PR TITLE
Use 'new' import style for flask extensions.

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '31.0.0'
+__version__ = '31.0.1'

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -1,7 +1,7 @@
 import os
 from flask_featureflags.contrib.inline import InlineFeatureFlag
 from . import config, logging, proxy_fix, request_id, formats, filters
-from flask.ext.script import Manager, Server
+from flask_script import Manager, Server
 
 
 def init_app(


### PR DESCRIPTION
Fixes a warning generated by flask.

http://flask.pocoo.org/docs/0.12/extensiondev/#extension-import-transition