### PR TITLE
If no "timestamp" metadata fall back to AWS last_modified

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '31.1.0'
+__version__ = '31.1.1'

--- a/dmutils/s3.py
+++ b/dmutils/s3.py
@@ -165,9 +165,11 @@ class S3(object):
             'size': obj.size if hasattr(obj, "size") else obj.content_length,
         }
         if with_timestamp:
+            # First look for custom "timestamp" metadata field that is explicitly set by our S3 uploader
+            # fall back to AWS's "last_modified" if this doesn't exist
             keydict["last_modified"] = (
-                obj.metadata.get("timestamp") and parse_time(obj.metadata["timestamp"]).strftime(DATETIME_FORMAT)
-            )
+                (obj.metadata.get("timestamp") and parse_time(obj.metadata["timestamp"])) or obj.last_modified
+            ).strftime(DATETIME_FORMAT)
 
         return keydict
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ hypothesis==3.6.1
 mock==2.0.0
 moto==0.4.31
 pytest==3.2.3
-pytest-cov==2.2.0
+pytest-cov==2.5.1
 python-coveralls==2.5.0
 Flask==0.10.1
 Flask-WTF==0.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
-[pytest]
+[tool:pytest]
 norecursedirs = venv* src
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -8,99 +8,74 @@ from datetime import datetime
 import pytest
 
 
-def test_timeformat():
-    cases = [
-        (datetime(2012, 11, 10, 9, 8, 7, 6), "09:08:07"),
-        ("2012-11-10T09:08:07.0Z", "09:08:07"),
-        (datetime(2012, 8, 10, 9, 8, 7, 6), "10:08:07"),
-        ("2012-08-12T12:12:12.0Z", "13:12:12"),
-        (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "10:08:07"),
-        (datetime(2012, 8, 10, 0, 8, 7, 6, tzinfo=pytz.utc), "01:08:07"),
-    ]
-
-    def check_timeformat(dt, formatted_time):
-        assert timeformat(dt) == formatted_time
-
-    for dt, formatted_time in cases:
-        yield check_timeformat, dt, formatted_time
+@pytest.mark.parametrize("dt, formatted_time", (
+    (datetime(2012, 11, 10, 9, 8, 7, 6), "09:08:07"),
+    ("2012-11-10T09:08:07.0Z", "09:08:07"),
+    (datetime(2012, 8, 10, 9, 8, 7, 6), "10:08:07"),
+    ("2012-08-12T12:12:12.0Z", "13:12:12"),
+    (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "10:08:07"),
+    (datetime(2012, 8, 10, 0, 8, 7, 6, tzinfo=pytz.utc), "01:08:07"),
+))
+def test_timeformat(dt, formatted_time):
+    assert timeformat(dt) == formatted_time
 
 
-def test_shortdateformat():
-    cases = [
-        (datetime(2012, 11, 10, 9, 8, 7, 6), "10 November"),
-        ("2012-11-10T09:08:07.0Z", "10 November"),
-        (datetime(2012, 8, 10, 9, 8, 7, 6), "10 August"),
-        ("2012-08-10T09:08:07.0Z", "10 August"),
-        (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "10 August"),
-        ("2016-04-27T23:59:59.0Z", "27 April"),
-        (datetime(2016, 4, 27, 23, 59, 59, 0, tzinfo=pytz.utc), "27 April"),
-        (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), "1 August"),
-    ]
-
-    def check_shortdateformat(dt, formatted_date):
-        assert shortdateformat(dt) == formatted_date
-
-    for dt, formatted_date in cases:
-        yield check_shortdateformat, dt, formatted_date
+@pytest.mark.parametrize("dt, formatted_date", (
+    (datetime(2012, 11, 10, 9, 8, 7, 6), "10 November"),
+    ("2012-11-10T09:08:07.0Z", "10 November"),
+    (datetime(2012, 8, 10, 9, 8, 7, 6), "10 August"),
+    ("2012-08-10T09:08:07.0Z", "10 August"),
+    (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "10 August"),
+    ("2016-04-27T23:59:59.0Z", "27 April"),
+    (datetime(2016, 4, 27, 23, 59, 59, 0, tzinfo=pytz.utc), "27 April"),
+    (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), "1 August"),
+))
+def test_shortdateformat(dt, formatted_date):
+    assert shortdateformat(dt) == formatted_date
 
 
-def test_dateformat():
-    cases = [
-        (datetime(2012, 11, 10, 9, 8, 7, 6), "Saturday 10 November 2012"),
-        ("2012-11-10T09:08:07.0Z", "Saturday 10 November 2012"),
-        (datetime(2012, 8, 10, 9, 8, 7, 6), "Friday 10 August 2012"),
-        ("2012-08-10T09:08:07.0Z", "Friday 10 August 2012"),
-        (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "Friday 10 August 2012"),
-        ("2016-04-27T23:59:59.0Z", "Wednesday 27 April 2016"),
-        (datetime(2016, 4, 27, 23, 59, 59, 0), "Wednesday 27 April 2016"),
-        (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), "Wednesday 1 August 2012"),
-    ]
-
-    def check_dateformat(dt, formatted_date):
-        assert dateformat(dt) == formatted_date
-
-    for dt, formatted_date in cases:
-        yield check_dateformat, dt, formatted_date
+@pytest.mark.parametrize("dt, formatted_date", (
+    (datetime(2012, 11, 10, 9, 8, 7, 6), "Saturday 10 November 2012"),
+    ("2012-11-10T09:08:07.0Z", "Saturday 10 November 2012"),
+    (datetime(2012, 8, 10, 9, 8, 7, 6), "Friday 10 August 2012"),
+    ("2012-08-10T09:08:07.0Z", "Friday 10 August 2012"),
+    (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "Friday 10 August 2012"),
+    ("2016-04-27T23:59:59.0Z", "Wednesday 27 April 2016"),
+    (datetime(2016, 4, 27, 23, 59, 59, 0), "Wednesday 27 April 2016"),
+    (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), "Wednesday 1 August 2012"),
+))
+def test_dateformat(dt, formatted_date):
+    assert dateformat(dt) == formatted_date
 
 
-def test_datetimeformat():
-    cases = [
-        (datetime(2012, 11, 10, 9, 8, 7, 6), "Saturday 10 November 2012 at 9:08am"),
-        ("2012-11-10T09:08:07.0Z", "Saturday 10 November 2012 at 9:08am"),
-        (datetime(2012, 8, 10, 9, 8, 7, 6), "Friday 10 August 2012 at 10:08am"),
-        ("2012-08-10T09:08:07.0Z", "Friday 10 August 2012 at 10:08am"),
-        (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "Friday 10 August 2012 at 10:08am"),
-        (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), "Wednesday 1 August 2012 at 10:08am"),
-        (datetime(2012, 8, 1, 22, 59, 7, 6, tzinfo=pytz.utc), "Wednesday 1 August 2012 at 11:59pm"),
-        # Daylight savings edge case
-        (datetime(2012, 3, 25, 0, 59, 7, 6, tzinfo=pytz.utc), "Sunday 25 March 2012 at 12:59am"),
-        (datetime(2012, 3, 25, 1, 59, 7, 6, tzinfo=pytz.utc), "Sunday 25 March 2012 at 2:59am"),
-        # Fall back to default if no valid date supplied
-        (None, None),
-    ]
-
-    def check_datetimeformat(dt, formatted_datetime):
-        assert datetimeformat(dt) == formatted_datetime
-
-    for dt, formatted_datetime in cases:
-        yield check_datetimeformat, dt, formatted_datetime
+@pytest.mark.parametrize("dt, formatted_datetime", (
+    (datetime(2012, 11, 10, 9, 8, 7, 6), "Saturday 10 November 2012 at 9:08am"),
+    ("2012-11-10T09:08:07.0Z", "Saturday 10 November 2012 at 9:08am"),
+    (datetime(2012, 8, 10, 9, 8, 7, 6), "Friday 10 August 2012 at 10:08am"),
+    ("2012-08-10T09:08:07.0Z", "Friday 10 August 2012 at 10:08am"),
+    (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "Friday 10 August 2012 at 10:08am"),
+    (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), "Wednesday 1 August 2012 at 10:08am"),
+    (datetime(2012, 8, 1, 22, 59, 7, 6, tzinfo=pytz.utc), "Wednesday 1 August 2012 at 11:59pm"),
+    # Daylight savings edge case
+    (datetime(2012, 3, 25, 0, 59, 7, 6, tzinfo=pytz.utc), "Sunday 25 March 2012 at 12:59am"),
+    (datetime(2012, 3, 25, 1, 59, 7, 6, tzinfo=pytz.utc), "Sunday 25 March 2012 at 2:59am"),
+    # Fall back to default if no valid date supplied
+    (None, None),
+))
+def test_datetimeformat(dt, formatted_datetime):
+    assert datetimeformat(dt) == formatted_datetime
 
 
-def test_utcdatetimeformat():
-    cases = [
-        # UTC+00 date: display as normal
-        (datetime(2012, 3, 24, 23, 59, 7, 6, tzinfo=pytz.utc), "Saturday 24 March 2012 at 11:59pm GMT"),
-        # UTC+01 date: force to UTC+00 if date would rollover to the next day
-        (datetime(2012, 3, 25, 23, 59, 7, 6, tzinfo=pytz.utc), "Sunday 25 March 2012 at 11:59pm GMT"),
-        # Fall back to default if no valid date supplied
-        (None, None),
-    ]
-
-    def check_datetimeformat(dt, formatted_datetime):
-        assert utcdatetimeformat(dt) == formatted_datetime
-
-    for dt, formatted_datetime in cases:
-        yield check_datetimeformat, dt, formatted_datetime
+@pytest.mark.parametrize("dt, formatted_datetime", (
+    # UTC+00 date: display as normal
+    (datetime(2012, 3, 24, 23, 59, 7, 6, tzinfo=pytz.utc), "Saturday 24 March 2012 at 11:59pm GMT"),
+    # UTC+01 date: force to UTC+00 if date would rollover to the next day
+    (datetime(2012, 3, 25, 23, 59, 7, 6, tzinfo=pytz.utc), "Sunday 25 March 2012 at 11:59pm GMT"),
+    # Fall back to default if no valid date supplied
+    (None, None),
+))
+def test_utcdatetimeformat(dt, formatted_datetime):
+    assert utcdatetimeformat(dt) == formatted_datetime
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Addresses this bug: https://trello.com/c/qBiGn3bP/9-legal-documents-files-not-appearing-on-framework-application-dashboard

Some pages in our apps (eg framework dashboard) look for the existence of "last_modified" on an S3 key as an indicator for if the file exists or not, and only show a link to files with a "last_modified" date.

This meant that if a file was uploaded to S3 using the AWS console and didn't have "timestamp" set then the link to the file would not display, even though the file is there.

This also fixes all warnings generated during test runs.