### PR TITLE
Adds missing external routes used by other applications

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '31.1.1'
+__version__ = '31.2.0'

--- a/dmutils/external.py
+++ b/dmutils/external.py
@@ -5,8 +5,18 @@ external = Blueprint('external', __name__)
 # Buyer frontend
 
 
+@external.route('/')
+def index():
+    raise NotImplementedError()
+
+
 @external.route('/<framework_framework>/opportunities/<brief_id>')
 def get_brief_by_id(framework_framework, brief_id):
+    raise NotImplementedError()
+
+
+@external.route('/g-cloud/suppliers')
+def suppliers_list_by_prefix():
     raise NotImplementedError()
 
 
@@ -14,7 +24,12 @@ def get_brief_by_id(framework_framework, brief_id):
 def help():
     raise NotImplementedError()
 
+
 # Supplier frontend
+
+@external.route('/suppliers')
+def dashboard():
+    raise NotImplementedError()
 
 
 @external.route('/suppliers/opportunities/<int:brief_id>/responses/result')
@@ -26,6 +41,7 @@ def view_response_result(brief_id):
 def opportunities_dashboard(framework_slug):
     raise NotImplementedError()
 
+
 # User frontend
 
 
@@ -36,4 +52,12 @@ def create_user(encoded_token):
 
 @external.route('/user/login')
 def render_login():
+    raise NotImplementedError()
+
+
+# Briefs frontend
+
+
+@external.route('/buyers/create')
+def create_buyer_account():
     raise NotImplementedError()

--- a/dmutils/external.py
+++ b/dmutils/external.py
@@ -28,7 +28,7 @@ def help():
 # Supplier frontend
 
 @external.route('/suppliers')
-def dashboard():
+def supplier_dashboard():
     raise NotImplementedError()
 
 


### PR DESCRIPTION
adds in:

- `/`
- `/g-cloud/suppliers`
- `/suppliers`
- `/buyers/create`

Bumps version to `31.2.0`