### PR TITLE
Use bucket owner full control instead of privte acl

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '31.3.1'
+__version__ = '31.3.2'

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -72,8 +72,8 @@ def upload_document(uploader, upload_type, documents_url, service, field, file_c
     :param field: name of the service field that the document URL is saved to,
                   used to generate the document name
     :param file_contents: attached file object
-    :param public: if True, set file permission to 'public-read'. Otherwise file
-                   is private.
+    :param public: if True, set file permission to 'public-read'. Otherwise 'bucket-owner-full-control',
+                   which is private to the object owner and bucket owner.
 
     :return: generated document URL or ``False`` if document upload
              failed
@@ -90,7 +90,7 @@ def upload_document(uploader, upload_type, documents_url, service, field, file_c
         file_contents.filename
     )
 
-    acl = 'public-read' if public else 'private'
+    acl = 'public-read' if public else 'bucket-owner-full-control'
 
     try:
         uploader.save(file_path, file_contents, acl=acl)

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -179,7 +179,7 @@ class TestUploadDocument(unittest.TestCase):
         uploader.save.assert_called_once_with(
             'g-cloud-6/documents/5/123-pricing-document-2015-01-02-0405.pdf',
             mock.ANY,
-            acl='private'
+            acl='bucket-owner-full-control'
         )
 
     def test_document_upload_s3_error(self):
@@ -272,7 +272,10 @@ class TestUploadServiceDocuments(object):
                 public=False)
 
         self.uploader.save.assert_called_with(
-            'g-cloud-7/documents/12345/654321-pricing-document-2015-10-04-1436.pdf', mock.ANY, acl='private')
+            'g-cloud-7/documents/12345/654321-pricing-document-2015-10-04-1436.pdf',
+            mock.ANY,
+            acl='bucket-owner-full-control'
+        )
 
         assert 'pricingDocumentURL' in files
         assert len(errors) == 0


### PR DESCRIPTION
Because we now log in to S3 using IAM roles inherited from other accounts, files uploaded as 'private' can not be viewed by developers logged in to the console.

Using 'bucket-owner-full-control' rather than 'private' means that devs will be able to view and modify documents in the S3 console.