### PR TITLE
Use `SHARED_EMAIL_KEY` not `SECRET_KEY` for reset password tokens

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '31.3.2'
+__version__ = '31.4.0'

--- a/dmutils/email/tokens.py
+++ b/dmutils/email/tokens.py
@@ -100,13 +100,24 @@ def decode_password_reset_token(token, data_api_client):
     try:
         decoded, token_timestamp = decode_token(
             token,
-            current_app.config["SECRET_KEY"],
+            current_app.config["SHARED_EMAIL_KEY"],
             current_app.config["RESET_PASSWORD_SALT"],
             ONE_DAY_IN_SECONDS,
         )
-    except fernet.InvalidToken as e:
-        current_app.logger.info("Error changing password: {error}", extra={'error': six.text_type(e)})
-        return {'error': 'token_invalid'}
+    except fernet.InvalidToken:
+        try:
+            # We used to issue tokens with `current_app.config["SECRET_KEY"]` as our key, so we maintain backwards
+            # compatability with them for a short period (1 day) to allow for both type of tokens to be valid until the
+            # older ones have expired and can remove the support for tokens using `current_app.config["SECRET_KEY"]`
+            decoded, token_timestamp = decode_token(
+                token,
+                current_app.config["SECRET_KEY"],
+                current_app.config["RESET_PASSWORD_SALT"],
+                ONE_DAY_IN_SECONDS,
+            )
+        except fernet.InvalidToken as e:
+            current_app.logger.info("Error changing password: {error}", extra={'error': six.text_type(e)})
+            return {'error': 'token_invalid'}
 
     user = data_api_client.get_user(decoded["user"])
     user_last_changed_password_at = datetime.strptime(


### PR DESCRIPTION
https://trello.com/c/WTbemGdn/219-reset-password-emails-are-using-secretkey-instead-of-sharedemailkey-to-encrypt-tokens

We will be changing our tokens for reset password emails to be
generated using the `SHARED_EMAIL_KEY` rather than the `SECRET_KEY`
in an applications config. This is because
- this will be consistent with the other email tokens we generate
- although there is technically no harm in using `SECRET_KEY`,
the actual purpose of the `SECRET_KEY` is to be used for encrypting
Flask sessions. This would mean if we needed to rotate a key for
our Flask sessions it would also break out email tokens and vice
versa. By using different keys we should reduce the risk of a
token rotation having an impact on too large a part of the site

We maintain backwards compatability so tokens generated within the
past day using the old token will not be broken by this change.
The next step will be to start encrypting tokens with
`SHARED_EMAIL_KEY` for a full day at which point we can remove
the backwards compatability support for `SECRET_KEY`.