### PR TITLE
Drop support for reset password tokens using `SECRET_KEY` key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Records breaking changes from major version bumps
 
+## 32.0.0
+
+PR: [#355](https://github.com/alphagov/digitalmarketplace-utils/pull/355)
+
+Drops support for `decode_password_reset_token` to allow tokens generated with `current_app.config["SECRET_KEY"]`
+as the key. We now only support reset password tokens generated with `current_app.config["SHARED_EMAIL_KEY"]`.
+
 ## 31.0.0
 
 PR: [#343](https://github.com/alphagov/digitalmarketplace-utils/pull/343)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '31.4.0'
+__version__ = '32.0.0'

--- a/dmutils/email/tokens.py
+++ b/dmutils/email/tokens.py
@@ -104,20 +104,9 @@ def decode_password_reset_token(token, data_api_client):
             current_app.config["RESET_PASSWORD_SALT"],
             ONE_DAY_IN_SECONDS,
         )
-    except fernet.InvalidToken:
-        try:
-            # We used to issue tokens with `current_app.config["SECRET_KEY"]` as our key, so we maintain backwards
-            # compatability with them for a short period (1 day) to allow for both type of tokens to be valid until the
-            # older ones have expired and can remove the support for tokens using `current_app.config["SECRET_KEY"]`
-            decoded, token_timestamp = decode_token(
-                token,
-                current_app.config["SECRET_KEY"],
-                current_app.config["RESET_PASSWORD_SALT"],
-                ONE_DAY_IN_SECONDS,
-            )
-        except fernet.InvalidToken as e:
-            current_app.logger.info("Error changing password: {error}", extra={'error': six.text_type(e)})
-            return {'error': 'token_invalid'}
+    except fernet.InvalidToken as e:
+        current_app.logger.info("Error changing password: {error}", extra={'error': six.text_type(e)})
+        return {'error': 'token_invalid'}
 
     user = data_api_client.get_user(decoded["user"])
     user_last_changed_password_at = datetime.strptime(

--- a/tests/email/test_tokens.py
+++ b/tests/email/test_tokens.py
@@ -112,54 +112,41 @@ def test_decrypt_token_ok_for_known_good_token():
     assert data == ({'email': 'test@example.com', 'user': 123}, datetime(2016, 1, 1, 12, 0, 0))
 
 
-class BaseDecodePasswordResetToken(object):
-    def test_decode_password_reset_token_ok_for_good_token(self, email_app, data_api_client, password_reset_token):
-        with email_app.app_context():
-            token = generate_token(password_reset_token, self.key, 'PassSalt')
-            assert decode_password_reset_token(token, data_api_client) == password_reset_token
-        data_api_client.get_user.assert_called_once_with(123)
+def test_decode_password_reset_token_ok_for_good_token(email_app, data_api_client, password_reset_token):
+    with email_app.app_context():
+        token = generate_token(password_reset_token, "Key", 'PassSalt')
+        assert decode_password_reset_token(token, data_api_client) == password_reset_token
+    data_api_client.get_user.assert_called_once_with(123)
 
-    def test_decode_password_reset_token_does_not_work_if_bad_token(
-        self, email_app, data_api_client, password_reset_token
-    ):
-        token = generate_token(password_reset_token, self.key, 'PassSalt')[1:]
 
+def test_decode_password_reset_token_does_not_work_if_bad_token(email_app, data_api_client, password_reset_token):
+    token = generate_token(password_reset_token, "Key", 'PassSalt')[1:]
+
+    with email_app.app_context():
+        assert decode_password_reset_token(token, data_api_client) == {'error': 'token_invalid'}
+
+
+def test_decode_password_reset_token_does_not_work_if_token_expired(email_app, data_api_client, password_reset_token):
+    with freeze_time('2015-01-02 03:04:05'):
+        # Token was generated a year before current time
+        token = generate_token(password_reset_token, "Key", 'PassSalt')
+
+    with freeze_time('2016-01-02 03:04:05'):
         with email_app.app_context():
             assert decode_password_reset_token(token, data_api_client) == {'error': 'token_invalid'}
 
-    def test_decode_password_reset_token_does_not_work_if_token_expired(
-        self, email_app, data_api_client, password_reset_token
-    ):
-        with freeze_time('2015-01-02 03:04:05'):
-            # Token was generated a year before current time
-            token = generate_token(password_reset_token, self.key, 'PassSalt')
 
-        with freeze_time('2016-01-02 03:04:05'):
-            with email_app.app_context():
-                assert decode_password_reset_token(token, data_api_client) == {'error': 'token_invalid'}
+def test_decode_password_reset_token_does_not_work_if_password_changed_later_than_token(
+    email_app, data_api_client, password_reset_token
+):
+    with freeze_time('2016-01-01T11:00:00.30Z'):
+        # Token was generated an hour earlier than password was changed
+        token = generate_token(password_reset_token, "Key", 'PassSalt')
 
-    def test_decode_password_reset_token_does_not_work_if_password_changed_later_than_token(
-        self, email_app, data_api_client, password_reset_token
-    ):
-        with freeze_time('2016-01-01T11:00:00.30Z'):
-            # Token was generated an hour earlier than password was changed
-            token = generate_token(password_reset_token, self.key, 'PassSalt')
-
-        with freeze_time('2016-01-01T13:00:00.30Z'):
-            # Token is two hours old; password was changed an hour ago
-            with email_app.app_context():
-                assert decode_password_reset_token(token, data_api_client) == {'error': 'token_invalid'}
-
-
-class TestDecodePasswordResetTokenUsingSecretKey(BaseDecodePasswordResetToken):
-    # Key for which old password reset tokens exist that we must support for 1 day minimum of backwards compatability
-    # before this support can be removed
-    key = "Secret"  # app.config['SECRET_KEY'] in our `email_app` fixture
-
-
-class TestDecodePasswordResetTokenUsingSharedEmailKey(BaseDecodePasswordResetToken):
-    # Key for which we will be issuing password reset tokens going ahead
-    key = "Key"  # app.config['SHARED_EMAIL_KEY'] in our `email_app` fixture
+    with freeze_time('2016-01-01T13:00:00.30Z'):
+        # Token is two hours old; password was changed an hour ago
+        with email_app.app_context():
+            assert decode_password_reset_token(token, data_api_client) == {'error': 'token_invalid'}
 
 
 def test_decode_invitation_token_decodes_ok(email_app):


### PR DESCRIPTION
https://trello.com/c/WTbemGdn/219-reset-password-emails-are-using-secretkey-instead-of-sharedemailkey-to-encrypt-tokens

Drops the temporary backwards compatability introduced in
https://github.com/alphagov/digitalmarketplace-utils/pull/354
as after one day all old tokens using `SECRET_KEY` will be
invalid anyway.