### PR TITLE
Change back to eea/odfpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Records breaking changes from major version bumps
 
+## 33.0.0
+
+Reverting our usage of an interim alphagov fork of odfpy now that our patch has been merged into master and released.
+1
+ACTION: update your `requirements-app.txt`, removing the alphagov odfpy
+github URI (if present).
+
 ## 32.0.0
 
 PR: [#355](https://github.com/alphagov/digitalmarketplace-utils/pull/355)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '32.0.0'
+__version__ = '33.0.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-git+https://github.com/alphagov/odfpy.git@ee4482a#egg=odfpy==1.3.6dev
 -e .

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
          'mandrill==1.0.57',
          'monotonic==0.3',
          'notifications-python-client==4.1.0',
-         'odfpy==1.3.6dev',
+         'odfpy==1.3.6',
          'python-json-logger==0.1.4',
          'pytz==2015.4',
          'pyyaml==3.11',


### PR DESCRIPTION
## Summary
Stop using our alphagov fork of odfpy, which was created to allow us to patch a bug until it went into the main library. Our patch was merged into release 1.3.6 of odfpy, so now we can just use that.

Reverts https://github.com/alphagov/digitalmarketplace-utils/pull/343

## Ticket
https://trello.com/c/3bDwjW6V/278-odfpy-remove-dependency-on-alphagov-fork