### PR TITLE
request id handling: redesign for added flexibility and zipkin header handling

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '34.0.0'
+__version__ = '34.1.0'

--- a/dmutils/request_id.py
+++ b/dmutils/request_id.py
@@ -11,18 +11,32 @@ class RequestIdRequestMixin(object):
 
     @property
     def trace_id(self):
+        """
+            The "trace id" (in zipkin terms) assigned to this request. If one was set in the request header, that will
+            be used. Failing that, this will be an id we've generated and assigned ourselves.
+        """
         if not hasattr(self, "_trace_id"):
             self._trace_id = self._get_first_header(current_app.config['DM_TRACE_ID_HEADERS']) or str(uuid.uuid4().hex)
         return self._trace_id
 
     @property
     def span_id(self):
+        """
+            The "span id" (in zipkin terms) set in this request's header, if present (None otherwise)
+        """
         if not hasattr(self, "_span_id"):
+            # note how we don't generate an id of our own. not being supplied a span id implies that we are running in
+            # an environment with no span-id-aware request router, and thus would have no intermediary to prevent the
+            # propagation of our span id all the way through all our onwards requests much like trace id. and the point
+            # of span id is to assign identifiers to each individual request.
             self._span_id = self._get_first_header(current_app.config['DM_SPAN_ID_HEADERS'])
         return self._span_id
 
     @property
     def parent_span_id(self):
+        """
+            The "parent span id" (in zipkin terms) set in this request's header, if present (None otherwise)
+        """
         if not hasattr(self, "_parent_span_id"):
             self._parent_span_id = self._get_first_header(current_app.config['DM_PARENT_SPAN_ID_HEADERS'])
         return self._parent_span_id

--- a/dmutils/request_id.py
+++ b/dmutils/request_id.py
@@ -5,6 +5,11 @@ from flask import request, current_app
 
 
 class RequestIdRequestMixin(object):
+    """
+        A mixin intended for use against a flask Request class, implementing extraction (and partly generation) of
+        headers approximately according to the "zipkin" scheme https://github.com/openzipkin/b3-propagation
+    """
+
     @property
     def request_id(self):
         return self.trace_id

--- a/dmutils/request_id.py
+++ b/dmutils/request_id.py
@@ -1,41 +1,73 @@
 import uuid
+from itertools import chain
 
 from flask import request, current_app
-from flask.wrappers import Request
 
 
-class CustomRequest(Request):
-    _request_id = None
-
+class RequestIdRequestMixin(object):
     @property
     def request_id(self):
-        if self._request_id is None:
-            self._request_id = self._get_request_id(
-                current_app.config['DM_REQUEST_ID_HEADER'],
-                current_app.config['DM_DOWNSTREAM_REQUEST_ID_HEADER'])
-        return self._request_id
+        return self.trace_id
 
-    def _get_request_id(self, request_id_header, downstream_header):
-        if request_id_header in self.headers:
-            return self.headers.get(request_id_header)
-        elif downstream_header and downstream_header in self.headers:
-            return self.headers.get(downstream_header)
+    @property
+    def trace_id(self):
+        if not hasattr(self, "_trace_id"):
+            self._trace_id = self._get_first_header(current_app.config['DM_TRACE_ID_HEADERS']) or str(uuid.uuid4())
+        return self._trace_id
+
+    @property
+    def span_id(self):
+        if not hasattr(self, "_span_id"):
+            self._span_id = self._get_first_header(current_app.config['DM_SPAN_ID_HEADERS'])
+        return self._span_id
+
+    @property
+    def parent_span_id(self):
+        if not hasattr(self, "_parent_span_id"):
+            self._parent_span_id = self._get_first_header(current_app.config['DM_PARENT_SPAN_ID_HEADERS'])
+        return self._parent_span_id
+
+    def _get_first_header(self, header_names):
+        """
+        Returns value of request's first present (and Truthy) header from header_names
+        """
+        for header_name in header_names:
+            if header_name in self.headers and self.headers[header_name]:
+                return self.headers[header_name]
         else:
-            return str(uuid.uuid4())
+            return None
+
+    def get_onwards_request_headers(self):
+        """
+            Headers to add to any further (internal) http api requests we perform if we want that request to be
+            considered part of this "trace id"
+        """
+        return dict(chain(
+            (
+                (header_name, self.trace_id)
+                for header_name in current_app.config['DM_TRACE_ID_HEADERS']
+                if self.trace_id
+            ),
+            (
+                (header_name, self.span_id)
+                for header_name in current_app.config['DM_SPAN_ID_HEADERS']
+                if self.span_id
+            ),
+        ))
 
 
 class ResponseHeaderMiddleware(object):
-    def __init__(self, app, request_id_header):
+    def __init__(self, app, trace_id_headers):
         self.app = app
-        self.request_id_header = request_id_header
+        self.trace_id_headers = trace_id_headers
 
     def __call__(self, environ, start_response):
         def rewrite_response_headers(status, headers, exc_info=None):
-            if self.request_id_header not in dict(headers).keys():
-                headers = headers + [(
-                    self.request_id_header,
-                    str(request.request_id)
-                )]
+            headers = headers + [
+                (header_name, str(request.request_id),)
+                for header_name in self.trace_id_headers
+                if header_name not in dict(headers)
+            ]
 
             return start_response(status, headers, exc_info)
 
@@ -43,8 +75,16 @@ class ResponseHeaderMiddleware(object):
 
 
 def init_app(app):
-    app.config.setdefault('DM_REQUEST_ID_HEADER', 'DM-Request-ID')
-    app.config.setdefault('DM_DOWNSTREAM_REQUEST_ID_HEADER', '')
+    app.config.setdefault("DM_TRACE_ID_HEADERS", (
+        (app.config.get("DM_REQUEST_ID_HEADER") or "DM-Request-ID"),
+        (app.config.get("DM_DOWNSTREAM_REQUEST_ID_HEADER") or "X-B3-TraceId"),
+    ))
+    app.config.setdefault("DM_SPAN_ID_HEADERS", ("X-B3-SpanId",))
+    app.config.setdefault("DM_PARENT_SPAN_ID_HEADERS", ("X-B3-ParentSpan",))
 
-    app.request_class = CustomRequest
-    app.wsgi_app = ResponseHeaderMiddleware(app.wsgi_app, app.config['DM_REQUEST_ID_HEADER'])
+    # dynamically define this class as we don't necessarily know how request_class may have already been modified by
+    # another init_app
+    class _RequestIdRequest(RequestIdRequestMixin, app.request_class):
+        pass
+    app.request_class = _RequestIdRequest
+    app.wsgi_app = ResponseHeaderMiddleware(app.wsgi_app, app.config['DM_TRACE_ID_HEADERS'])

--- a/dmutils/request_id.py
+++ b/dmutils/request_id.py
@@ -12,7 +12,7 @@ class RequestIdRequestMixin(object):
     @property
     def trace_id(self):
         if not hasattr(self, "_trace_id"):
-            self._trace_id = self._get_first_header(current_app.config['DM_TRACE_ID_HEADERS']) or str(uuid.uuid4())
+            self._trace_id = self._get_first_header(current_app.config['DM_TRACE_ID_HEADERS']) or str(uuid.uuid4().hex)
         return self._trace_id
 
     @property

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -325,7 +325,7 @@ def test_request_header(
     _param_combinations,
 )
 @mock.patch('dmutils.request_id.uuid.uuid4', autospec=True)
-def test_request_id_is_set_on_response(
+def test_response_headers_regular_response(
     uuid4_mock,
     app,
     extra_config,
@@ -365,7 +365,7 @@ def test_request_id_is_set_on_response(
     _param_combinations,
 )
 @mock.patch('dmutils.request_id.uuid.uuid4', autospec=True)
-def test_request_id_is_set_on_error_response(
+def test_response_headers_error_response(
     uuid4_mock,
     app,
     extra_config,

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -114,7 +114,7 @@ _trace_id_related_params = (
         },
         # extra_req_headers
         (
-            ("x-b3-traceid", "H. M. S. Belleisle",),  # should be ignored as default header name has been overwritten
+            ("X-B3-TraceId", "H. M. S. Belleisle",),  # should be ignored as default header name has been overwritten
         ),
         # expected_trace_id
         _GENERATED_TRACE_VALUE,
@@ -193,7 +193,7 @@ _trace_id_related_params = (
         # extra_req_headers
         (
             ("x-kidneys", "pork",),
-            ("x-b3-traceid", "Grilled Mutton",),
+            ("x-b3-traceid", "Grilled Mutton",),  # also checking header case-insensitivity here
         ),
         # expected_trace_id
         "Grilled Mutton",
@@ -219,7 +219,7 @@ _span_id_related_params = (
         {},
         # extra_req_headers
         (
-            ("x-b3-spanid", "Steak, kidney, liver, mashed",),
+            ("x-b3-spanid", "Steak, kidney, liver, mashed",),  # also checking header case-insensitivity here
         ),
         # expected_span_id
         "Steak, kidney, liver, mashed",
@@ -245,7 +245,7 @@ _span_id_related_params = (
         },
         # extra_req_headers
         (
-            ("bloomusalem", "huge-pork-kidney",),
+            ("bloomusalem", "huge-pork-kidney",),  # also checking header case-insensitivity here
         ),
         # expected_span_id
         "huge-pork-kidney",
@@ -285,7 +285,7 @@ _parent_span_id_related_params = (
         },
         # extra_req_headers
         (
-            ("POTATO-PRESERVATIVE", "Plage and Pestilence",),
+            ("POTATO-PRESERVATIVE", "Plage and Pestilence",),  # also checking header case-insensitivity here
         ),
         # expected_parent_span_id
         "Plage and Pestilence",

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -1,77 +1,393 @@
+from flask import request
+from itertools import chain, product
 import mock
-from werkzeug.test import EnvironBuilder
+import pytest
 
-from dmutils import request_id
-from dmutils.request_id import CustomRequest
-
-
-def test_get_request_id_from_request_id_header():
-    builder = EnvironBuilder()
-    builder.headers['DM-REQUEST-ID'] = 'from-header'
-    builder.headers['DOWNSTREAM-REQUEST-ID'] = 'from-downstream'
-    request = CustomRequest(builder.get_environ())
-
-    request_id = request._get_request_id('DM-REQUEST-ID',
-                                         'DOWNSTREAM-REQUEST-ID')
-
-    assert request_id == 'from-header'
+from dmutils.request_id import init_app as request_id_init_app
 
 
-def test_get_request_id_from_downstream_header():
-    builder = EnvironBuilder()
-    builder.headers['DOWNSTREAM-REQUEST-ID'] = 'from-downstream'
-    request = CustomRequest(builder.get_environ())
+_trace_id_related_params = (
+    (
+        # extra_config
+        {
+            "DM_REQUEST_ID_HEADER": "DM-REQUEST-ID",
+            "DM_DOWNSTREAM_REQUEST_ID_HEADER": "DOWNSTREAM-REQUEST-ID",
+        },
+        # extra_req_headers
+        (
+            ("DM-REQUEST-ID", "from-header",),
+            ("DOWNSTREAM-REQUEST-ID", "from-downstream",),
+        ),
+        # expected_trace_id
+        "from-header",
+        # expect_uuid_call
+        False,
+        # expected_onwards_req_headers
+        {
+            "DM-REQUEST-ID": "from-header",
+            "DOWNSTREAM-REQUEST-ID": "from-header",
+        },
+        # expected_resp_headers
+        {
+            "DM-REQUEST-ID": "from-header",
+            "DOWNSTREAM-REQUEST-ID": "from-header",
+        },
+    ),
+    (
+        {
+            "DM_REQUEST_ID_HEADER": "DM-REQUEST-ID",
+            "DM_DOWNSTREAM_REQUEST_ID_HEADER": "DOWNSTREAM-REQUEST-ID",
+        },
+        (
+            ("DOWNSTREAM-REQUEST-ID", "from-downstream",),
+        ),
+        "from-downstream",
+        False,
+        {
+            "DM-REQUEST-ID": "from-downstream",
+            "DOWNSTREAM-REQUEST-ID": "from-downstream",
+        },
+        {
+            "DM-REQUEST-ID": "from-downstream",
+            "DOWNSTREAM-REQUEST-ID": "from-downstream",
+        },
+    ),
+    (
+        {
+            "DM_REQUEST_ID_HEADER": "DM-REQUEST-ID",
+            "DM_DOWNSTREAM_REQUEST_ID_HEADER": "",
+        },
+        (),
+        "generated",
+        True,
+        {
+            "DM-REQUEST-ID": "generated",
+            "X-B3-TraceId": "generated",
+        },
+        {
+            "DM-REQUEST-ID": "generated",
+            "X-B3-TraceId": "generated",
+        },
+    ),
+    (
+        {
+            "DM_REQUEST_ID_HEADER": "DM-REQUEST-ID",
+            "DM_DOWNSTREAM_REQUEST_ID_HEADER": "DOWNSTREAM-REQUEST-ID",
+        },
+        (),
+        "generated",
+        True,
+        {
+            "DM-REQUEST-ID": "generated",
+            "DOWNSTREAM-REQUEST-ID": "generated",
+        },
+        {
+            "DM-REQUEST-ID": "generated",
+            "DOWNSTREAM-REQUEST-ID": "generated",
+        },
+    ),
+    (
+        {
+            "DM_REQUEST_ID_HEADER": "DM-REQUEST-ID",
+            "DM_DOWNSTREAM_REQUEST_ID_HEADER": "DOWNSTREAM-REQUEST-ID",
+        },
+        (),
+        "generated",
+        True,
+        {
+            "DM-REQUEST-ID": "generated",
+            "DOWNSTREAM-REQUEST-ID": "generated",
+        },
+        {
+            "DM-REQUEST-ID": "generated",
+            "DOWNSTREAM-REQUEST-ID": "generated",
+        },
+    ),
+    (
+        {
+            "DM_TRACE_ID_HEADERS": ("x-tommy-caffrey", "y-jacky-caffrey",),
+            "DM_REQUEST_ID_HEADER": "DM-REQUEST-ID",
+            "DM_DOWNSTREAM_REQUEST_ID_HEADER": "DOWNSTREAM-REQUEST-ID",
+        },
+        (
+            # these should both be ignored because of the presence of the DM_TRACE_ID_HEADERS setting
+            ("DM-REQUEST-ID", "from-header",),
+            ("DOWNSTREAM-REQUEST-ID", "from-downstream",),
+        ),
+        "generated",
+        True,
+        {
+            "x-tommy-caffrey": "generated",
+            "y-jacky-caffrey": "generated",
+        },
+        {
+            "x-tommy-caffrey": "generated",
+            "y-jacky-caffrey": "generated",
+        },
+    ),
+    (
+        {
+            "DM_TRACE_ID_HEADERS": ("x-tommy-caffrey", "y-jacky-caffrey",),
+        },
+        (
+            ("y-jacky-caffrey", "jacky-header-value",),
+            ("x-tommy-caffrey", "tommy-header-value",),
+        ),
+        "tommy-header-value",
+        False,
+        {
+            "x-tommy-caffrey": "tommy-header-value",
+            "y-jacky-caffrey": "tommy-header-value",
+        },
+        {
+            "x-tommy-caffrey": "tommy-header-value",
+            "y-jacky-caffrey": "tommy-header-value",
+        },
+    ),
+    (
+        {
+            "DM_REQUEST_ID_HEADER": "DM-REQUEST-ID",
+            # not setting DM_DOWNSTREAM_REQUEST_ID_HEADER should cause it to fall back to the default, X-B3-TraceId
+        },
+        (
+            ("x-kidneys", "pork",),
+            ("x-b3-traceid", "Grilled Mutton",),
+        ),
+        "Grilled Mutton",
+        False,
+        {
+            "DM-REQUEST-ID": "Grilled Mutton",
+            "X-B3-TraceId": "Grilled Mutton",
+        },
+        {
+            "DM-REQUEST-ID": "Grilled Mutton",
+            "X-B3-TraceId": "Grilled Mutton",
+        },
+    ),
+)
 
-    request_id = request._get_request_id('DM-REQUEST-ID',
-                                         'DOWNSTREAM-REQUEST-ID')
 
-    assert request_id == 'from-downstream'
+_span_id_related_params = (
+    (
+        # extra_config
+        {},
+        # extra_req_headers
+        (
+            ("x-b3-spanid", "Steak, kidney, liver, mashed",),
+        ),
+        # expected_span_id
+        "Steak, kidney, liver, mashed",
+        # expected_onwards_req_headers
+        {
+            "X-B3-SpanId": "Steak, kidney, liver, mashed",
+        },
+    ),
+    (
+        {},
+        (),
+        None,
+        {},
+    ),
+    (
+        {
+            "DM_SPAN_ID_HEADERS": ("barrels-and-boxes", "Bloomusalem",),
+        },
+        (
+            ("bloomusalem", "huge-pork-kidney",),
+        ),
+        "huge-pork-kidney",
+        {
+            "barrels-and-boxes": "huge-pork-kidney",
+            "Bloomusalem": "huge-pork-kidney",
+        },
+    ),
+)
 
 
-@mock.patch('dmutils.request_id.uuid.uuid4')
-def test_get_request_id_with_no_downstream_header_configured(uuid4_mock):
-    builder = EnvironBuilder()
-    builder.headers[''] = 'from-downstream'
-    request = CustomRequest(builder.get_environ())
-    uuid4_mock.return_value = 'generated'
+_parent_span_id_related_params = (
+    (
+        # extra_config
+        {},
+        # extra_req_headers
+        (
+            ("X-B3-PARENTSPAN", "colossal-edifice",),
+            ("X-WANDERING-SOAP", "Flower of the Bath",),
+        ),
+        # expected_parent_span_id
+        "colossal-edifice",
+    ),
+    (
+        {},
+        (),
+        None,
+    ),
+    (
+        {
+            "DM_PARENT_SPAN_ID_HEADERS": ("Potato-Preservative",),
+        },
+        (
+            ("POTATO-PRESERVATIVE", "Plage and Pestilence",),
+        ),
+        "Plage and Pestilence",
+    ),
+)
 
-    request_id = request._get_request_id('DM-REQUEST-ID', '')
 
-    uuid4_mock.assert_called_once()
-    assert request_id == 'generated'
+_param_combinations = tuple(
+    # to prove that the behaviour of trace_id, span_id and parent_span_id is independent, we use the cartesian product
+    # of all sets of parameters to test every possible combination of scenarios we've provided...
+    (
+        # extra_config
+        dict(chain(t_extra_config.items(), s_extra_config.items(), p_extra_config.items(),)),
+        # extra_req_headers
+        tuple(chain(t_extra_req_headers, s_extra_req_headers, p_extra_req_headers)),
+        expected_trace_id,
+        expect_uuid_call,
+        expected_span_id,
+        expected_parent_span_id,
+        # expected_onwards_req_headers
+        dict(chain(t_expected_onwards_req_headers.items(), s_expected_onwards_req_headers.items(),)),
+        expected_resp_headers,
+    ) for (
+        t_extra_config,
+        t_extra_req_headers,
+        expected_trace_id,
+        expect_uuid_call,
+        t_expected_onwards_req_headers,
+        # so far only the trace_id should affect the response headers
+        expected_resp_headers,
+    ), (
+        s_extra_config,
+        s_extra_req_headers,
+        expected_span_id,
+        s_expected_onwards_req_headers,
+    ), (
+        p_extra_config,
+        p_extra_req_headers,
+        expected_parent_span_id,
+    ) in product(_trace_id_related_params, _span_id_related_params, _parent_span_id_related_params)
+)
 
 
-@mock.patch('dmutils.request_id.uuid.uuid4')
-def test_get_request_id_generates_id(uuid4_mock):
-    builder = EnvironBuilder()
-    request = CustomRequest(builder.get_environ())
-    uuid4_mock.return_value = 'generated'
+@pytest.mark.parametrize(
+    (
+        "extra_config",
+        "extra_req_headers",
+        "expected_trace_id",
+        "expect_uuid_call",
+        "expected_span_id",
+        "expected_parent_span_id",
+        "expected_onwards_req_headers",
+        "expected_resp_headers",
+    ),
+    _param_combinations,
+)
+@mock.patch('dmutils.request_id.uuid.uuid4', autospec=True)
+def test_request_header(
+    uuid4_mock,
+    app,
+    extra_config,
+    extra_req_headers,
+    expected_trace_id,
+    expect_uuid_call,
+    expected_span_id,
+    expected_parent_span_id,
+    expected_onwards_req_headers,
+    expected_resp_headers,  # unused here
+):
+    app.config.update(extra_config)
+    request_id_init_app(app)
 
-    request_id = request._get_request_id('DM-REQUEST-ID',
-                                         'DOWNSTREAM-REQUEST-ID')
+    uuid4_mock.return_value = "generated"
 
-    uuid4_mock.assert_called_once()
-    assert request_id == 'generated'
+    with app.test_request_context(headers=extra_req_headers):
+        assert request.request_id == request.trace_id == expected_trace_id
+        assert request.span_id == expected_span_id
+        assert request.parent_span_id == expected_parent_span_id
+        assert request.get_onwards_request_headers() == expected_onwards_req_headers
+
+    assert uuid4_mock.called is expect_uuid_call
 
 
-def test_request_id_is_set_on_response(app):
-    request_id.init_app(app)
+@pytest.mark.parametrize(
+    (
+        "extra_config",
+        "extra_req_headers",
+        "expected_trace_id",
+        "expect_uuid_call",
+        "expected_span_id",
+        "expected_parent_span_id",
+        "expected_onwards_req_headers",
+        "expected_resp_headers",
+    ),
+    _param_combinations,
+)
+@mock.patch('dmutils.request_id.uuid.uuid4', autospec=True)
+def test_request_id_is_set_on_response(
+    uuid4_mock,
+    app,
+    extra_config,
+    extra_req_headers,
+    expected_trace_id,  # unused here
+    expect_uuid_call,
+    expected_span_id,  # unused here
+    expected_parent_span_id,  # unused here
+    expected_onwards_req_headers,  # unused here
+    expected_resp_headers,
+):
+    app.config.update(extra_config)
+    request_id_init_app(app)
     client = app.test_client()
+
+    uuid4_mock.return_value = "generated"
 
     with app.app_context():
-        response = client.get('/', headers={'DM-REQUEST-ID': 'generated'})
-        assert response.headers['DM-Request-ID'] == 'generated'
+        response = client.get('/', headers=extra_req_headers)
+        # note using these mechanisms we're not able to test for the *absence* of a header
+        assert {k: v for k, v in response.headers.items() if k in expected_onwards_req_headers} == expected_resp_headers
+
+    assert uuid4_mock.called is expect_uuid_call
 
 
-def test_request_id_is_set_on_error_response(app):
-    request_id.init_app(app)
+@pytest.mark.parametrize(
+    (
+        "extra_config",
+        "extra_req_headers",
+        "expected_trace_id",
+        "expect_uuid_call",
+        "expected_span_id",
+        "expected_parent_span_id",
+        "expected_onwards_req_headers",
+        "expected_resp_headers",
+    ),
+    _param_combinations,
+)
+@mock.patch('dmutils.request_id.uuid.uuid4', autospec=True)
+def test_request_id_is_set_on_error_response(
+    uuid4_mock,
+    app,
+    extra_config,
+    extra_req_headers,
+    expected_trace_id,  # unused here
+    expect_uuid_call,
+    expected_span_id,  # unused here
+    expected_parent_span_id,  # unused here
+    expected_onwards_req_headers,  # unused here
+    expected_resp_headers,
+):
+    app.config.update(extra_config)
+    request_id_init_app(app)
     client = app.test_client()
+
+    uuid4_mock.return_value = "generated"
 
     @app.route('/')
     def error_route():
         raise Exception()
 
     with app.app_context():
-        response = client.get('/', headers={'DM-REQUEST-ID': 'generated'})
+        response = client.get('/', headers=extra_req_headers)
         assert response.status_code == 500
-        assert response.headers['DM-Request-ID'] == 'generated'
+        assert {k: v for k, v in response.headers.items() if k in expected_onwards_req_headers} == expected_resp_headers
+
+    assert uuid4_mock.called is expect_uuid_call

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -37,133 +37,174 @@ _trace_id_related_params = (
         },
     ),
     (
+        # extra_config
         {
             "DM_REQUEST_ID_HEADER": "DM-REQUEST-ID",
             "DM_DOWNSTREAM_REQUEST_ID_HEADER": "DOWNSTREAM-REQUEST-ID",
         },
+        # extra_req_headers
         (
             ("DOWNSTREAM-REQUEST-ID", "from-downstream",),
         ),
+        # expected_trace_id
         "from-downstream",
         False,
+        # expected_onwards_req_headers
         {
             "DM-REQUEST-ID": "from-downstream",
             "DOWNSTREAM-REQUEST-ID": "from-downstream",
         },
+        # expected_resp_headers
         {
             "DM-REQUEST-ID": "from-downstream",
             "DOWNSTREAM-REQUEST-ID": "from-downstream",
         },
     ),
     (
+        # extra_config
         {
             "DM_REQUEST_ID_HEADER": "DM-REQUEST-ID",
             "DM_DOWNSTREAM_REQUEST_ID_HEADER": "",
         },
+        # extra_req_headers
         (),
+        # expected_trace_id
         _GENERATED_TRACE_VALUE,
+        # expect_uuid_call
         True,
+        # expected_onwards_req_headers
         {
             "DM-REQUEST-ID": _GENERATED_TRACE_VALUE,
             "X-B3-TraceId": _GENERATED_TRACE_VALUE,
         },
+        # expected_resp_headers
         {
             "DM-REQUEST-ID": _GENERATED_TRACE_VALUE,
             "X-B3-TraceId": _GENERATED_TRACE_VALUE,
         },
     ),
     (
+        # extra_config
         {
             "DM_REQUEST_ID_HEADER": "DM-REQUEST-ID",
             "DM_DOWNSTREAM_REQUEST_ID_HEADER": "DOWNSTREAM-REQUEST-ID",
         },
+        # extra_req_headers
         (),
+        # expected_trace_id
         _GENERATED_TRACE_VALUE,
+        # expect_uuid_call
         True,
+        # expected_onwards_req_headers
         {
             "DM-REQUEST-ID": _GENERATED_TRACE_VALUE,
             "DOWNSTREAM-REQUEST-ID": _GENERATED_TRACE_VALUE,
         },
+        # expected_resp_headers
         {
             "DM-REQUEST-ID": _GENERATED_TRACE_VALUE,
             "DOWNSTREAM-REQUEST-ID": _GENERATED_TRACE_VALUE,
         },
     ),
     (
+        # extra_config
         {
             # not setting DM_REQUEST_ID_HEADER should cause it to fall back to the default, DM-Request-ID
             "DM_DOWNSTREAM_REQUEST_ID_HEADER": "DOWNSTREAM-REQUEST-ID",
         },
+        # extra_req_headers
         (
             ("x-b3-traceid", "H. M. S. Belleisle",),  # should be ignored as default header name has been overwritten
         ),
+        # expected_trace_id
         _GENERATED_TRACE_VALUE,
+        # expect_uuid_call
         True,
+        # expected_onwards_req_headers
         {
             "DM-Request-ID": _GENERATED_TRACE_VALUE,
             "DOWNSTREAM-REQUEST-ID": _GENERATED_TRACE_VALUE,
         },
+        # expected_resp_headers
         {
             "DM-Request-ID": _GENERATED_TRACE_VALUE,
             "DOWNSTREAM-REQUEST-ID": _GENERATED_TRACE_VALUE,
         },
     ),
     (
+        # extra_config
         {
             "DM_TRACE_ID_HEADERS": ("x-tommy-caffrey", "y-jacky-caffrey",),
             "DM_REQUEST_ID_HEADER": "DM-REQUEST-ID",
             "DM_DOWNSTREAM_REQUEST_ID_HEADER": "DOWNSTREAM-REQUEST-ID",
         },
+        # extra_req_headers
         (
             # these should both be ignored because of the presence of the DM_TRACE_ID_HEADERS setting
             ("DM-REQUEST-ID", "from-header",),
             ("DOWNSTREAM-REQUEST-ID", "from-downstream",),
         ),
+        # expected_trace_id
         _GENERATED_TRACE_VALUE,
+        # expect_uuid_call
         True,
+        # expected_onwards_req_headers
         {
             "x-tommy-caffrey": _GENERATED_TRACE_VALUE,
             "y-jacky-caffrey": _GENERATED_TRACE_VALUE,
         },
+        # expected_resp_headers
         {
             "x-tommy-caffrey": _GENERATED_TRACE_VALUE,
             "y-jacky-caffrey": _GENERATED_TRACE_VALUE,
         },
     ),
     (
+        # extra_config
         {
             "DM_TRACE_ID_HEADERS": ("x-tommy-caffrey", "y-jacky-caffrey",),
         },
+        # extra_req_headers
         (
             ("y-jacky-caffrey", "jacky-header-value",),
             ("x-tommy-caffrey", "tommy-header-value",),
         ),
+        # expected_trace_id
         "tommy-header-value",
+        # expect_uuid_call
         False,
+        # expected_onwards_req_headers
         {
             "x-tommy-caffrey": "tommy-header-value",
             "y-jacky-caffrey": "tommy-header-value",
         },
+        # expected_resp_headers
         {
             "x-tommy-caffrey": "tommy-header-value",
             "y-jacky-caffrey": "tommy-header-value",
         },
     ),
     (
+        # extra_config
         {
             "DM_REQUEST_ID_HEADER": "DM-REQUEST-ID",
             # not setting DM_DOWNSTREAM_REQUEST_ID_HEADER should cause it to fall back to the default, X-B3-TraceId
         },
+        # extra_req_headers
         (
             ("x-kidneys", "pork",),
             ("x-b3-traceid", "Grilled Mutton",),
         ),
+        # expected_trace_id
         "Grilled Mutton",
+        # expect_uuid_call
         False,
+        # expected_onwards_req_headers
         {
             "DM-REQUEST-ID": "Grilled Mutton",
             "X-B3-TraceId": "Grilled Mutton",
         },
+        # expected_resp_headers
         {
             "DM-REQUEST-ID": "Grilled Mutton",
             "X-B3-TraceId": "Grilled Mutton",
@@ -188,19 +229,27 @@ _span_id_related_params = (
         },
     ),
     (
+        # extra_config
         {},
+        # extra_req_headers
         (),
+        # expected_span_id
         None,
+        # expected_onwards_req_headers
         {},
     ),
     (
+        # extra_config
         {
             "DM_SPAN_ID_HEADERS": ("barrels-and-boxes", "Bloomusalem",),
         },
+        # extra_req_headers
         (
             ("bloomusalem", "huge-pork-kidney",),
         ),
+        # expected_span_id
         "huge-pork-kidney",
+        # expected_onwards_req_headers
         {
             "barrels-and-boxes": "huge-pork-kidney",
             "Bloomusalem": "huge-pork-kidney",
@@ -222,17 +271,23 @@ _parent_span_id_related_params = (
         "colossal-edifice",
     ),
     (
+        # extra_config
         {},
+        # extra_req_headers
         (),
+        # expected_parent_span_id
         None,
     ),
     (
+        # extra_config
         {
             "DM_PARENT_SPAN_ID_HEADERS": ("Potato-Preservative",),
         },
+        # extra_req_headers
         (
             ("POTATO-PRESERVATIVE", "Plage and Pestilence",),
         ),
+        # expected_parent_span_id
         "Plage and Pestilence",
     ),
 )

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -88,18 +88,20 @@ _trace_id_related_params = (
     ),
     (
         {
-            "DM_REQUEST_ID_HEADER": "DM-REQUEST-ID",
+            # not setting DM_REQUEST_ID_HEADER should cause it to fall back to the default, DM-Request-ID
             "DM_DOWNSTREAM_REQUEST_ID_HEADER": "DOWNSTREAM-REQUEST-ID",
         },
-        (),
+        (
+            ("x-b3-traceid", "H. M. S. Belleisle",),  # should be ignored as default header name has been overwritten
+        ),
         "generated",
         True,
         {
-            "DM-REQUEST-ID": "generated",
+            "DM-Request-ID": "generated",
             "DOWNSTREAM-REQUEST-ID": "generated",
         },
         {
-            "DM-REQUEST-ID": "generated",
+            "DM-Request-ID": "generated",
             "DOWNSTREAM-REQUEST-ID": "generated",
         },
     ),

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -6,6 +6,9 @@ import pytest
 from dmutils.request_id import init_app as request_id_init_app
 
 
+_GENERATED_TRACE_VALUE = "di5ea5e5deadbeefbaadf00dabadcafe"
+
+
 _trace_id_related_params = (
     (
         # extra_config
@@ -58,15 +61,15 @@ _trace_id_related_params = (
             "DM_DOWNSTREAM_REQUEST_ID_HEADER": "",
         },
         (),
-        "generated",
+        _GENERATED_TRACE_VALUE,
         True,
         {
-            "DM-REQUEST-ID": "generated",
-            "X-B3-TraceId": "generated",
+            "DM-REQUEST-ID": _GENERATED_TRACE_VALUE,
+            "X-B3-TraceId": _GENERATED_TRACE_VALUE,
         },
         {
-            "DM-REQUEST-ID": "generated",
-            "X-B3-TraceId": "generated",
+            "DM-REQUEST-ID": _GENERATED_TRACE_VALUE,
+            "X-B3-TraceId": _GENERATED_TRACE_VALUE,
         },
     ),
     (
@@ -75,15 +78,15 @@ _trace_id_related_params = (
             "DM_DOWNSTREAM_REQUEST_ID_HEADER": "DOWNSTREAM-REQUEST-ID",
         },
         (),
-        "generated",
+        _GENERATED_TRACE_VALUE,
         True,
         {
-            "DM-REQUEST-ID": "generated",
-            "DOWNSTREAM-REQUEST-ID": "generated",
+            "DM-REQUEST-ID": _GENERATED_TRACE_VALUE,
+            "DOWNSTREAM-REQUEST-ID": _GENERATED_TRACE_VALUE,
         },
         {
-            "DM-REQUEST-ID": "generated",
-            "DOWNSTREAM-REQUEST-ID": "generated",
+            "DM-REQUEST-ID": _GENERATED_TRACE_VALUE,
+            "DOWNSTREAM-REQUEST-ID": _GENERATED_TRACE_VALUE,
         },
     ),
     (
@@ -94,15 +97,15 @@ _trace_id_related_params = (
         (
             ("x-b3-traceid", "H. M. S. Belleisle",),  # should be ignored as default header name has been overwritten
         ),
-        "generated",
+        _GENERATED_TRACE_VALUE,
         True,
         {
-            "DM-Request-ID": "generated",
-            "DOWNSTREAM-REQUEST-ID": "generated",
+            "DM-Request-ID": _GENERATED_TRACE_VALUE,
+            "DOWNSTREAM-REQUEST-ID": _GENERATED_TRACE_VALUE,
         },
         {
-            "DM-Request-ID": "generated",
-            "DOWNSTREAM-REQUEST-ID": "generated",
+            "DM-Request-ID": _GENERATED_TRACE_VALUE,
+            "DOWNSTREAM-REQUEST-ID": _GENERATED_TRACE_VALUE,
         },
     ),
     (
@@ -116,15 +119,15 @@ _trace_id_related_params = (
             ("DM-REQUEST-ID", "from-header",),
             ("DOWNSTREAM-REQUEST-ID", "from-downstream",),
         ),
-        "generated",
+        _GENERATED_TRACE_VALUE,
         True,
         {
-            "x-tommy-caffrey": "generated",
-            "y-jacky-caffrey": "generated",
+            "x-tommy-caffrey": _GENERATED_TRACE_VALUE,
+            "y-jacky-caffrey": _GENERATED_TRACE_VALUE,
         },
         {
-            "x-tommy-caffrey": "generated",
-            "y-jacky-caffrey": "generated",
+            "x-tommy-caffrey": _GENERATED_TRACE_VALUE,
+            "y-jacky-caffrey": _GENERATED_TRACE_VALUE,
         },
     ),
     (
@@ -300,7 +303,7 @@ def test_request_header(
     app.config.update(extra_config)
     request_id_init_app(app)
 
-    uuid4_mock.return_value = "generated"
+    uuid4_mock.return_value = mock.Mock(hex=_GENERATED_TRACE_VALUE)
 
     with app.test_request_context(headers=extra_req_headers):
         assert request.request_id == request.trace_id == expected_trace_id
@@ -341,7 +344,7 @@ def test_response_headers_regular_response(
     request_id_init_app(app)
     client = app.test_client()
 
-    uuid4_mock.return_value = "generated"
+    uuid4_mock.return_value = mock.Mock(hex=_GENERATED_TRACE_VALUE)
 
     with app.app_context():
         response = client.get('/', headers=extra_req_headers)
@@ -381,7 +384,7 @@ def test_response_headers_error_response(
     request_id_init_app(app)
     client = app.test_client()
 
-    uuid4_mock.return_value = "generated"
+    uuid4_mock.return_value = mock.Mock(hex=_GENERATED_TRACE_VALUE)
 
     @app.route('/')
     def error_route():


### PR DESCRIPTION
Trello:
 - https://trello.com/c/dlbLmRDB/343-make-use-of-zipkin-headers-in-preference-to-request-id-pt-1 
 - https://trello.com/c/UOXf4vZZ/308-make-use-of-zipkin-headers-in-preference-to-request-id

This is _designed to be_ fully backwards-compatible. Hopefully it achieves that and is thus deployable at will.

As before, this will cause apps to look for a `DM-Request-ID` header on requests and take that on as the request id if that's present. This will allow "downstream" apps to continue to assume the request id generated by an upstream app. However failing that it will now also look for a `X-B3-TraceId` header to allow our hosting infrastructure to assign an appropriate id for us. This has the advantage of added certainty that a (single) id is assigned to all requests, whether they start their journey through an app running this middleware or not.

The previous implementation already had a mechanism which would do a similar thing, controlled by the `DM_DOWNSTREAM_REQUEST_ID_HEADER` config setting - I simply made the feature more generic - allowing an arbitrary sequence of header names to be checked for in priority order (`DM_TRACE_ID_HEADERS`). However the previous config settings are respected and used as the defaults of `DM_TRACE_ID_HEADERS`

Also added the ability to record "span id" if it is provided to us.

Added a centralized, extensible way for a request to specify headers which should be propagated in onwards (internal) http api requests rather than have the apiclient need to know the exact details of what details to drag out of where as it currently does. This should allow us to easily add propagatable headers such as debug flags with minimal cross-repo-churn.

By default it propagates headers using *all* alternative header names it knows about, again, for compatibility reasons.

Because I think this should be 100% back-compatible I haven't done a major version bump. Hoping that's ok.