### PR TITLE
Shared access control function 'require_login'

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '33.0.1'
+__version__ = '33.1.0'

--- a/dmutils/access_control.py
+++ b/dmutils/access_control.py
@@ -1,0 +1,24 @@
+from flask_login import current_user, login_required
+from flask import current_app, flash, Markup
+
+
+ROLES = {
+    'buyer': {
+        'loginRequiredMessage': Markup("You must log in with a buyer account to see this page."),
+    },
+}
+
+
+@login_required
+def require_login(role):
+    """
+    Shared function to limit access to a view by role. Intended to be used with Application.before_request
+    or Blueprint.before_request, for example:
+        some_blueprint.before_request(functools.partial(require_login, role='buyer'))
+    :param role: string, e.g. admin, buyer, supplier
+    :return: an unauthorized response, or None if access is allowed (once logged in)
+    """
+    if current_user.is_authenticated() and current_user.role != role:
+        flash(ROLES[role]['loginRequiredMessage'], 'error')
+        return current_app.login_manager.unauthorized()
+

--- a/dmutils/access_control.py
+++ b/dmutils/access_control.py
@@ -6,13 +6,16 @@ ROLES = {
     'buyer': {
         'loginRequiredMessage': Markup("You must log in with a buyer account to see this page."),
     },
+    'supplier': {
+        'loginRequiredMessage': Markup("You must log in with a supplier account to see this page."),
+    },
 }
 
 
 @login_required
 def require_login(role):
     """
-    Shared function to limit access to a view by role. Intended to be used with Application.before_request
+    Shared function to limit access to a view by role. Can be used with Application.before_request
     or Blueprint.before_request, for example:
         some_blueprint.before_request(functools.partial(require_login, role='buyer'))
     :param role: string, e.g. admin, buyer, supplier

--- a/dmutils/access_control.py
+++ b/dmutils/access_control.py
@@ -24,4 +24,3 @@ def require_login(role):
     if current_user.is_authenticated() and current_user.role != role:
         flash(ROLES[role]['loginRequiredMessage'], 'error')
         return current_app.login_manager.unauthorized()
-

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,5 @@ pytest-cov==2.5.1
 python-coveralls==2.5.0
 Flask==0.10.1
 Flask-WTF==0.12
+
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@1.0.0#egg=digitalmarketplace-test-utils==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
          'Flask-Script==2.0.5',
          'Flask-WTF==0.12',
          'Flask>=0.10',
+         'Flask-Login>=0.2.11',
          'boto3==1.4.4',
          'contextlib2==0.4.0',
          'cryptography==1.9',

--- a/tests/test_access_control.py
+++ b/tests/test_access_control.py
@@ -1,0 +1,66 @@
+import functools
+import pytest
+
+from flask import Blueprint
+from flask_login import LoginManager
+
+from dmutils.access_control import require_login
+from dmutils.user import User
+from dmtestutils.login import login_for_tests, USERS
+
+
+@pytest.fixture
+def access_controlled_app(app):
+    """
+    An app where all the routes are access-controlled to the 'buyer' role, and there are some login routes if we need.
+    """
+    login_manager = LoginManager()
+    login_manager.init_app(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        # simulate loading a user from the API
+        return User.from_json({"users": USERS[user_id]})
+
+    app.register_blueprint(login_for_tests)
+    app.secret_key = 'secret'
+
+    main = Blueprint('main', 'main')
+
+    @main.route('/')
+    def simple_route():
+        return "Hello"
+
+    main.before_request(functools.partial(require_login, role='buyer'))
+    app.register_blueprint(main)
+
+    return app
+
+
+def test_all_routes_require_login(access_controlled_app):
+    """
+    Check that routes where we are applying our "require_login" function are actually protected from anonymous access
+    - in this case with a 401 rather than a redirect-to-login, because we don't set a login page for our test client.
+    """
+
+    client = access_controlled_app.test_client()
+    response = client.get('/')
+    assert response.status_code == 401
+
+
+def test_access_deny_for_wrong_role(access_controlled_app):
+    client = access_controlled_app.test_client()
+    response = client.get("/auto-supplier-login")
+    assert response.status_code == 200
+
+    response = client.get('/')
+    assert response.status_code == 401
+
+
+def test_access_allow_for_correct_role(access_controlled_app):
+    client = access_controlled_app.test_client()
+    response = client.get("/auto-buyer-login")
+    assert response.status_code == 200
+
+    response = client.get('/')
+    assert response.status_code == 200


### PR DESCRIPTION
These flash messages are being being moved out of the frontend toolkit so that we no longer need special cases in the flash message template.

The "buyer" version of this message must be in dm-utils because it needs to be shared between the buyer app and the briefs app. (This is arguably an indication that they should not be separate apps, ho hum.) The supplier version of the message is moving here because in this case having the messages in one place is still beneficial, it's just that the template is the wrong place for them.

The suggested method of applying this function is a bit weird and only applies when we're attaching the behaviour to an entire blueprint. The supplier app just calls the function from a decorator.

This is dependent on a PR in the dm-test-utils repo - or we could move that module here instead. https://github.com/alphagov/digitalmarketplace-test-utils/pull/2

https://trello.com/c/lQIP4rf8/300-flash-messages-briefs-app

--
PS to understand how this code will be used, here are the proposed changes to the supplier and briefs apps:

https://github.com/alphagov/digitalmarketplace-supplier-frontend/compare/move-flash-messages-out-of-template
https://github.com/alphagov/digitalmarketplace-briefs-frontend/compare/move-flash-messages-out-of-template
