### PR TITLE
request id handling: back-populate the first value of DM_TRACE_ID_HEADERS back to the DM_REQUEST_ID_HEADER setting

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '34.1.0'
+__version__ = '34.1.1'

--- a/dmutils/request_id.py
+++ b/dmutils/request_id.py
@@ -101,6 +101,12 @@ def init_app(app):
     app.config.setdefault("DM_SPAN_ID_HEADERS", ("X-B3-SpanId",))
     app.config.setdefault("DM_PARENT_SPAN_ID_HEADERS", ("X-B3-ParentSpan",))
 
+    # we do something a little odd here now - back-populate the first value of DM_TRACE_ID_HEADERS back to the
+    # DM_REQUEST_ID_HEADER setting, because it turns out that some components (notably the apiclient) depend on that
+    # setting
+    if app.config.get("DM_TRACE_ID_HEADERS"):
+        app.config["DM_REQUEST_ID_HEADER"] = app.config["DM_TRACE_ID_HEADERS"][0]
+
     # dynamically define this class as we don't necessarily know how request_class may have already been modified by
     # another init_app
     class _RequestIdRequest(RequestIdRequestMixin, app.request_class):

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -35,6 +35,8 @@ _trace_id_related_params = (
             "DM-REQUEST-ID": "from-header",
             "DOWNSTREAM-REQUEST-ID": "from-header",
         },
+        # expected_dm_request_id_header_final_value
+        "DM-REQUEST-ID",
     ),
     (
         # extra_config
@@ -59,6 +61,8 @@ _trace_id_related_params = (
             "DM-REQUEST-ID": "from-downstream",
             "DOWNSTREAM-REQUEST-ID": "from-downstream",
         },
+        # expected_dm_request_id_header_final_value
+        "DM-REQUEST-ID",
     ),
     (
         # extra_config
@@ -82,6 +86,8 @@ _trace_id_related_params = (
             "DM-REQUEST-ID": _GENERATED_TRACE_VALUE,
             "X-B3-TraceId": _GENERATED_TRACE_VALUE,
         },
+        # expected_dm_request_id_header_final_value
+        "DM-REQUEST-ID",
     ),
     (
         # extra_config
@@ -105,6 +111,8 @@ _trace_id_related_params = (
             "DM-REQUEST-ID": _GENERATED_TRACE_VALUE,
             "DOWNSTREAM-REQUEST-ID": _GENERATED_TRACE_VALUE,
         },
+        # expected_dm_request_id_header_final_value
+        "DM-REQUEST-ID",
     ),
     (
         # extra_config
@@ -130,6 +138,8 @@ _trace_id_related_params = (
             "DM-Request-ID": _GENERATED_TRACE_VALUE,
             "DOWNSTREAM-REQUEST-ID": _GENERATED_TRACE_VALUE,
         },
+        # expected_dm_request_id_header_final_value
+        "DM-Request-ID",
     ),
     (
         # extra_config
@@ -158,6 +168,8 @@ _trace_id_related_params = (
             "x-tommy-caffrey": _GENERATED_TRACE_VALUE,
             "y-jacky-caffrey": _GENERATED_TRACE_VALUE,
         },
+        # expected_dm_request_id_header_final_value
+        "x-tommy-caffrey",
     ),
     (
         # extra_config
@@ -183,6 +195,8 @@ _trace_id_related_params = (
             "x-tommy-caffrey": "tommy-header-value",
             "y-jacky-caffrey": "tommy-header-value",
         },
+        # expected_dm_request_id_header_final_value
+        "x-tommy-caffrey",
     ),
     (
         # extra_config
@@ -209,6 +223,8 @@ _trace_id_related_params = (
             "DM-REQUEST-ID": "Grilled Mutton",
             "X-B3-TraceId": "Grilled Mutton",
         },
+        # expected_dm_request_id_header_final_value
+        "DM-REQUEST-ID",
     ),
 )
 
@@ -308,6 +324,7 @@ _param_combinations = tuple(
         # expected_onwards_req_headers
         dict(chain(t_expected_onwards_req_headers.items(), s_expected_onwards_req_headers.items(),)),
         expected_resp_headers,
+        expected_dm_request_id_header_final_value,
     ) for (
         t_extra_config,
         t_extra_req_headers,
@@ -316,6 +333,7 @@ _param_combinations = tuple(
         t_expected_onwards_req_headers,
         # so far only the trace_id should affect the response headers
         expected_resp_headers,
+        expected_dm_request_id_header_final_value,
     ), (
         s_extra_config,
         s_extra_req_headers,
@@ -339,6 +357,7 @@ _param_combinations = tuple(
         "expected_parent_span_id",
         "expected_onwards_req_headers",
         "expected_resp_headers",
+        "expected_dm_request_id_header_final_value",
     ),
     _param_combinations,
 )
@@ -354,9 +373,12 @@ def test_request_header(
     expected_parent_span_id,
     expected_onwards_req_headers,
     expected_resp_headers,  # unused here
+    expected_dm_request_id_header_final_value,
 ):
     app.config.update(extra_config)
     request_id_init_app(app)
+
+    assert app.config.get("DM_REQUEST_ID_HEADER") == expected_dm_request_id_header_final_value
 
     uuid4_mock.return_value = mock.Mock(hex=_GENERATED_TRACE_VALUE)
 
@@ -365,6 +387,7 @@ def test_request_header(
         assert request.span_id == expected_span_id
         assert request.parent_span_id == expected_parent_span_id
         assert request.get_onwards_request_headers() == expected_onwards_req_headers
+        assert app.config.get("DM_REQUEST_ID_HEADER") == expected_dm_request_id_header_final_value
 
     assert uuid4_mock.called is expect_uuid_call
 
@@ -379,6 +402,7 @@ def test_request_header(
         "expected_parent_span_id",
         "expected_onwards_req_headers",
         "expected_resp_headers",
+        "expected_dm_request_id_header_final_value",
     ),
     _param_combinations,
 )
@@ -394,6 +418,7 @@ def test_response_headers_regular_response(
     expected_parent_span_id,  # unused here
     expected_onwards_req_headers,  # unused here
     expected_resp_headers,
+    expected_dm_request_id_header_final_value,  # unused here
 ):
     app.config.update(extra_config)
     request_id_init_app(app)
@@ -419,6 +444,7 @@ def test_response_headers_regular_response(
         "expected_parent_span_id",
         "expected_onwards_req_headers",
         "expected_resp_headers",
+        "expected_dm_request_id_header_final_value",
     ),
     _param_combinations,
 )
@@ -434,6 +460,7 @@ def test_response_headers_error_response(
     expected_parent_span_id,  # unused here
     expected_onwards_req_headers,  # unused here
     expected_resp_headers,
+    expected_dm_request_id_header_final_value,  # unused here
 ):
     app.config.update(extra_config)
     request_id_init_app(app)


### PR DESCRIPTION
...because it turns out that some components (notably the apiclient) depend on that setting - we can get rid of this once that/those are fixed. this also has the nice property that `DM_REQUEST_ID_HEADER` should now always equal the first entry of `DM_TRACE_ID_HEADERS`, even if it was `DM_TRACE_ID_HEADERS` that was overridden.

Trello https://trello.com/c/dlbLmRDB/343-make-use-of-zipkin-headers-in-preference-to-request-id-pt-1