### PR TITLE
Add supplier organisation size to User object

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '34.1.1'
+__version__ = '34.2.0'

--- a/dmutils/user.py
+++ b/dmutils/user.py
@@ -49,6 +49,7 @@ class User():
             'emailAddress': self.email_address,
             'supplierId': self.supplier_id,
             'supplierName': self.supplier_name,
+            'supplierOrganisationSize': self.supplier_organisation_size,
             'locked': self.locked,
         }
 

--- a/dmutils/user.py
+++ b/dmutils/user.py
@@ -6,7 +6,7 @@ def user_has_role(user, role):
 
 
 class User():
-    def __init__(self, user_id, email_address, supplier_id, supplier_name,
+    def __init__(self, user_id, email_address, supplier_id, supplier_name, supplier_organisation_size,
                  locked, active, name, role):
         self.id = user_id
         self.email_address = email_address
@@ -14,6 +14,7 @@ class User():
         self.role = role
         self.supplier_id = supplier_id
         self.supplier_name = supplier_name
+        self.supplier_organisation_size = supplier_organisation_size
         self.locked = locked
         self.active = active
 
@@ -56,14 +57,17 @@ class User():
         user = user_json["users"]
         supplier_id = None
         supplier_name = None
+        supplier_organisation_size = None
         if "supplier" in user:
             supplier_id = user["supplier"]["supplierId"]
             supplier_name = user["supplier"]["name"]
+            supplier_organisation_size = user["supplier"].get("organisationSize")
         return User(
             user_id=user["id"],
             email_address=user['emailAddress'],
             supplier_id=supplier_id,
             supplier_name=supplier_name,
+            supplier_organisation_size=supplier_organisation_size,
             locked=user.get('locked', False),
             active=user.get('active', True),
             name=user['name'],

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -25,7 +25,7 @@ def test_user_has_role_returns_false_on_non_matching_role():
 
 
 def test_User_from_json():
-    user = User.from_json({'users': {
+    admin_user = User.from_json({'users': {
         'id': 123,
         'emailAddress': 'test@example.com',
         'locked': False,
@@ -34,16 +34,16 @@ def test_User_from_json():
         'role': 'admin',
     }})
 
-    assert user.id == 123
-    assert user.name == 'Name'
-    assert user.role == 'admin'
-    assert user.email_address == 'test@example.com'
-    assert not user.is_locked()
-    assert user.is_active()
+    assert admin_user.id == 123
+    assert admin_user.name == 'Name'
+    assert admin_user.role == 'admin'
+    assert admin_user.email_address == 'test@example.com'
+    assert not admin_user.is_locked()
+    assert admin_user.is_active()
 
 
 def test_User_from_json_with_supplier():
-    user = User.from_json({'users': {
+    supplier_user = User.from_json({'users': {
         'id': 123,
         'name': 'Name',
         'role': 'supplier',
@@ -56,13 +56,13 @@ def test_User_from_json_with_supplier():
             'organisationSize': 'micro'
         }
     }})
-    assert user.id == 123
-    assert user.name == 'Name'
-    assert user.role == 'supplier'
-    assert user.email_address == 'test@example.com'
-    assert user.supplier_id == 321
-    assert user.supplier_name == 'test supplier'
-    assert user.supplier_organisation_size == 'micro'
+    assert supplier_user.id == 123
+    assert supplier_user.name == 'Name'
+    assert supplier_user.role == 'supplier'
+    assert supplier_user.email_address == 'test@example.com'
+    assert supplier_user.supplier_id == 321
+    assert supplier_user.supplier_name == 'test supplier'
+    assert supplier_user.supplier_organisation_size == 'micro'
 
 
 def test_User_from_json_with_supplier_no_organisation_size():
@@ -82,27 +82,27 @@ def test_User_from_json_with_supplier_no_organisation_size():
 
 
 def test_User_has_role(user_json):
-    user = User.from_json(user_json)
-    assert user.has_role('supplier')
-    assert not user.has_role('admin')
+    supplier_user = User.from_json(user_json)
+    assert supplier_user.has_role('supplier')
+    assert not supplier_user.has_role('admin')
 
 
 def test_User_has_any_role(user_json):
-    user = User.from_json(user_json)
-    assert user.has_any_role('supplier', 'other')
-    assert user.has_any_role('other', 'supplier')
-    assert not user.has_any_role('other', 'admin')
+    supplier_user = User.from_json(user_json)
+    assert supplier_user.has_any_role('supplier', 'other')
+    assert supplier_user.has_any_role('other', 'supplier')
+    assert not supplier_user.has_any_role('other', 'admin')
 
 
 def test_User_load_user(user_json):
     data_api_client = mock.Mock()
     data_api_client.get_user.return_value = user_json
 
-    user = User.load_user(data_api_client, 123)
+    loaded_user = User.load_user(data_api_client, 123)
 
     data_api_client.get_user.assert_called_once_with(user_id=123)
-    assert user is not None
-    assert user.id == 123
+    assert loaded_user is not None
+    assert loaded_user.id == 123
 
 
 def test_User_load_user_raises_ValueError_on_non_integer_user_id():

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -5,7 +5,7 @@ from dmutils.user import user_has_role, User
 
 @pytest.fixture
 def user():
-    return User(123, 'test@example.com', 321, 'test supplier', False, True, "Name", 'supplier')
+    return User(123, 'test@example.com', 321, 'test supplier', 'micro', False, True, "Name", 'supplier')
 
 
 def test_user_has_role():
@@ -53,6 +53,7 @@ def test_User_from_json_with_supplier():
         'supplier': {
             'supplierId': 321,
             'name': 'test supplier',
+            'organisationSize': 'micro'
         }
     }})
     assert user.id == 123
@@ -61,6 +62,23 @@ def test_User_from_json_with_supplier():
     assert user.email_address == 'test@example.com'
     assert user.supplier_id == 321
     assert user.supplier_name == 'test supplier'
+    assert user.supplier_organisation_size == 'micro'
+
+
+def test_User_from_json_with_supplier_no_organisation_size():
+    supplier_user = User.from_json({'users': {
+        'id': 123,
+        'name': 'Name',
+        'role': 'supplier',
+        'emailAddress': 'test@example.com',
+        'locked': False,
+        'active': True,
+        'supplier': {
+            'supplierId': 321,
+            'name': 'test supplier'
+        }
+    }})
+    assert supplier_user.supplier_organisation_size is None
 
 
 def test_User_has_role(user_json):


### PR DESCRIPTION
Trello: https://trello.com/c/PZyZdMtG/337-custom-dimension-to-capture-size-of-supplier

For our analytics we want to capture logged-in suppliers' organisation size. This needs to be exposed via an attribute of the Flask user object, so we can set the custom dimension in the template, for example:

```
{% set custom_dimensions = [
      {"data_id": 11, "data_value": current_user.supplier_organisation_size }
   ] 
%}
```

This version of utils should be backwards compatible even if the relevant API changes (see https://github.com/alphagov/digitalmarketplace-api/pull/754) haven't been released yet.