### PR TITLE
Prevent timeouts when fetching Mailchimp email lists

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '34.3.0'
+__version__ = '34.4.0'

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -95,8 +95,8 @@ class DMMailChimpClient(object):
             # mailchimp to never add them to mailchimp lists. In this case, we resort to allowing a failed API call (but
             # log) as a user of this method would unlikely be able to do anything as we have no control over this
             # behaviour.
-            if getattr(e, "response", None) and (
-                "looks fake or invalid, please enter a real email address." in e.response.json()["detail"]
+            if getattr(e, "response", None) is not None and (
+                "looks fake or invalid, please enter a real email address." in e.response.json().get("detail", "")
             ):
                 self.logger.error(
                     "Expected error: Mailchimp failed to add user ({}) to list ({}). API error: The email address looks fake or invalid, please enter a real email address.".format(  # noqa

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -108,7 +108,8 @@ def test_log_error_message_if_error_subscribing_email_to_list(get_email_hash, lo
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', logger)
     with mock.patch.object(
             dm_mailchimp_client._client.lists.members, 'create_or_update', autospec=True) as create_or_update:
-        response = mock.Mock()
+        # The 400 response from MailChimp is actually falsey
+        response = mock.MagicMock(__bool__=False)
         response.json.return_value = {"detail": "Unexpected error."}
         create_or_update.side_effect = RequestException("error sending", response=response)
 
@@ -127,7 +128,7 @@ def test_returns_true_if_expected_error_subscribing_email_to_list(get_email_hash
     dm_mailchimp_client = DMMailChimpClient('username', 'api key', logger)
     with mock.patch.object(
             dm_mailchimp_client._client.lists.members, 'create_or_update', autospec=True) as create_or_update:
-        response = mock.Mock()
+        response = mock.MagicMock(__bool__=False)
         response.json.return_value = {"detail": "foo looks fake or invalid, please enter a real email address."}
         create_or_update.side_effect = RequestException("error sending", response=response)
 


### PR DESCRIPTION
### Retrieve email address from list with pagination
We were giving the `all()` method the `get_all=True` argument. This makes
the client attempt to download 5000 members in one go. This was causing
us issues with timeouts.

By using the `count` and `offset` arguments we can fetch all the email
addresses with a few calls, preventing the timeouts.

More info on how the mail chimp client handles pagination here:
https://github.com/charlesthk/python-mailchimp#pagination

The `timeout_retry` decorator has been adjusted slightly to allow it to
be applied to just the client call, instead of the entire function call.
This way, if only one call to the Mailchimp api times out, we don't have to start
at the beginning of the pagination. 

### Fix bug with checking error response
When there was a `RequestException` from Mailchimp the response was a 400,
which when evaluated was falsey. Therefore the first check would always
fail and the error handling would pass on and return False.

