### PR TITLE
Add disk space check for healthcheck

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '34.5.0'
+__version__ = '34.6.0'

--- a/dmutils/status.py
+++ b/dmutils/status.py
@@ -1,5 +1,6 @@
-import os
 import datetime
+import math
+import os
 from .formats import DATE_FORMAT
 from flask_featureflags import FEATURE_FLAGS_CONFIG
 
@@ -24,6 +25,19 @@ def get_flags(current_app):
                 flags[config_var] = current_app.config[config_var]
 
     return flags
+
+
+def get_disk_space_status(low_disk_percent_threshold=5):
+    """Accepts a single parameter that indicates the minimum percentage of disk space which should be free for the
+    instance to be considered healthy.
+
+    Returns a tuple containing two items: a status (OK or LOW) indicating whether the disk space remaining on the
+    instance is below the threshold and the integer percentage remaining disk space."""
+    disk_stats = os.statvfs('/')
+
+    disk_free_percent = 100 - int(math.ceil(((disk_stats.f_bfree * 1.0) / disk_stats.f_blocks) * 100))
+
+    return 'OK' if disk_free_percent >= low_disk_percent_threshold else 'LOW', disk_free_percent
 
 
 def enabled_since(date_string):

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,29 @@
+from collections import namedtuple
+
+import mock
+import pytest
+
+from dmutils.status import get_disk_space_status
+
+
+def statvfs_fixture(total_blocks, free_blocks):
+    statvfs = namedtuple('statvfs', 'f_blocks f_bfree')
+    return statvfs(total_blocks, free_blocks)
+
+
+@mock.patch('dmutils.status.os.statvfs')
+@pytest.mark.parametrize('kwargs, total_blocks, free_blocks, expected_status',
+                         (
+                             ({}, 1024, 0, ('OK', 100)),
+                             ({}, 1024, 512, ('OK', 50)),
+                             ({}, 1024, 920, ('OK', 10)),
+                             ({}, 1024, 1000, ('LOW', 2)),
+                             ({}, 1024, 1024, ('LOW', 0)),
+                             ({'low_disk_percent_threshold': 10}, 1024, 950, ('LOW', 7)),
+                             ({'low_disk_percent_threshold': 20}, 1024, 920, ('LOW', 10)),
+                             ({'low_disk_percent_threshold': 75}, 1024, 512, ('LOW', 50)),
+                         ))
+def test_disk_space_status(disk_usage, kwargs, total_blocks, free_blocks, expected_status):
+    disk_usage.return_value = statvfs_fixture(total_blocks, free_blocks)
+
+    assert get_disk_space_status(**kwargs) == expected_status


### PR DESCRIPTION
## Summary
We want to be able to check free disk space on instances as part of
their healthcheck endpoint. Here's where we are going to do it.

`get_disk_space_status` will report 'OK' if at least 5% disk space is
free (by default) and 'LOW' if less than 5% is free.

## Ticket
https://trello.com/c/BBvu6eUk/383-ensure-healthcheck-endpoint-fails-if-low-disk-space