### PR TITLE
Centralised app _status endpoint

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,7 @@
 # W503: line break before binary operator
 exclude = venv*,__pycache__,node_modules,bower_components
 ignore = D203,W503
-max-complexity = 10
+max-complexity = 12
 max-line-length = 120
 per-file-ignores =
     **/__init__.py : F401

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '35.1.1'
+__version__ = '35.2.0'

--- a/dmutils/status.py
+++ b/dmutils/status.py
@@ -2,6 +2,7 @@ import datetime
 import math
 import os
 from .formats import DATE_FORMAT
+from flask import jsonify, current_app
 from flask_featureflags import FEATURE_FLAGS_CONFIG
 
 
@@ -47,3 +48,68 @@ def enabled_since(date_string):
         return date_string
 
     return False
+
+
+class StatusError(Exception):
+    """A stub class to use when implementing additional checks for an app's _status endpoint. See API for example.
+    When raising a StatusError, make sure that the message passed in uniquely identifies the additional check you are
+    performing so that any errors can more easily be tied back to a specific dependency that has failed."""
+    message = ''
+
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message
+
+
+def get_app_status(data_api_client=None,
+                   search_api_client=None,
+                   ignore_dependencies=False,
+                   additional_checks=None):
+    """Generates output for `_status` endpoints on apps
+
+    :param current_app: The flask `current_app` global.
+    :param data_api_client: The app's data_api_client, if used.
+    :param search_api_client: The app's search_api_client, if used.
+    :param ignore_dependencies: Minimal endpoint checks only (i.e. the app is routable and disk space is fine).
+    :param additional_checks: A sequence of callables that return dicts of data to be injected into the final JSON
+                              response or raise StatusErrors if they need to log an error that should fail the
+                              check (this will cause the endpoint to return a 500).
+    :return: A dictionary describing the current state of the app with, at least, a 'status' key with a value of 'ok'
+             or 'error'.
+    """
+    error_messages = []
+    response_data = {'status': 'ok'}
+
+    disk_status = get_disk_space_status()
+    response_data['disk'] = f'{disk_status[0]} ({disk_status[1]}% free)'
+    if disk_status[0].lower() != 'ok':
+        error_messages.append(f'Disk space low: {disk_status[1]}% remaining.')
+
+    if not ignore_dependencies:
+        response_data['version'] = current_app.config['VERSION']
+        response_data['flags'] = get_flags(current_app)
+
+        if data_api_client:
+            data_api_status = data_api_client.get_status() or {'status': 'n/a'}
+            response_data['api_status'] = data_api_status
+            if data_api_status['status'].lower() != 'ok':
+                error_messages.append('Error connecting to the Data API.')
+
+        if search_api_client:
+            search_api_status = search_api_client.get_status() or {'status': 'n/a'}
+            response_data['search_api_status'] = search_api_status
+            if search_api_status['status'].lower() != 'ok':
+                error_messages.append('Error connecting to the Search API.')
+
+        for additional_check in (additional_checks or []):
+            try:
+                response_data.update(additional_check())
+
+            except StatusError as e:
+                error_messages.append(e.message)
+
+    if error_messages:
+        response_data['status'] = 'error'
+        response_data['message'] = error_messages
+
+    return jsonify(**response_data), 200 if not error_messages else 500

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,9 +1,10 @@
 from collections import namedtuple
 
+import json
 import mock
 import pytest
 
-from dmutils.status import get_disk_space_status
+from dmutils.status import get_disk_space_status, get_app_status
 
 
 def statvfs_fixture(total_blocks, free_blocks):
@@ -27,3 +28,175 @@ def test_disk_space_status(disk_usage, kwargs, total_blocks, free_blocks, expect
     disk_usage.return_value = statvfs_fixture(total_blocks, free_blocks)
 
     assert get_disk_space_status(**kwargs) == expected_status
+
+
+def additional_check(key, value):
+    m = mock.MagicMock()
+    m.return_value = {key: value}
+    return m
+
+
+@pytest.mark.parametrize('disk_status, '
+                         'data_api_status, '
+                         'search_api_status, '
+                         'ignore_dependencies, '
+                         'additional_checks, '
+                         'expected_json, '
+                         'expected_http_status',
+                         (
+                             (  # Test case #1 - no api clients, ignore_deps = False, result: 200
+                                 ('OK', 90),
+                                 None,
+                                 None,
+                                 False,
+                                 [],
+                                 {'flags': {}, 'status': 'ok', 'version': 'release-0', 'disk': 'OK (90% free)'},
+                                 200
+                             ),
+                             (  # Test case #2 - data api client OK, ignore_deps = False, result: 200
+                                 ('OK', 90),
+                                 'ok',
+                                 None,
+                                 False,
+                                 [],
+                                 {'flags': {}, 'api_status': {'status': 'ok'}, 'status': 'ok', 'version': 'release-0',
+                                  'disk': 'OK (90% free)'},
+                                 200
+                             ),
+                             (  # Test case #3 - search api client OK, ignore_deps = False, result: 200
+                                 ('OK', 90),
+                                 None,
+                                 'ok',
+                                 False,
+                                 [],
+                                 {'flags': {}, 'search_api_status': {'status': 'ok'}, 'status': 'ok',
+                                  'version': 'release-0', 'disk': 'OK (90% free)'},
+                                 200
+                             ),
+                             (  # Test case #4 - data+search api clients OK, ignore_deps = False, result: 200
+                                 ('OK', 90),
+                                 'ok',
+                                 'ok',
+                                 False,
+                                 [],
+                                 {'flags': {}, 'api_status': {'status': 'ok'}, 'search_api_status': {'status': 'ok'},
+                                  'status': 'ok', 'version': 'release-0', 'disk': 'OK (90% free)'},
+                                 200
+                             ),
+                             (  # Test case #5 - data+search api clients OK, ignore_deps = False, +2 checks, result: 500
+                                 ('OK', 90),
+                                 'ok',
+                                 'ok',
+                                 False,
+                                 [additional_check('k', 'v'), additional_check('k2', 'v2')],
+                                 {
+                                     'flags': {}, 'api_status': {'status': 'ok'}, 'search_api_status': {'status': 'ok'},
+                                     'status': 'ok', 'version': 'release-0', 'disk': 'OK (90% free)',
+                                     'k': 'v', 'k2': 'v2'
+                                 },
+                                 200,
+                             ),
+                             (  # Test case #6 - data+search api clients OK, ignore_deps = True, +2 checks, result: 500
+                                 ('OK', 90),
+                                 'ok',
+                                 'ok',
+                                 True,
+                                 [additional_check('k', 'v'), additional_check('k2', 'v2')],
+                                 {'status': 'ok', 'disk': 'OK (90% free)'},
+                                 200,
+                             ),
+                             (  # Test case #6 - data api client ERROR, search api OK, ignore_deps = False, result: 500
+                                 ('OK', 90),
+                                 'error',
+                                 'ok',
+                                 False,
+                                 [],
+                                 {'flags': {},
+                                  'api_status': {'status': 'error'},
+                                  'search_api_status': {'status': 'ok'},
+                                  'status': 'error',
+                                  'version': 'release-0',
+                                  'disk': 'OK (90% free)',
+                                  'message': ['Error connecting to the Data API.']},
+                                 500,
+                             ),
+                             (  # Test case #7 - data+search api client ERROR, ignore_deps = False, result: 500
+                                 ('OK', 90),
+                                 'error',
+                                 'error',
+                                 False,
+                                 [],
+                                 {'flags': {},
+                                  'api_status': {'status': 'error'},
+                                  'search_api_status': {'status': 'error'},
+                                  'status': 'error',
+                                  'version': 'release-0',
+                                  'disk': 'OK (90% free)',
+                                  'message': ['Error connecting to the Data API.',
+                                              'Error connecting to the Search API.']},
+                                 500,
+                             ),
+                             (  # Test case #8 - data+search api client ERROR, ignore_deps = True, result: 200
+                                 ('OK', 90),
+                                 'error',
+                                 'error',
+                                 True,
+                                 [],
+                                 {'status': 'ok', 'disk': 'OK (90% free)'},
+                                 200,
+                             ),
+                             (  # Test case #9 - api clients OK, disk LOW, ignore_deps = True, result: 500
+                                 ('LOW', 1),
+                                 'error',
+                                 'error',
+                                 True,
+                                 [],
+                                 {'status': 'error', 'disk': 'LOW (1% free)',
+                                  'message': ['Disk space low: 1% remaining.']},
+                                 500,
+                             ),
+                         ))
+def test_get_app_status(app,
+                        disk_status,
+                        data_api_status,
+                        search_api_status,
+                        ignore_dependencies,
+                        additional_checks,
+                        expected_json,
+                        expected_http_status):
+    app.config['VERSION'] = 'release-0'
+    data_api_client = None
+    search_api_client = None
+
+    if data_api_status:
+        data_api_client = mock.MagicMock()
+        data_api_client.get_status.return_value = {'status': data_api_status}
+
+    if search_api_status:
+        search_api_client = mock.MagicMock()
+        search_api_client.get_status.return_value = {'status': search_api_status}
+
+    with mock.patch('dmutils.status.get_disk_space_status') as disk_status_patch:
+        disk_status_patch.return_value = disk_status
+
+        with app.app_context(), app.test_request_context():
+            response, status_code = get_app_status(data_api_client=data_api_client,
+                                                   search_api_client=search_api_client,
+                                                   ignore_dependencies=ignore_dependencies,
+                                                   additional_checks=additional_checks)
+
+    assert json.loads(response.data) == expected_json
+    assert status_code == expected_http_status
+
+    # If we pass in the ignore-dependencies flag we want to make sure that the API clients and additional checks
+    # aren't called so that the endpoint returns as quickly as possible with the lowest chance to error.
+    expected_call_list = ([] if ignore_dependencies else [mock.call()])
+
+    if data_api_status:
+        assert data_api_client.get_status.call_args_list == expected_call_list
+
+    if search_api_status:
+        assert search_api_client.get_status.call_args_list == expected_call_list
+
+    for check in additional_checks:
+        assert check.call_args_list == expected_call_list


### PR DESCRIPTION
## Summary
Brings the core logic for serving an app's `_status` endpoint into utils
to share code and reduce replication. Each app should now need to only
call `get_app_status` and pass in the appropriate arguments. The default
status check will validate remaining disk space on the instance as well
as connectivity with the data/search API if applicable. If extra checks
need to be performed, these can be provided using `additional_checks`,
which is a sequence of callables that return dicts with the data that
should be included in the JSON response.

We also add a check for disk usage into the centralised status endpoint.
If disk space is below 5% (by default), we will return a 500 HTTP status
code causing Cloud Foundry to mark the instance as unhealthy and recycle
it.

The test data for this is pretty blegh, but it does provide good coverage and the test _itself_ isn't very hard to follow, hopefully...

## Implementations
* https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/369
* https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/89
* https://github.com/alphagov/digitalmarketplace-brief-responses-frontend/pull/39
* https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/731
* https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/836
* https://github.com/alphagov/digitalmarketplace-user-frontend/pull/46
* https://github.com/alphagov/digitalmarketplace-api/pull/763
* https://github.com/alphagov/digitalmarketplace-search-api/pull/145

## Ticket
https://trello.com/c/BBvu6eUk/383-ensure-healthcheck-endpoint-fails-if-low-disk-space