### PR TITLE
DMNotifyClient: add replacement_email_address mechanism

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '35.2.0'
+__version__ = '35.3.0'


### PR DESCRIPTION
In response to https://trello.com/c/YQB2HkiD/225-functional-tests-send-emails-to-invalid-email-addresses

This should allow a DMNotifyClient to be set up which will make its final call to notify with a fixed destination address - presumably one of notify's special integration test addresses, which we would add to the app config for staging/preview apps.

A few potentially controversial things here: 

 - The sentinel mechanism for the default kwarg
 - The address replacement happens "inside" the resend-detection code, and also has a "reference" based on the *original* address. I chose this because I thought it best to alter the code path as little as possible when we have this feature enabled.
 - Naming of the setting/feature. I'm reasonably flexible on this, but I did consider a number of alternatives before I decided `replacement_email_address` was the most appropriate.