### PR TITLE
Remove Python2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.6"
 install:
   - pip install -r requirements-dev.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Records breaking changes from major version bumps
 
+## 35.0.0
+
+PR [#371](https://github.com/alphagov/digitalmarketplace-utils/pull/371)
+
+We are dropping support for Python 2, so any libraries that pull this in will need to make sure they are compatible
+with Python 3.
+
 ## 34.0.0
 
 PR: [#360](https://github.com/alphagov/digitalmarketplace-utils/pull/360)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '34.6.0'
+__version__ = '35.0.0'

--- a/dmutils/dates.py
+++ b/dmutils/dates.py
@@ -1,4 +1,3 @@
-from six import string_types
 from datetime import datetime, timedelta
 from workdays import workday
 
@@ -31,7 +30,7 @@ def _brief_is_from_api_(brief):
 
 
 def _brief_is_from_frontend_app_and_published_(brief):
-    return brief.get('publishedAt') and isinstance(brief.get('publishedAt'), string_types)
+    return brief.get('publishedAt') and isinstance(brief.get('publishedAt'), str)
 
 
 def _get_start_date_from_brief_api(brief):

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Digital Marketplace MailChimp integration."""
 
-import six
-
 from hashlib import md5
 from requests.exceptions import RequestException, HTTPError
 
@@ -27,7 +25,7 @@ class DMMailChimpClient(object):
     @staticmethod
     def get_email_hash(email_address):
         """md5 hashing of lower cased emails has been chosen by mailchimp to identify email addresses"""
-        formatted_email_address = six.text_type(email_address.lower()).encode('utf-8')
+        formatted_email_address = str(email_address.lower()).encode('utf-8')
         return md5(formatted_email_address).hexdigest()
 
     def timeout_retry(self, method):

--- a/dmutils/email/helpers.py
+++ b/dmutils/email/helpers.py
@@ -2,10 +2,9 @@
 """Email helpers."""
 import base64
 import hashlib
-import six
 
 
 def hash_string(string):
     """Hash a given string."""
-    m = hashlib.sha256(six.text_type(string).encode('utf-8'))
+    m = hashlib.sha256(str(string).encode('utf-8'))
     return base64.urlsafe_b64encode(m.digest()).decode('utf-8')

--- a/dmutils/email/tokens.py
+++ b/dmutils/email/tokens.py
@@ -4,7 +4,6 @@ import struct
 
 from datetime import datetime
 
-import six
 from cryptography import fernet
 from flask import current_app
 
@@ -105,7 +104,7 @@ def decode_password_reset_token(token, data_api_client):
             ONE_DAY_IN_SECONDS,
         )
     except fernet.InvalidToken as e:
-        current_app.logger.info("Error changing password: {error}", extra={'error': six.text_type(e)})
+        current_app.logger.info("Error changing password: {error}", extra={'error': str(e)})
         return {'error': 'token_invalid'}
 
     user = data_api_client.get_user(decoded["user"])
@@ -145,7 +144,7 @@ def decode_invitation_token(encoded_token):
             )
 
             current_app.logger.info("Invitation reset attempt with expired token. error {error}",
-                                    extra={'error': six.text_type(error)})
+                                    extra={'error': str(error)})
 
             return {
                 'error': 'token_expired',
@@ -154,6 +153,6 @@ def decode_invitation_token(encoded_token):
 
         except fernet.InvalidToken as invalid_token_error:
             current_app.logger.info("Invitation reset attempt with invalid token. error {error}",
-                                    extra={'error': six.text_type(invalid_token_error)})
+                                    extra={'error': str(invalid_token_error)})
 
             return {'error': 'token_invalid'}

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 import re
-from six import string_types
 from jinja2 import evalcontextfilter, Markup, escape
 
 
@@ -66,7 +65,7 @@ def capitalize_first(maybe_text):
     :param maybe_text: Could be anything
     :return: If maybe_text is a string it will be returned with an initial capital letter, otherwise unchanged
     """
-    if maybe_text and isinstance(maybe_text, string_types):
+    if maybe_text and isinstance(maybe_text, str):
         if not maybe_text.startswith('http'):
             return maybe_text[0].capitalize() + maybe_text[1:]
     elif isinstance(maybe_text, (list, tuple)):

--- a/dmutils/s3.py
+++ b/dmutils/s3.py
@@ -5,7 +5,6 @@ import datetime
 import mimetypes
 import logging
 from dateutil.parser import parse as parse_time
-from six import text_type
 
 # a bit of a lie here - retains compatibility with consumers that were importing boto2's S3ResponseError from here. this
 # is the exception boto3 raises in (mostly) the same situations.
@@ -55,7 +54,7 @@ class S3(object):
                 disposition_type,
                 # boto/aws can't cope with unicode here, but wants the ultimate result as a `str` in py3, so doing this
                 # to strip non-ascii chars..
-                text_type(download_filename).encode("ascii", errors="ignore").decode(),
+                str(download_filename).encode("ascii", errors="ignore").decode(),
             )
         obj.put(
             ACL=acl,

--- a/dmutils/views.py
+++ b/dmutils/views.py
@@ -5,14 +5,12 @@ from flask import abort, request, Response
 from flask.views import View
 from io import BytesIO
 from odf.style import TextProperties, TableRowProperties, TableColumnProperties, TableCellProperties, FontFace
-import six
 
 from dmutils import csv_generator
 from dmutils import ods
 
 
-@six.add_metaclass(ABCMeta)
-class DownloadFileView(View):
+class DownloadFileView(View, metaclass=ABCMeta):
     """An abstract base class appropriate for subclassing in the frontend apps when the user needs to be able to
     download some data as a CSV or ODS file. All abstract methods must be implemented on the subclass (although example
     implementations are included here with the kind of return value expected); all other methods should be able to
@@ -164,8 +162,7 @@ class DownloadFileView(View):
         return response
 
 
-@six.add_metaclass(ABCMeta)
-class SimpleDownloadFileView(DownloadFileView):
+class SimpleDownloadFileView(DownloadFileView, metaclass=ABCMeta):
     """A slightly simplier version of the DownloadFileView where it is possible to have a single source of data
     for all download filetypes. If you want a fairly simple structure to your spreadsheet (in effect, a single sheet,
     with self-contained rows where cells don't span rows or columns), you can implement only `get_file_data_and_styles`

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from six import BytesIO
+from io import BytesIO
 
 
 class IsDatetime(object):
@@ -9,8 +9,7 @@ class IsDatetime(object):
 
 class MockFile(BytesIO):
     def __init__(self, initial=b"", filename="", name=""):
-        # BytesIO on py2 is an old-style class (yeah, i know...)
-        BytesIO.__init__(self, initial)
+        super().__init__(initial)
         self._name = name
         self._filename = filename
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -5,8 +5,8 @@ import boto3
 from moto import mock_s3
 import pytest
 from freezegun import freeze_time
-from six import BytesIO
-from six.moves.urllib.parse import parse_qs, urlparse
+from io import BytesIO
+from urllib.parse import parse_qs, urlparse
 
 from dmutils.s3 import S3, get_file_size, default_region
 from dmutils.formats import DATETIME_FORMAT

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,6 +1,4 @@
-from builtins import str, bytes  # py2/3 compatible unicode-str
 from flask import Response
-import six
 from werkzeug.exceptions import BadRequest
 
 import mock
@@ -64,7 +62,7 @@ class TestDownloadFileView():
                        'row-default', 'row-tall', 'row-tall-optimal',
                        'cell-default', 'cell-header']
         for style_name in style_names:
-            assert spreadsheet._document.getStyleByName(six.text_type(style_name)) is not None
+            assert spreadsheet._document.getStyleByName(str(style_name)) is not None
 
     def test_create_response_csv(self):
         kwargs = {'filename': 'test'}
@@ -100,7 +98,7 @@ class TestDownloadFileView():
         # based on creation time, so let's test the cells themselves.
         assert type(res) == Response
         assert bytes(mimetype, encoding='utf-8') in res.get_data()
-        assert len(res.get_data()) >= 1700 and len(res.get_data()) <= 1800
+        assert 1700 <= len(res.get_data()) <= 1800
 
         sheet = spreadsheet._sheets['sheet']
         assert sheet.read_cell(0, 0) == 'Heading 1'


### PR DESCRIPTION
## Summary
We've done a lot of work migrating our apps and libs to Python 3, so we
are no longer actively looking to support Python 2. The only known
things left running on Python 2 are a couple of scripts in dm-scripts,
but we have tickets to update these to Python 3 in the immediate future
and they are unlikely to be run before that happens.

Our other libs with Python 2 tests running are dm-apiclient, dm-aws, and dm-content-loader.