### PR TITLE
Add length to email validator

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '35.0.0'
+__version__ = '35.1.0'

--- a/dmutils/forms.py
+++ b/dmutils/forms.py
@@ -2,7 +2,7 @@ from itertools import chain
 import re
 
 from wtforms import StringField
-from wtforms.validators import Regexp
+from wtforms.validators import Regexp, Length
 
 
 class StripWhitespaceStringField(StringField):
@@ -22,6 +22,7 @@ class EmailField(StripWhitespaceStringField):
             kwargs.pop("validators", ()),
             (
                 EmailValidator(),
+                Length(max=511, message="Please enter an email address under 512 characters."),
             ),
         ))
         super(EmailField, self).__init__(label, **kwargs)


### PR DESCRIPTION
For this tech debt ticket: https://trello.com/c/StDVGuoI
See related PR here: https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/835

### Add default max length validator to EmailField
We weren't validating the length of emails.

Theoretically email should be limited to 254 chars
(https://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address),
however using the `+...@` pattern I've sent an email with an address
over 320 chars. Setting a max of 511 should be plenty.