### PR TITLE
Fix disk space metric

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '35.1.0'
+__version__ = '35.1.1'

--- a/dmutils/status.py
+++ b/dmutils/status.py
@@ -35,7 +35,7 @@ def get_disk_space_status(low_disk_percent_threshold=5):
     instance is below the threshold and the integer percentage remaining disk space."""
     disk_stats = os.statvfs('/')
 
-    disk_free_percent = 100 - int(math.ceil(((disk_stats.f_bfree * 1.0) / disk_stats.f_blocks) * 100))
+    disk_free_percent = int(math.ceil(((disk_stats.f_bfree * 1.0) / disk_stats.f_blocks) * 100))
 
     return 'OK' if disk_free_percent >= low_disk_percent_threshold else 'LOW', disk_free_percent
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -14,13 +14,13 @@ def statvfs_fixture(total_blocks, free_blocks):
 @mock.patch('dmutils.status.os.statvfs')
 @pytest.mark.parametrize('kwargs, total_blocks, free_blocks, expected_status',
                          (
-                             ({}, 1024, 0, ('OK', 100)),
+                             ({}, 1024, 1024, ('OK', 100)),
                              ({}, 1024, 512, ('OK', 50)),
-                             ({}, 1024, 920, ('OK', 10)),
-                             ({}, 1024, 1000, ('LOW', 2)),
-                             ({}, 1024, 1024, ('LOW', 0)),
-                             ({'low_disk_percent_threshold': 10}, 1024, 950, ('LOW', 7)),
-                             ({'low_disk_percent_threshold': 20}, 1024, 920, ('LOW', 10)),
+                             ({}, 1024, 102, ('OK', 10)),
+                             ({}, 1024, 14, ('LOW', 2)),
+                             ({}, 1024, 0, ('LOW', 0)),
+                             ({'low_disk_percent_threshold': 10}, 1024, 64, ('LOW', 7)),
+                             ({'low_disk_percent_threshold': 20}, 1024, 100, ('LOW', 10)),
                              ({'low_disk_percent_threshold': 75}, 1024, 512, ('LOW', 50)),
                          ))
 def test_disk_space_status(disk_usage, kwargs, total_blocks, free_blocks, expected_status):


### PR DESCRIPTION
 ## Summary
I somehow completed mangled the disk space by switching around free/used
at the last moment. The method _was_ reporting how much space was _used_
rather than _free_. It now correctly reports how much space is
free/remaining.