### PR TITLE
Mitigating "missing key" log message formatting failures

### DIFF
--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -125,9 +125,9 @@ class CustomLogFormatter(logging.Formatter):
 
 
 class JSONFormatter(BaseJSONFormatter):
-    def __init__(self, *args, missing_key_attempts=5, **kwargs):
+    def __init__(self, *args, max_missing_key_attempts=5, **kwargs):
         super().__init__(*args, **kwargs)
-        self._missing_key_attempts = missing_key_attempts
+        self._max_missing_key_attempts = max_missing_key_attempts
 
     def process_log_record(self, log_record):
         rename_map = {
@@ -141,7 +141,7 @@ class JSONFormatter(BaseJSONFormatter):
         log_record['logType'] = "application"
 
         missing_keys = []
-        for attempt in range(self._missing_key_attempts):
+        for attempt in range(self._max_missing_key_attempts):
             try:
                 log_record['message'] = log_record['message'].format(**log_record)
 

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -125,6 +125,10 @@ class CustomLogFormatter(logging.Formatter):
 
 
 class JSONFormatter(BaseJSONFormatter):
+    def __init__(self, *args, missing_key_attempts=5, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._missing_key_attempts = missing_key_attempts
+
     def process_log_record(self, log_record):
         rename_map = {
             "asctime": "time",
@@ -137,7 +141,7 @@ class JSONFormatter(BaseJSONFormatter):
         log_record['logType'] = "application"
 
         missing_keys = []
-        for attempt in range(5):
+        for attempt in range(self._missing_key_attempts):
             try:
                 log_record['message'] = log_record['message'].format(**log_record)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -131,7 +131,7 @@ class TestJSONFormatter(object):
 
         assert result['message'] == "hello bar"
 
-    def test_log_message_shows_missing_key1_if_fields_are_not_found(self):
+    def test_log_message_shows_missing_key_if_fields_are_not_found(self):
         self.logger.info("hello {bar}")
         result = json.loads(self.buffer.getvalue())
 
@@ -143,6 +143,14 @@ class TestJSONFormatter(object):
         result = json.loads(raw_result)
 
         assert result['message'].startswith("Missing keys when formatting log message: ['barry']")
+        assert result['levelname'] == 'WARNING'
+
+    def test_two_missing_keys_when_formatting_logs_a_warning(self):
+        self.logger.info("hello {barry} {paul}")
+        raw_result = self.dmbuffer.getvalue()
+        result = json.loads(raw_result)
+
+        assert result['message'].startswith("Missing keys when formatting log message: ['barry', 'paul']")
         assert result['levelname'] == 'WARNING'
 
     def test_failed_log_message_formatting_logs_an_error(self):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -131,7 +131,7 @@ class TestJSONFormatter(object):
 
         assert result['message'] == "hello bar"
 
-    def test_log_message_shows_missing_key_if_fields_are_not_found(self):
+    def test_log_message_shows_missing_key1_if_fields_are_not_found(self):
         self.logger.info("hello {bar}")
         result = json.loads(self.buffer.getvalue())
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -131,7 +131,7 @@ class TestJSONFormatter(object):
 
         assert result['message'] == "hello bar"
 
-    def test_log_message_is_unchanged_if_fields_are_not_found(self):
+    def test_log_message_shows_missing_key_if_fields_are_not_found(self):
         self.logger.info("hello {bar}")
         result = json.loads(self.buffer.getvalue())
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -135,14 +135,22 @@ class TestJSONFormatter(object):
         self.logger.info("hello {bar}")
         result = json.loads(self.buffer.getvalue())
 
-        assert result['message'] == "hello {bar}"
+        assert result['message'] == "hello {bar: missing key}"
 
-    def test_failed_log_message_formatting_logs_an_error(self):
+    def test_missing_key_when_formatting_logs_a_warning(self):
         self.logger.info("hello {barry}")
         raw_result = self.dmbuffer.getvalue()
         result = json.loads(raw_result)
 
-        assert result['message'].startswith("failed to format log message")
+        assert result['message'].startswith("Missing keys when formatting log message: ['barry']")
+        assert result['levelname'] == 'WARNING'
+
+    def test_failed_log_message_formatting_logs_an_error(self):
+        self.logger.info("hello {one} {two} {three} {four} {five} {six}")
+        raw_result = self.dmbuffer.getvalue()
+        result = json.loads(raw_result)
+
+        assert result['message'].startswith("Too many missing keys when attempting to format")
 
 
 class TestCustomLogFormatter(object):


### PR DESCRIPTION
This is a rough sketch for mitigating not-very-good log output as described in https://trello.com/c/qLOqQYy0/226-unable-to-format-log-message-log-messages-not-particularly-useful

No tests - I'm not sure it's worth going ahead with - will see what others think.