### PR TITLE
Add S3 object copy

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '35.3.0'
+__version__ = '35.4.0'


### PR DESCRIPTION
 ## Summary
DM-scripts need to copy files between S3 buckets and they currently try
to use our implementation's private _bucket instance to run boto/boto3
methods directly. This adds a layer of abstraction around the boto copy
to give our own interface.

 ## Ticket
https://trello.com/c/mtiS5IAx/3-move-scripts-running-python-2-on-jenkins-to-python3-docker