### PR TITLE
Retrieve emails as a generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Records breaking changes from major version bumps
 
+## 36.0.0
+
+PR [#?376](https://github.com/alphagov/digitalmarketplace-utils/pull/376)
+
+DMMailChimpClient's `get_email_addresses_from_list` method is now a generator and has a reduced default page size of 100 (down from 1000) in an effort to reduce timeouts with the Mailchimp servers. Any code that uses email addresses from `get_email_addresses_from_list` will need to be updated to take account of the fact it returns a generator object rather than a list - mainly, where the result object is iterated over multiple times, this will fail without refactoring or converting the generator to a list object first (though this should be avoided to reap the most benefit from it being a generator).
+
+Old code:
+```python
+emails = client.get_email_addresses_from_list('xyz')
+```
+
+New code (sub-optimal; consider refactoring instead):
+```python
+emails = list(client.get_email_addresses_from_list('xyz'))
+```
+
+
 ## 35.0.0
 
 PR [#371](https://github.com/alphagov/digitalmarketplace-utils/pull/371)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '35.4.0'
+__version__ = '36.0.0'

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -120,8 +120,7 @@ class DMMailChimpClient(object):
                 success = False
         return success
 
-    def get_email_addresses_from_list(self, list_id, pagination_size=1000):
-        email_addresses = []
+    def get_email_addresses_from_list(self, list_id, pagination_size=100):
         offset = 0
         while True:
             member_data = self.timeout_retry(
@@ -130,6 +129,5 @@ class DMMailChimpClient(object):
             if not member_data.get("members", None):
                 break
             offset += pagination_size
-            email_addresses.extend(member["email_address"] for member in member_data["members"])
 
-        return email_addresses
+            yield from [member['email_address'] for member in member_data['members']]


### PR DESCRIPTION
 ## Summary
We have been getting intermittent 504 timeouts on our DOS email upload
job and they trace back to DMMailChimpClient's
get_email_addresses_from_list job, which tries to get emails back in
batches of 1000. This seems to take too long sometimes, so have reduced
it to a page size of 100 and converted the method to a generator to
reduce overhead.

 ## Ticket
https://trello.com/c/4cK1wTvq/236