### PR TITLE
tracing: output spanId and parentSpanId in json logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .cache
 venv*
 .hypothesis
+local.nix

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '36.2.2'
+__version__ = '36.3.0'

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -11,6 +11,13 @@ from pythonjsonlogger.jsonlogger import JsonFormatter as BaseJSONFormatter
 LOG_FORMAT = '%(asctime)s %(app_name)s %(name)s %(levelname)s ' \
              '%(trace_id)s "%(message)s" [in %(pathname)s:%(lineno)d]'
 
+
+LOG_FORMAT_EXTRA_JSON_KEYS = (
+    "span_id",
+    "parent_span_id",
+)
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -53,11 +60,15 @@ def configure_handler(handler, app, formatter):
     return handler
 
 
+def get_json_log_format():
+    return LOG_FORMAT + "".join(f" %({key})s" for key in LOG_FORMAT_EXTRA_JSON_KEYS)
+
+
 def get_handler(app):
     if app.config.get('DM_PLAIN_TEXT_LOGS'):
         formatter = CustomLogFormatter(LOG_FORMAT)
     else:
-        formatter = JSONFormatter(LOG_FORMAT)
+        formatter = JSONFormatter(get_json_log_format())
 
     if app.config.get('DM_LOG_PATH'):
         handler = logging.FileHandler(app.config['DM_LOG_PATH'])

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -104,15 +104,17 @@ class RequestExtraContextFilter(logging.Filter):
 class CustomLogFormatter(logging.Formatter):
     """Accepts a format string for the message and formats it with the extra fields"""
 
-    FORMAT_STRING_FIELDS_PATTERN = re.compile(r'\((.+?)\)', re.IGNORECASE)
+    FORMAT_STRING_FIELDS_PATTERN = re.compile(r'\((.+?)\)')
 
     def add_fields(self, record):
+        """Ensure all values found in our `fmt` have non-None entries in `record`"""
         for field in self.FORMAT_STRING_FIELDS_PATTERN.findall(self._fmt):
-            record.__dict__[field] = record.__dict__.get(field)
-        return record
+            # slightly clunky - this is so we catch explicitly-set Nones too and turn them into "-"
+            fetched_value = record.__dict__.get(field)
+            record.__dict__[field] = fetched_value if fetched_value is not None else "-"
 
     def format(self, record):
-        record = self.add_fields(record)
+        self.add_fields(record)
         msg = super(CustomLogFormatter, self).format(record)
 
         try:

--- a/dmutils/request_id.py
+++ b/dmutils/request_id.py
@@ -74,6 +74,16 @@ class RequestIdRequestMixin(object):
             ),
         ))
 
+    def get_extra_log_context(self):
+        """
+            extra attributes to be made available on a log record based on this request
+        """
+        return {
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+            "parent_span_id": self.parent_span_id,
+        }
+
 
 class ResponseHeaderMiddleware(object):
     def __init__(self, app, trace_id_headers, span_id_headers):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -9,25 +9,44 @@ import json
 
 import mock
 
-from dmutils import request_id
-from dmutils.logging import init_app, RequestIdFilter, JSONFormatter, CustomLogFormatter
+from flask import request
+
+from dmutils.logging import init_app, RequestExtraContextFilter, JSONFormatter, CustomLogFormatter
 from dmutils.logging import LOG_FORMAT
 
 
-def test_request_id_filter_not_in_app_context():
-    assert RequestIdFilter().request_id == 'no-request-id'
+def test_request_extra_context_filter_not_in_app_context():
+    # using spec_set to ensure no attribute-setting is attempted on this "record"
+    result = RequestExtraContextFilter().filter(mock.Mock(spec_set=[]))
+    assert result.called is False
 
 
-def test_formatter_request_id(app):
-    headers = {'DM-Request-Id': 'generated'}
-    request_id.init_app(app)  # set CustomRequest class
-    with app.test_request_context('/', headers=headers):
-        assert RequestIdFilter().request_id == 'generated'
+def test_request_extra_context_filter_in_app_context(app):
+    with app.test_request_context('/'):
+        test_extra_log_context = {
+            "poldy": "Old Ollebo, M. P.",
+            "Dante": "Riordan",
+        }
+        # add a simple mock callable instead of using our full custom request implementation
+        request.get_extra_log_context = mock.Mock(spec_set=[])
+        request.get_extra_log_context.return_value = test_extra_log_context
+
+        # using spec_set to ensure only our listed keys are set on this "record"
+        result = RequestExtraContextFilter().filter(mock.Mock(spec_set=list(test_extra_log_context.keys())))
+
+        assert request.get_extra_log_context.call_args_list == [()]  # a single zero-arg call
+        # ...and the mock record should have all its values set appropriately
+        assert {k: getattr(result, k) for k in test_extra_log_context.keys()} == test_extra_log_context
 
 
-def test_formatter_request_id_in_non_logging_app(app):
-    with app.test_request_context('/', headers={'DM-Request-Id': 'generated'}):
-        assert RequestIdFilter().request_id == 'no-request-id'
+def test_request_extra_context_filter_no_method(app):
+    with app.test_request_context('/'):
+        # not adding a get_extra_log_context mock method to request to check we behave gracefully when not using a
+        # request class that implements this
+
+        # using spec_set to ensure no attribute-setting is attempted on this "record"
+        result = RequestExtraContextFilter().filter(mock.Mock(spec_set=[]))
+        assert result.called is False
 
 
 def test_init_app_adds_stream_handler_without_log_path(app):
@@ -113,7 +132,7 @@ class TestJSONFormatter(object):
         assert 'time' in result
         assert 'asctime' not in result
         assert 'requestId' in result
-        assert 'request_id' not in result
+        assert 'trace_id' not in result
         assert 'application' in result
         assert 'app_name' not in result
 

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -243,6 +243,10 @@ _span_id_related_params = (
         {
             "X-B3-SpanId": "Steak, kidney, liver, mashed",
         },
+        # expected_resp_headers
+        {
+            "X-B3-SpanId": "Steak, kidney, liver, mashed",
+        },
     ),
     (
         # extra_config
@@ -252,6 +256,8 @@ _span_id_related_params = (
         # expected_span_id
         None,
         # expected_onwards_req_headers
+        {},
+        # expected_resp_headers
         {},
     ),
     (
@@ -266,6 +272,11 @@ _span_id_related_params = (
         # expected_span_id
         "huge-pork-kidney",
         # expected_onwards_req_headers
+        {
+            "barrels-and-boxes": "huge-pork-kidney",
+            "Bloomusalem": "huge-pork-kidney",
+        },
+        # expected_resp_headers
         {
             "barrels-and-boxes": "huge-pork-kidney",
             "Bloomusalem": "huge-pork-kidney",
@@ -323,7 +334,8 @@ _param_combinations = tuple(
         expected_parent_span_id,
         # expected_onwards_req_headers
         dict(chain(t_expected_onwards_req_headers.items(), s_expected_onwards_req_headers.items(),)),
-        expected_resp_headers,
+        # expected_resp_headers
+        dict(chain(t_expected_resp_headers.items(), s_expected_resp_headers.items(),)),
         expected_dm_request_id_header_final_value,
     ) for (
         t_extra_config,
@@ -331,14 +343,14 @@ _param_combinations = tuple(
         expected_trace_id,
         expect_uuid_call,
         t_expected_onwards_req_headers,
-        # so far only the trace_id should affect the response headers
-        expected_resp_headers,
+        t_expected_resp_headers,
         expected_dm_request_id_header_final_value,
     ), (
         s_extra_config,
         s_extra_req_headers,
         expected_span_id,
         s_expected_onwards_req_headers,
+        s_expected_resp_headers,
     ), (
         p_extra_config,
         p_extra_req_headers,

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -400,6 +400,11 @@ def test_request_header(
         assert request.parent_span_id == expected_parent_span_id
         assert request.get_onwards_request_headers() == expected_onwards_req_headers
         assert app.config.get("DM_REQUEST_ID_HEADER") == expected_dm_request_id_header_final_value
+        assert request.get_extra_log_context() == {
+            "trace_id": expected_trace_id,
+            "span_id": expected_span_id,
+            "parent_span_id": expected_parent_span_id,
+        }
 
     assert uuid4_mock.called is expect_uuid_call
 


### PR DESCRIPTION
Trello https://trello.com/c/b2pEjCkV/358-zipkin-headers-pt3-logging and https://trello.com/c/UOXf4vZZ/308-make-use-of-zipkin-headers-in-preference-to-request-id

This genericizes the ad-hoc request id injection, pulling arbitrary key/values from the request's extensible `get_extra_log_context()` method.

Also included in here is the addition of the span id header to the response (in the same, slightly non-standard way we include the trace id and previously the request id) to make it easier to piece together corresponding log events from each end of a request.