### PR TITLE
Clean up utils dependencies

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '36.0.0'
+__version__ = '36.0.1'

--- a/dmutils/forms.py
+++ b/dmutils/forms.py
@@ -39,4 +39,4 @@ class EmailValidator(Regexp):
 
     def __init__(self, **kwargs):
         kwargs.setdefault("message", "Please enter a valid email address.")
-        return super(EmailValidator, self).__init__(self._email_re, **kwargs)
+        super(EmailValidator, self).__init__(self._email_re, **kwargs)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,6 @@ pytest==3.2.3
 pytest-cov==2.5.1
 python-coveralls==2.5.0
 Flask==0.10.1
-Flask-WTF==0.12
+Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-test-utils.git@1.2.0#egg=digitalmarketplace-test-utils==1.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,5 @@ moto==0.4.31
 pytest==3.2.3
 pytest-cov==2.5.1
 python-coveralls==2.5.0
-Flask==0.10.1
-Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-test-utils.git@1.2.0#egg=digitalmarketplace-test-utils==1.2.0

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,10 @@ setup(
     install_requires=[
          'Flask-FeatureFlags==0.6',
          'Flask-Script==2.0.5',
-         'Flask-WTF==0.12',
-         'Flask>=0.10',
+         'Flask-WTF==0.14.2',
+         'Flask>=0.10.1',
          'Flask-Login>=0.2.11',
-         'boto3==1.4.4',
+         'boto3==1.4.5',
          'contextlib2==0.4.0',
          'cryptography==1.9',
          'inflection==0.2.1',

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,6 +1,6 @@
 from itertools import product
 
-from flask.ext.wtf import Form
+from flask_wtf import FlaskForm
 from wtforms.validators import DataRequired, Length, Optional
 from werkzeug.datastructures import ImmutableMultiDict
 import pytest
@@ -8,7 +8,7 @@ import pytest
 from dmutils.forms import EmailField
 
 
-class EmailFieldFormatTestForm(Form):
+class EmailFieldFormatTestForm(FlaskForm):
     test_email = EmailField("An Electronic Mailing Address")
 
 
@@ -32,7 +32,7 @@ class TestEmailFieldFormat(object):
                 formdata=ImmutableMultiDict((
                     ("test_email", email_address,),
                 )),
-                csrf_enabled=False,
+                meta={'csrf': False},
             )
 
             assert form.validate() is False
@@ -53,7 +53,7 @@ class TestEmailFieldFormat(object):
                 formdata=ImmutableMultiDict((
                     ("test_email", email_address,),
                 )),
-                csrf_enabled=False,
+                meta={'csrf': False},
             )
 
             assert form.validate()
@@ -66,14 +66,14 @@ class TestEmailFieldFormat(object):
                 formdata=ImmutableMultiDict((
                     ("test_email", email_address,),
                 )),
-                csrf_enabled=False,
+                meta={'csrf': False},
             )
 
             assert not form.validate()
             assert form.errors == {'test_email': ['Please enter an email address under 512 characters.']}
 
     def test_default_length_and_message_can_be_overridden(self, app):
-        class OverrideDefaultValidatorTestForm(Form):
+        class OverrideDefaultValidatorTestForm(FlaskForm):
             test_email = EmailField(
                 "An Electronic Mailing Address",
                 validators=[Length(max=11, message='Only really short emails please')]
@@ -85,14 +85,14 @@ class TestEmailFieldFormat(object):
                 formdata=ImmutableMultiDict((
                     ("test_email", email_address,),
                 )),
-                csrf_enabled=False,
+                meta={'csrf': False},
             )
 
             assert not form.validate()
             assert form.errors == {'test_email': ['Only really short emails please']}
 
 
-class EmailFieldCombinationTestForm(Form):
+class EmailFieldCombinationTestForm(FlaskForm):
     required_email = EmailField(
         "Required Electronic Mailing Address",
         validators=[DataRequired(message="No really, we want this")],
@@ -122,7 +122,7 @@ class TestEmailFieldCombination(object):
                     ("optional_email", optional_field_email,),
                     ("unspecified_email", unspecified_field_email,),
                 )),
-                csrf_enabled=False,
+                meta={'csrf': False},
             )
 
             assert form.validate() is bool(


### PR DESCRIPTION
- Upgrades `Flask-WTF` to 0.14.2 (addressing CSRF issues: https://flask-wtf.readthedocs.io/en/latest/changelog.html). This introduces some deprecation warnings (I've fixed them for this repo's tests) but no breaking changes as far as I can see.
- Upgrades `Flask` to 0.10.1 to match all the FE apps. 
- Removes duplicated `Flask` and `Flask-WTF` from `requirements-dev.txt`.

The FE apps and the APIs all pin their `Flask` (and `Flask-WTF`) dependencies in their `requirements-app.txt`, even though the same versions are pulled in via dm-utils. Was there a reason for stating them explicitly in the apps, or can we use dm-utils as the single source of truth instead? Thoughts welcome!