### PR TITLE
Update dependencies

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '36.0.1'
+__version__ = '36.0.2'

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
          'boto3==1.4.5',
          'contextlib2==0.4.0',
          'cryptography==1.9',
-         'inflection==0.2.1',
+         'inflection==0.3.1',
          'mailchimp3==2.0.11',
          'mandrill==1.0.57',
          'monotonic==0.3',
@@ -40,8 +40,9 @@ setup(
          'python-json-logger==0.1.4',
          'pytz==2015.4',
          'pyyaml==3.11',
-         'six==1.9.0',
+         'six==1.11.0',
          'unicodecsv==0.14.1',
+         'Werkzeug==0.14.1',
          'workdays==1.4'
     ],
 )


### PR DESCRIPTION
 ## Summary
Some of our libraries now have dependencies on different versions of the
same lib. This commit, and some corresponding commits on our other
repos, will bring them all in line so that we don't get pip complaining
that it cannot meet our conflicting requirements.

Specifically we are setting:
* Werkzeug==0.14.1
* six==1.11.0
* inflection==0.3.1

## Other PRs
https://github.com/alphagov/digitalmarketplace-apiclient/pull/133
https://github.com/alphagov/digitalmarketplace-content-loader/pull/57