### PR TITLE
Remove csrf token utility

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '36.0.2'
+__version__ = '36.1.0'

--- a/dmutils/forms.py
+++ b/dmutils/forms.py
@@ -40,3 +40,19 @@ class EmailValidator(Regexp):
     def __init__(self, **kwargs):
         kwargs.setdefault("message", "Please enter a valid email address.")
         super(EmailValidator, self).__init__(self._email_re, **kwargs)
+
+
+def remove_csrf_token(data):
+    """Flask-WTF==0.14.2 now includes `csrf_token` in `form.data`, whereas previously wtforms explicitly didn't do
+    this. When we pass form data straight through to the API, the API often carries out strict validation and doesn't
+    like to see `csrf_token` in the input. So this helper will strip it out of a dict, if it's present.
+
+    Example:
+    >>> remove_csrf_token(form.data)
+    """
+    cleaned_data = {**data}
+
+    if 'csrf_token' in data:
+        del cleaned_data['csrf_token']
+
+    return cleaned_data

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -5,7 +5,7 @@ from wtforms.validators import DataRequired, Length, Optional
 from werkzeug.datastructures import ImmutableMultiDict
 import pytest
 
-from dmutils.forms import EmailField
+from dmutils.forms import EmailField, remove_csrf_token
 
 
 class EmailFieldFormatTestForm(FlaskForm):
@@ -141,3 +141,20 @@ class TestEmailFieldCombination(object):
 
             if unspecified_field_email in (self._invalid_address, ""):
                 assert form.errors["unspecified_email"] == ["Please enter a valid email address."]
+
+
+class TestRemoveCsrfToken:
+    def test_csrf_token_removed_if_present(self):
+        data = {'key': 'value', 'key2': 'value2', 'csrf_token': '123tgredsca2345ywt34rwe'}
+        cleaned_data = remove_csrf_token(data)
+        assert 'csrf_token' not in cleaned_data
+
+    def test_original_data_not_mutated_by_remove_csrf_token(self):
+        data = {'key': 'value', 'key2': 'value2', 'csrf_token': '123tgredsca2345ywt34rwe'}
+        remove_csrf_token(data)
+        assert 'csrf_token' in data
+
+    def test_silently_passes_if_csrf_token_not_present(self):
+        data = {'key': 'value', 'key2': 'value2'}
+        cleaned_data = remove_csrf_token(data)
+        assert cleaned_data == data


### PR DESCRIPTION
 ## Summary
FlaskWTF==0.14.2 seems to now include `csrf_token` in a FlaskForm's data
attribute, whereas previously this was not the case. Our API doesn't
like receiving `csrf_token` for some of its validated fields, so we need
to strip it out before passing it across. This will do that.