### PR TITLE
Revert Flask-WTF upgrade

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '36.1.0'
+__version__ = '36.2.0'

--- a/dmutils/forms.py
+++ b/dmutils/forms.py
@@ -39,7 +39,7 @@ class EmailValidator(Regexp):
 
     def __init__(self, **kwargs):
         kwargs.setdefault("message", "Please enter a valid email address.")
-        super(EmailValidator, self).__init__(self._email_re, **kwargs)
+        return super(EmailValidator, self).__init__(self._email_re, **kwargs)
 
 
 def remove_csrf_token(data):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,5 +10,7 @@ moto==0.4.31
 pytest==3.2.3
 pytest-cov==2.5.1
 python-coveralls==2.5.0
+Flask==0.10.1
+Flask-WTF==0.14.2
 
 git+https://github.com/alphagov/digitalmarketplace-test-utils.git@1.2.0#egg=digitalmarketplace-test-utils==1.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,6 @@ pytest==3.2.3
 pytest-cov==2.5.1
 python-coveralls==2.5.0
 Flask==0.10.1
-Flask-WTF==0.14.2
+Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-test-utils.git@1.2.0#egg=digitalmarketplace-test-utils==1.2.0

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,10 @@ setup(
     install_requires=[
          'Flask-FeatureFlags==0.6',
          'Flask-Script==2.0.5',
-         'Flask-WTF==0.14.2',
-         'Flask>=0.10.1',
+         'Flask-WTF==0.12',
+         'Flask>=0.10',
          'Flask-Login>=0.2.11',
-         'boto3==1.4.5',
+         'boto3==1.4.4',
          'contextlib2==0.4.0',
          'cryptography==1.9',
          'inflection==0.3.1',

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,6 +1,6 @@
 from itertools import product
 
-from flask_wtf import FlaskForm
+from flask.ext.wtf import Form
 from wtforms.validators import DataRequired, Length, Optional
 from werkzeug.datastructures import ImmutableMultiDict
 import pytest
@@ -8,7 +8,7 @@ import pytest
 from dmutils.forms import EmailField, remove_csrf_token
 
 
-class EmailFieldFormatTestForm(FlaskForm):
+class EmailFieldFormatTestForm(Form):
     test_email = EmailField("An Electronic Mailing Address")
 
 
@@ -32,7 +32,7 @@ class TestEmailFieldFormat(object):
                 formdata=ImmutableMultiDict((
                     ("test_email", email_address,),
                 )),
-                meta={'csrf': False},
+                csrf_enabled=False,
             )
 
             assert form.validate() is False
@@ -53,7 +53,7 @@ class TestEmailFieldFormat(object):
                 formdata=ImmutableMultiDict((
                     ("test_email", email_address,),
                 )),
-                meta={'csrf': False},
+                csrf_enabled=False,
             )
 
             assert form.validate()
@@ -66,14 +66,14 @@ class TestEmailFieldFormat(object):
                 formdata=ImmutableMultiDict((
                     ("test_email", email_address,),
                 )),
-                meta={'csrf': False},
+                csrf_enabled=False,
             )
 
             assert not form.validate()
             assert form.errors == {'test_email': ['Please enter an email address under 512 characters.']}
 
     def test_default_length_and_message_can_be_overridden(self, app):
-        class OverrideDefaultValidatorTestForm(FlaskForm):
+        class OverrideDefaultValidatorTestForm(Form):
             test_email = EmailField(
                 "An Electronic Mailing Address",
                 validators=[Length(max=11, message='Only really short emails please')]
@@ -85,14 +85,14 @@ class TestEmailFieldFormat(object):
                 formdata=ImmutableMultiDict((
                     ("test_email", email_address,),
                 )),
-                meta={'csrf': False},
+                csrf_enabled=False,
             )
 
             assert not form.validate()
             assert form.errors == {'test_email': ['Only really short emails please']}
 
 
-class EmailFieldCombinationTestForm(FlaskForm):
+class EmailFieldCombinationTestForm(Form):
     required_email = EmailField(
         "Required Electronic Mailing Address",
         validators=[DataRequired(message="No really, we want this")],
@@ -122,7 +122,7 @@ class TestEmailFieldCombination(object):
                     ("optional_email", optional_field_email,),
                     ("unspecified_email", unspecified_field_email,),
                 )),
-                meta={'csrf': False},
+                csrf_enabled=False,
             )
 
             assert form.validate() is bool(


### PR DESCRIPTION
## Summary
When we upgraded to Flask-WTF==0.14 we didn't realise that the way CSRF tokens were generated changed fundamentally, meaning that tokens generated in an app with Flask-WTF==0.14 (e.g. supplier-fe) would not be recognised by a view in another app running Flask-WTF<0.14 (e.g. user-fe). This led to us being unable to logout from the supplier app.

We will need to spend a bit of time working out how we are going to manage this upgrade, but at the moment we will need to remain on Flask-WTF==0.12 until we have worked it out. Our tests will generate deprecation warnings until this is sorted, so we aren't likely to forget.