### PR TITLE
bump boto3 dependency to 1.4.8

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,6 +13,8 @@ in (with args; {
     shortName = "dm-utils";
     buildInputs = [
       pythonPackages.virtualenv
+      pkgs.libffi
+      pkgs.openssl
       pkgs.git
     ] ++ pkgs.stdenv.lib.optionals forDev ([
       ] ++ pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '36.2.0'
+__version__ = '36.2.1'

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
          'Flask-WTF==0.12',
          'Flask>=0.10',
          'Flask-Login>=0.2.11',
-         'boto3==1.4.4',
+         'boto3==1.4.8',
          'contextlib2==0.4.0',
          'cryptography==1.9',
          'inflection==0.3.1',


### PR DESCRIPTION
https://snyk.io/vuln/SNYK-PYTHON-BOTO3-40617

admin, briefs and supplier frontends seem to pass their tests with this change.