### PR TITLE
timing: add logged_duration context manager

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '36.8.0'
+__version__ = '36.9.0'

--- a/dmutils/timing.py
+++ b/dmutils/timing.py
@@ -1,0 +1,82 @@
+from contextlib import contextmanager
+import logging
+import sys
+from time import perf_counter, process_time
+
+from flask import request
+from flask.ctx import has_request_context
+
+
+#
+# logged_duration's defaults are exposed here so that a caller is able to defer to the default or simply use a wrapper
+# for the default when customizing the call.
+#
+
+
+def default_message(log_context):
+    return "Block {} in {{duration_real}}s of real-time".format(
+        "executed" if sys.exc_info()[0] is None else "raised {}".format(sys.exc_info()[0].__name__)
+    )
+
+
+def default_condition(log_context):
+    return has_request_context() and getattr(request, "sampling_decision", False)
+
+
+def default_log_func(logger, message, log_level, log_context):
+    final_message = message(log_context) if callable(message) else message
+    logger.log(log_level, final_message, exc_info=(sys.exc_info()[0] is not None), extra=log_context)
+
+
+# exposing this allows a caller to specify default_logger.getChild(...) as their logger
+default_logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def logged_duration(
+    logger=default_logger,
+    message=default_message,
+    log_level=logging.DEBUG,
+    condition=default_condition,
+    log_func=default_log_func,
+):
+    """
+        returns a context manager which will monitor the amount of time spent "inside" its code block and emit a log
+        message on exiting block if ``condition`` passes. Uses a ``log_context`` dictionary as the log call's ``extra``
+        parameter which will contain the parameters ``duration_real`` and ``duration_process``, each being a float
+        duration in seconds. Logging action is triggered whether execution fell out of the block naturally or the code
+        raised an exception. If log messages are not desired on exeptions these can always be excluded by a custom
+        ``condition``. Can also be used as a function decorator.
+
+        :param logger:    The logger to log the message to. It's best to set this at the very least to give the log
+                          reader a clue as to what block of code is being timed.
+        :param message:   Message format string to emit. Can be a callable which should return the desired message
+                          format string when passed a ``log_context``.
+        :param log_level: Numeric log level to use.
+        :param condition: Callable accepting a single dictionary argument of the ``log_context``. Should return a
+                          boolean signalling whether a log message should be emitted or not. Default condition emits a
+                          log if there is a current Flask request with a True `sampling_decision` attribute. A
+                          condition of True or None will cause logs to *always* be emitted.
+        :param log_func:  The actual logging function which will be called if `condition` passes. Arguments passed are:
+                          ``logger``, ``message``, ``log_level`` (all verbatim as passed to ``logged_duration``) and
+                          ``log_context``.
+    """
+    original_real_time = perf_counter()
+    # NOTE this is *process* time, not *thread* time. if multiple threads are running in this process it will include
+    # their cpu time too. getting *thread* time will be possible in python 3.7+ (but even then it doesn't work on older
+    # macos)
+    original_process_time = process_time()
+
+    try:
+        yield
+    finally:
+        duration_real = perf_counter() - original_real_time
+        duration_process = process_time() - original_process_time
+
+        log_context = {
+            "duration_real": duration_real,
+            "duration_process": duration_process,
+        }
+
+        if condition in (True, None,) or condition(log_context):
+            log_func(logger, message, log_level, log_context)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import tempfile
+
 import pytest
 from flask import Flask
 import mock
@@ -11,6 +13,16 @@ def app():
     app = Flask(__name__)
     init_app(app)
     return app
+
+
+# it's deceptively difficult to capture & inspect *actual* log output in pytest (no, capfd doesn't seem to work)
+@pytest.fixture
+def app_logtofile():
+    with tempfile.NamedTemporaryFile() as f:
+        app = Flask(__name__)
+        app.config['DM_LOG_PATH'] = f.name
+        init_app(app)
+        yield app
 
 
 @pytest.yield_fixture

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -90,7 +90,7 @@ _messages_expected = OrderedDict((
 
 
 _parameter_combinations = tuple(product(
-    (  # sampling_decision values
+    (  # is_sampled values
         False,
         None,
         True,
@@ -126,7 +126,7 @@ _parameter_combinations = tuple(product(
 
 
 def _expect_log(
-    sampling_decision,
+    is_sampled,
     sleep_time,
     message,
     log_level,
@@ -136,16 +136,16 @@ def _expect_log(
 ):
     """return whether to expect a log line to be output or not"""
     return (
-        (condition is timing.default_condition and sampling_decision)
+        (condition is timing.default_condition and is_sampled)
         or (condition is _duration_real_gt_075 and sleep_time >= 0.08)
-        or (condition is _default_and_no_exception and sampling_decision and raise_exception is None)
+        or (condition is _default_and_no_exception and is_sampled and raise_exception is None)
         or (condition in (True, None,))
     )
 
 
 @pytest.mark.parametrize(
     (
-        "sampling_decision",
+        "is_sampled",
         "sleep_time",
         "message",
         "log_level",
@@ -156,7 +156,7 @@ def _expect_log(
     ),
     tuple(
         (
-            sampling_decision,
+            is_sampled,
             sleep_time,
             message,
             log_level,
@@ -179,7 +179,7 @@ def _expect_log(
                     },
                 )
             ] if _expect_log(
-                sampling_decision,
+                is_sampled,
                 sleep_time,
                 message,
                 log_level,
@@ -188,7 +188,7 @@ def _expect_log(
                 inject_context,
             ) else []
         ) for  # noqa - i don't know what you want me to do here flake8 nor do i care
-            sampling_decision,
+            is_sampled,
             sleep_time,
             message,
             log_level,
@@ -200,7 +200,7 @@ def _expect_log(
 )
 def test_logged_duration_mock_logger(
     app,
-    sampling_decision,
+    is_sampled,
     sleep_time,
     message,
     log_level,
@@ -210,7 +210,7 @@ def test_logged_duration_mock_logger(
     expected_call_args_list,
 ):
     with app.test_request_context("/", headers={}):
-        request.sampling_decision = sampling_decision
+        request.is_sampled = is_sampled
         mock_logger = mock.Mock(spec_set=("log",))
 
         with (null_context_manager() if raise_exception is None else pytest.raises(raise_exception)):
@@ -232,7 +232,7 @@ def test_logged_duration_mock_logger(
 
 @pytest.mark.parametrize(
     (
-        "sampling_decision",
+        "is_sampled",
         "sleep_time",
         "message",
         "log_level",
@@ -243,7 +243,7 @@ def test_logged_duration_mock_logger(
     ),
     tuple(
         (
-            sampling_decision,
+            is_sampled,
             sleep_time,
             message,
             log_level,
@@ -279,7 +279,7 @@ def test_logged_duration_mock_logger(
                     ),
                 }),
             ) if _expect_log(
-                sampling_decision,
+                is_sampled,
                 sleep_time,
                 message,
                 log_level,
@@ -288,7 +288,7 @@ def test_logged_duration_mock_logger(
                 inject_context,
             ) else ()
         ) for  # noqa - i don't know what you want me to do here flake8 nor do i care
-            sampling_decision,
+            is_sampled,
             sleep_time,
             message,
             log_level,
@@ -300,7 +300,7 @@ def test_logged_duration_mock_logger(
 )
 def test_logged_duration_real_logger(
     app_logtofile,
-    sampling_decision,
+    is_sampled,
     sleep_time,
     message,
     log_level,
@@ -314,7 +314,7 @@ def test_logged_duration_real_logger(
         log_file.read()
 
         with app_logtofile.test_request_context("/", headers={}):
-            request.sampling_decision = sampling_decision
+            request.is_sampled = is_sampled
 
             with (null_context_manager() if raise_exception is None else pytest.raises(raise_exception)):
                 with timing.logged_duration(

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -80,6 +80,8 @@ def mock_time_functions():
 
 @contextmanager
 def actual_time_functions():
+    # this is only a context manager so it can be swapped out in place of mock_time_functions, which uses mock.patch
+    # extensively
     yield time.sleep, time.perf_counter, time.process_time
 
 
@@ -233,20 +235,31 @@ def _expect_log(
                 inject_context
             in _parameter_combinations
         ),
-        (  # we include a few explicit test cases using unmocked time functions to ensure the functions *actually* work
-           # as expected
+        (   #
+            # we include a few explicit test cases using unmocked time functions to ensure the functions *actually* work
+            # as expected
+            #
             (
+                # is_sampled
                 True,
+                # sleep_time
                 0.5,
+                # message
                 "Touched the obedient {key}s for {duration_real}s",
+                # log_level
                 logging.WARNING,
+                # condition
                 timing.default_condition,
+                # raise_exception
                 None,
+                # inject_context
                 {
                     "key": "D#",
                     "keyes": "House Of",
                 },
+                # mock_time
                 False,
+                # expected_call_args_list
                 [mock.call(
                     logging.WARNING,
                     "Touched the obedient {key}s for {duration_real}s",
@@ -260,14 +273,23 @@ def _expect_log(
                 )],
             ),
             (
+                # is_sampled
                 None,
+                # sleep_time
                 0.2,
+                # message
                 "The obedient {item}s feeding in {exc_info}",
+                # log_level
                 logging.ERROR,
+                # condition
                 True,
+                # raise_exception
                 ValueError,
+                # inject_context
                 None,
+                # mock_time
                 False,
+                # expected_call_args_list
                 [mock.call(
                     logging.ERROR,
                     "The obedient {item}s feeding in {exc_info}",
@@ -396,20 +418,31 @@ def test_logged_duration_mock_logger(
                 inject_context
             in _parameter_combinations
         ),
-        (  # we include a few explicit test cases using unmocked time functions to ensure the functions *actually* work
-           # as expected
+        (   #
+            # we include a few explicit test cases using unmocked time functions to ensure the functions *actually* work
+            # as expected
+            #
             (
+                # is_sampled
                 True,
+                # sleep_time
                 0.5,
+                # message
                 "Touched the obedient {key}s for {duration_real}s",
+                # log_level
                 logging.WARNING,
+                # condition
                 timing.default_condition,
+                # raise_exception
                 None,
+                # inject_context
                 {
                     "key": "D#",
                     "keyes": "House Of",
                 },
+                # mock_time
                 False,
+                # expected_logs
                 (AnySupersetOf({
                     "message": AnyStringMatching(r"Touched the obedient D#s for [0-9Ee.-]+s"),
                     "levelname": "WARNING",
@@ -420,14 +453,23 @@ def test_logged_duration_mock_logger(
                 }),),
             ),
             (
+                # is_sampled
                 None,
+                # sleep_time
                 0.2,
+                # message
                 "The obedient {item}s feeding in {exc_info}",
+                # log_level
                 logging.ERROR,
+                # condition
                 True,
+                # raise_exception
                 ValueError,
+                # inject_context
                 None,
+                # mock_time
                 False,
+                # expected_logs
                 (
                     AnySupersetOf({
                         "levelname": "WARNING",

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -101,14 +101,14 @@ def _duration_real_gt_075(log_context):
 
 
 def _default_and_no_exception(log_context):
-    return timing.default_condition(log_context) and sys.exc_info()[0] is None
+    return timing.logged_duration.default_condition(log_context) and sys.exc_info()[0] is None
 
 
 # a dictionary of messages to be passed to logged_duration mapped against a tuple of values to expect, the first of
 # these in the case that log message formatting has *not* yet taken place, the second assuming it *has*.
 _messages_expected = OrderedDict((
     (
-        timing.default_message,
+        timing.logged_duration.default_message,
         (
             AnyStringMatching(r"Block (executed|raised \w+) in \{duration_real\}s of real-time"),
             AnyStringMatching(r"Block (executed|raised \w+) in [0-9eE.-]+s of real-time"),
@@ -143,7 +143,7 @@ _parameter_combinations = tuple(product(
     (  # condition values
         True,
         None,
-        timing.default_condition,
+        timing.logged_duration.default_condition,
         _duration_real_gt_075,
         _default_and_no_exception,
     ),
@@ -171,7 +171,7 @@ def _expect_log(
 ):
     """return whether to expect a log line to be output or not"""
     return (
-        (condition is timing.default_condition and is_sampled)
+        (condition is timing.logged_duration.default_condition and is_sampled)
         or (condition is _duration_real_gt_075 and sleep_time >= 0.08)
         or (condition is _default_and_no_exception and is_sampled and raise_exception is None)
         or (condition in (True, None,))
@@ -249,7 +249,7 @@ def _expect_log(
                 # log_level
                 logging.WARNING,
                 # condition
-                timing.default_condition,
+                timing.logged_duration.default_condition,
                 # raise_exception
                 None,
                 # inject_context
@@ -432,7 +432,7 @@ def test_logged_duration_mock_logger(
                 # log_level
                 logging.WARNING,
                 # condition
-                timing.default_condition,
+                timing.logged_duration.default_condition,
                 # raise_exception
                 None,
                 # inject_context

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -3,17 +3,19 @@ from dmutils import timing
 from collections import OrderedDict
 from contextlib import contextmanager
 from functools import lru_cache
-from itertools import product
+from itertools import chain, product
 import json
 import logging
 import mock
 from numbers import Number
+import random
 import re
 import sys
-from time import sleep
+import time
 
 from flask import request
 import pytest
+import six
 
 
 class malleable_ANY:
@@ -44,10 +46,41 @@ class ANY_string_matching(malleable_ANY):
 
     def __init__(self, *args, **kwargs):
         self._regex = self._cached_re_compile(*args, **kwargs)
-        super().__init__(lambda other: self._regex.match(other))
+        super().__init__(lambda other: isinstance(other, six.string_types) and self._regex.match(other))
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self._regex})"
+
+
+@contextmanager
+def mock_time_functions():
+    with mock.patch.multiple("time", perf_counter=mock.DEFAULT, process_time=mock.DEFAULT) as time_mocks:
+        # to simulate the behaviour of these time functions, we create them all as closures capturing these common
+        # "state" variables tracking the apparent pseudo-time according to each sampling function
+        perf_counter_state = random.uniform(1000, 10000)
+        process_time_state = random.uniform(1000, 10000)
+
+        # the sampling functions just return the current state
+        time_mocks["perf_counter"].side_effect = lambda: perf_counter_state
+        time_mocks["process_time"].side_effect = lambda: process_time_state
+
+        # the associated sleep function increments the apparent pseudo-times with an amount of randomness. it may seem
+        # a bad idea to introduce randomness to "unit" tests, but the alternatives these are replacing are the *actual*
+        # timing functions, which add much more noise & randomness to the process, and the tests have been written to
+        # cope with that
+        def _sleep(sleep_seconds):
+            nonlocal perf_counter_state, process_time_state
+            # allow for a small amount of "oversleep"
+            perf_counter_state += random.uniform(sleep_seconds, sleep_seconds * 1.3)
+            # the process may have been servicing other thread(s) during this period
+            process_time_state += random.uniform(sleep_seconds * 0.001, sleep_seconds)
+
+        yield _sleep, time_mocks["perf_counter"], time_mocks["process_time"]
+
+
+@contextmanager
+def actual_time_functions():
+    yield time.sleep, time.perf_counter, time.process_time
 
 
 # python 3.7 has an in-built version of this, but for now...
@@ -152,33 +185,12 @@ def _expect_log(
         "condition",
         "raise_exception",
         "inject_context",
+        "mock_time",
         "expected_call_args_list",
     ),
-    tuple(
+    tuple(chain(
         (
-            is_sampled,
-            sleep_time,
-            message,
-            log_level,
-            condition,
-            raise_exception,
-            inject_context,
-            [  # expected_call_args_list
-                mock.call(
-                    log_level,
-                    _messages_expected[message][0],
-                    exc_info=bool(raise_exception),
-                    extra={
-                        "duration_real": malleable_ANY(
-                            # a double-closure here to get around python's weird behaviour when capturing iterated
-                            # variables (in this case `sleep_time`)
-                            (lambda st: lambda val: st * 0.95 < val < st * 1.5)(sleep_time)
-                        ),
-                        "duration_process": mock.ANY,
-                        **(inject_context or {}),
-                    },
-                )
-            ] if _expect_log(
+            (
                 is_sampled,
                 sleep_time,
                 message,
@@ -186,46 +198,130 @@ def _expect_log(
                 condition,
                 raise_exception,
                 inject_context,
-            ) else []
-        ) for  # noqa - i don't know what you want me to do here flake8 nor do i care
-            is_sampled,
-            sleep_time,
-            message,
-            log_level,
-            condition,
-            raise_exception,
-            inject_context
-        in _parameter_combinations
-    )
+                True,  # mock_time
+                [  # expected_call_args_list
+                    mock.call(
+                        log_level,
+                        _messages_expected[message][0],
+                        exc_info=bool(raise_exception),
+                        extra={
+                            "duration_real": malleable_ANY(
+                                # a double-closure here to get around python's weird behaviour when capturing iterated
+                                # variables (in this case `sleep_time`)
+                                (lambda st: lambda val: st * 0.95 < val < st * 1.5)(sleep_time)
+                            ),
+                            "duration_process": mock.ANY,
+                            **(inject_context or {}),
+                        },
+                    )
+                ] if _expect_log(
+                    is_sampled,
+                    sleep_time,
+                    message,
+                    log_level,
+                    condition,
+                    raise_exception,
+                    inject_context,
+                ) else []
+            ) for  # noqa - i don't know what you want me to do here flake8 nor do i care
+                is_sampled,
+                sleep_time,
+                message,
+                log_level,
+                condition,
+                raise_exception,
+                inject_context
+            in _parameter_combinations
+        ),
+        (  # we include a few explicit test cases using unmocked time functions to ensure the functions *actually* work
+           # as expected
+            (
+                True,
+                0.5,
+                "Touched the obedient {key}s for {duration_real}s",
+                logging.WARNING,
+                timing.default_condition,
+                None,
+                {
+                    "key": "D#",
+                    "keyes": "House Of",
+                },
+                False,
+                [mock.call(
+                    logging.WARNING,
+                    "Touched the obedient {key}s for {duration_real}s",
+                    exc_info=False,
+                    extra={
+                        "key": "D#",
+                        "keyes": "House Of",
+                        "duration_real": malleable_ANY(lambda value: 0.48 < value < 0.6),
+                        "duration_process": malleable_ANY(lambda value: isinstance(value, Number)),
+                    },
+                )],
+            ),
+            (
+                None,
+                0.2,
+                "The obedient {item}s feeding in {exc_info}",
+                logging.ERROR,
+                True,
+                ValueError,
+                None,
+                False,
+                [mock.call(
+                    logging.ERROR,
+                    "The obedient {item}s feeding in {exc_info}",
+                    exc_info=True,
+                    extra={
+                        "duration_real": malleable_ANY(lambda value: 0.18 < value < 0.35),
+                        "duration_process": malleable_ANY(lambda value: isinstance(value, Number)),
+                    },
+                )],
+            ),
+        ),
+    ))
 )
 def test_logged_duration_mock_logger(
     app,
+    # value to set the is_sampled flag to on the mock request
     is_sampled,
+    # how long to sleep in seconds
     sleep_time,
+    # message, log_level, condition - values to pass as arguments of logged_duration verbatim
     message,
     log_level,
     condition,
+    # exception (class) to raise inside logged_duration, None to raise no exception
     raise_exception,
+    # dict to update log_context with inside logged_duration, None perform no update
     inject_context,
+    # whether to use mocked time primitives to speed up the test
+    mock_time,
+    # sequence of log dicts to expect to be output as json logs
     expected_call_args_list,
 ):
     with app.test_request_context("/", headers={}):
         request.is_sampled = is_sampled
         mock_logger = mock.Mock(spec_set=("log",))
 
-        with (null_context_manager() if raise_exception is None else pytest.raises(raise_exception)):
-            with timing.logged_duration(
-                logger=mock_logger,
-                message=message,
-                log_level=log_level,
-                condition=condition,
-            ) as log_context:
-                assert mock_logger.log.call_args_list == []
-                sleep(sleep_time)
-                if inject_context is not None:
-                    log_context.update(inject_context)
-                if raise_exception is not None:
-                    raise raise_exception("Boo")
+        with (mock_time_functions() if mock_time else actual_time_functions()) as (
+            _sleep,
+            _perf_counter,
+            _process_time,
+        ):
+            with (null_context_manager() if raise_exception is None else pytest.raises(raise_exception)):
+                with timing.logged_duration(
+                    logger=mock_logger,
+                    message=message,
+                    log_level=log_level,
+                    condition=condition,
+                ) as log_context:
+                    assert mock_logger.log.call_args_list == []
+                    _sleep(sleep_time)
+                    if inject_context is not None:
+                        log_context.update(inject_context)
+                    if raise_exception is not None:
+                        raise raise_exception("Boo")
 
     assert mock_logger.log.call_args_list == expected_call_args_list
 
@@ -239,46 +335,12 @@ def test_logged_duration_mock_logger(
         "condition",
         "raise_exception",
         "inject_context",
+        "mock_time",
         "expected_logs",
     ),
-    tuple(
+    tuple(chain(
         (
-            is_sampled,
-            sleep_time,
-            message,
-            log_level,
-            condition,
-            raise_exception,
-            inject_context,
-            (  # expected_logs
-                *(  # in cases where our format string expects an extra parameter that wasn't supplied ("street" here),
-                    # our log output will be lead by a warning about the missing parameter - I feel it's important to
-                    # include this permutation to prove that we don't end up swallowing a genuine exception if we
-                    # inadvertantly raise an exception while outputting our log message
-                    (ANY_superset_of({"levelname": "WARNING"}),)
-                    if ("street" in str(message) and "street" not in (inject_context or {})) else ()
-                ),
-                ANY_superset_of({
-                    "name": "conftest.foobar",
-                    "levelname": logging.getLevelName(log_level),
-                    "message": _messages_expected[message][1],
-                    "duration_real": malleable_ANY(
-                        # a double-closure here to get around python's weird behaviour when capturing iterated
-                        # variables (in this case `sleep_time`)
-                        (lambda st: lambda val: st * 0.95 < val < st * 1.5)(sleep_time)
-                    ),
-                    "duration_process": malleable_ANY(lambda value: isinstance(value, Number)),
-                    **(inject_context or {}),
-                    **(
-                        {
-                            "exc_info": ANY_string_matching(
-                                r".*{}.*".format(re.escape(raise_exception.__name__)),
-                                flags=re.DOTALL,
-                            ),
-                        } if raise_exception else {}
-                    ),
-                }),
-            ) if _expect_log(
+            (
                 is_sampled,
                 sleep_time,
                 message,
@@ -286,27 +348,127 @@ def test_logged_duration_mock_logger(
                 condition,
                 raise_exception,
                 inject_context,
-            ) else ()
-        ) for  # noqa - i don't know what you want me to do here flake8 nor do i care
-            is_sampled,
-            sleep_time,
-            message,
-            log_level,
-            condition,
-            raise_exception,
-            inject_context
-        in _parameter_combinations
-    )
+                True,  # mock_time
+                (  # expected_logs
+                    *(  # in cases where our format string expects an extra parameter that wasn't supplied ("street"
+                        # here), our log output will be lead by a warning about the missing parameter - I feel it's
+                        # important to include this permutation to prove that we don't end up swallowing a genuine
+                        # exception if we inadvertantly raise an exception while outputting our log message
+                        (ANY_superset_of({"levelname": "WARNING"}),)
+                        if ("street" in str(message) and "street" not in (inject_context or {})) else ()
+                    ),
+                    ANY_superset_of({
+                        "name": "conftest.foobar",
+                        "levelname": logging.getLevelName(log_level),
+                        "message": _messages_expected[message][1],
+                        "duration_real": malleable_ANY(
+                            # a double-closure here to get around python's weird behaviour when capturing iterated
+                            # variables (in this case `sleep_time`)
+                            (lambda st: lambda val: st * 0.95 < val < st * 1.5)(sleep_time)
+                        ),
+                        "duration_process": malleable_ANY(lambda value: isinstance(value, Number)),
+                        **(inject_context or {}),
+                        **(
+                            {
+                                "exc_info": ANY_string_matching(
+                                    r".*{}.*".format(re.escape(raise_exception.__name__)),
+                                    flags=re.DOTALL,
+                                ),
+                            } if raise_exception else {}
+                        ),
+                    }),
+                ) if _expect_log(
+                    is_sampled,
+                    sleep_time,
+                    message,
+                    log_level,
+                    condition,
+                    raise_exception,
+                    inject_context,
+                ) else ()
+            ) for  # noqa - i don't know what you want me to do here flake8 nor do i care
+                is_sampled,
+                sleep_time,
+                message,
+                log_level,
+                condition,
+                raise_exception,
+                inject_context
+            in _parameter_combinations
+        ),
+        (  # we include a few explicit test cases using unmocked time functions to ensure the functions *actually* work
+           # as expected
+            (
+                True,
+                0.5,
+                "Touched the obedient {key}s for {duration_real}s",
+                logging.WARNING,
+                timing.default_condition,
+                None,
+                {
+                    "key": "D#",
+                    "keyes": "House Of",
+                },
+                False,
+                (ANY_superset_of({
+                    "message": ANY_string_matching(r"Touched the obedient D#s for [0-9Ee.-]+s"),
+                    "levelname": "WARNING",
+                    "key": "D#",
+                    "duration_real": malleable_ANY(lambda value: 0.48 < value < 0.6),
+                    "duration_process": malleable_ANY(lambda value: isinstance(value, Number)),
+                    "name": "conftest.foobar",
+                }),),
+            ),
+            (
+                None,
+                0.2,
+                "The obedient {item}s feeding in {exc_info}",
+                logging.ERROR,
+                True,
+                ValueError,
+                None,
+                False,
+                (
+                    ANY_superset_of({
+                        "levelname": "WARNING",
+                        "message": ANY_string_matching(r".*missing key.*", flags=re.IGNORECASE),
+                    }),
+                    ANY_superset_of({
+                        "message": ANY_string_matching(
+                            r"The obedient \{.*\}s feeding in .*ValueError.*",
+                            flags=re.DOTALL,
+                        ),
+                        "levelname": "ERROR",
+                        "exc_info": ANY_string_matching(
+                            r".*ValueError.*",
+                            flags=re.DOTALL,
+                        ),
+                        "duration_real": malleable_ANY(lambda value: 0.18 < value < 0.35),
+                        "duration_process": malleable_ANY(lambda value: isinstance(value, Number)),
+                        "name": "conftest.foobar",
+                    }),
+                ),
+            ),
+        )
+    ))
 )
 def test_logged_duration_real_logger(
     app_logtofile,
+    # value to set the is_sampled flag to on the mock request
     is_sampled,
+    # how long to sleep in seconds
     sleep_time,
+    # message, log_level, condition - values to pass as arguments of logged_duration verbatim
     message,
     log_level,
     condition,
+    # exception (class) to raise inside logged_duration, None to raise no exception
     raise_exception,
+    # dict to update log_context with inside logged_duration, None perform no update
     inject_context,
+    # whether to use mocked time primitives to speed up the test
+    mock_time,
+    # sequence of log dicts to expect to be output as json logs
     expected_logs,
 ):
     with open(app_logtofile.config["DM_LOG_PATH"], "r") as log_file:
@@ -316,18 +478,23 @@ def test_logged_duration_real_logger(
         with app_logtofile.test_request_context("/", headers={}):
             request.is_sampled = is_sampled
 
-            with (null_context_manager() if raise_exception is None else pytest.raises(raise_exception)):
-                with timing.logged_duration(
-                    logger=app_logtofile.logger.getChild("foobar"),
-                    message=message,
-                    log_level=log_level,
-                    condition=condition,
-                ) as log_context:
-                    sleep(sleep_time)
-                    if inject_context is not None:
-                        log_context.update(inject_context)
-                    if raise_exception is not None:
-                        raise raise_exception("Boo")
+            with (mock_time_functions() if mock_time else actual_time_functions()) as (
+                _sleep,
+                _perf_counter,
+                _process_time,
+            ):
+                with (null_context_manager() if raise_exception is None else pytest.raises(raise_exception)):
+                    with timing.logged_duration(
+                        logger=app_logtofile.logger.getChild("foobar"),
+                        message=message,
+                        log_level=log_level,
+                        condition=condition,
+                    ) as log_context:
+                        _sleep(sleep_time)
+                        if inject_context is not None:
+                            log_context.update(inject_context)
+                        if raise_exception is not None:
+                            raise raise_exception("Boo")
 
         # ensure buffers are flushed
         logging.shutdown()

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,305 @@
+from dmutils import timing
+
+from collections import OrderedDict
+from contextlib import contextmanager
+from functools import lru_cache
+from itertools import product
+import json
+import logging
+import mock
+from numbers import Number
+import re
+import sys
+from time import sleep
+
+from flask import request
+import pytest
+
+
+class malleable_ANY:
+    def __init__(self, condition):
+        self._condition = condition
+
+    def __eq__(self, other):
+        return self._condition(other)
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self._condition})"
+
+    def __hash__(self):
+        return None
+
+
+class ANY_superset_of(malleable_ANY):
+    def __init__(self, subset_dict):
+        self._subset_dict = subset_dict
+        super().__init__(lambda other: self._subset_dict == {k: v for k, v in other.items() if k in self._subset_dict})
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self._subset_dict})"
+
+
+class ANY_string_matching(malleable_ANY):
+    _cached_re_compile = staticmethod(lru_cache(maxsize=32)(re.compile))
+
+    def __init__(self, *args, **kwargs):
+        self._regex = self._cached_re_compile(*args, **kwargs)
+        super().__init__(lambda other: self._regex.match(other))
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self._regex})"
+
+
+# python 3.7 has an in-built version of this, but for now...
+@contextmanager
+def null_context_manager():
+    yield
+
+
+class SentinelError(Exception):
+    """An exception that can't be mistaken for a genuine problem"""
+    pass
+
+
+def _duration_real_gt_095(log_context):
+    return log_context["duration_real"] > 0.095
+
+
+def _default_and_no_exception(log_context):
+    return timing.default_condition(log_context) and sys.exc_info()[0] is None
+
+
+# a dictionary of messages to be passed to logged_duration mapped against a tuple of values to expect, the first of
+# these in the case that log message formatting has *not* yet taken place, the second assuming it *has*.
+_messages_expected = OrderedDict((
+    (
+        timing.default_message,
+        (
+            ANY_string_matching(r"Block (executed|raised \w+) in \{duration_real\}s of real-time"),
+            ANY_string_matching(r"Block (executed|raised \w+) in [0-9eE.-]+s of real-time"),
+        ),
+    ),
+    (
+        "{name} - {duration_process}s",
+        (
+            "{name} - {duration_process}s",
+            ANY_string_matching(r"[a-zA-Z_.-]+ - [0-9eE.-]+s"),
+        )
+    ),
+))
+
+
+_parameter_combinations = tuple(product(
+    (  # sampling_decision values
+        False,
+        None,
+        True,
+    ),
+    (  # sleep_time values
+        0.05,
+        0.1,
+    ),
+    # message values
+    _messages_expected.keys(),
+    (  # log_level values
+        logging.INFO,
+        logging.WARNING,
+    ),
+    (  # condition values
+        True,
+        None,
+        timing.default_condition,
+        _duration_real_gt_095,
+        _default_and_no_exception,
+    ),
+    (  # raise_exception values
+        None,
+        SentinelError,
+    ),
+))
+
+
+def _expect_log(
+    sampling_decision,
+    sleep_time,
+    message,
+    log_level,
+    condition,
+    raise_exception,
+):
+    """return whether to expect a log line to be output or not"""
+    return (
+        (condition is timing.default_condition and sampling_decision)
+        or (condition is _duration_real_gt_095 and sleep_time >= 0.1)
+        or (condition is _default_and_no_exception and sampling_decision and raise_exception is None)
+        or (condition in (True, None,))
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "sampling_decision",
+        "sleep_time",
+        "message",
+        "log_level",
+        "condition",
+        "raise_exception",
+        "expected_call_args_list",
+    ),
+    tuple(
+        (
+            sampling_decision,
+            sleep_time,
+            message,
+            log_level,
+            condition,
+            raise_exception,
+            [  # expected_call_args_list
+                mock.call(
+                    log_level,
+                    _messages_expected[message][0],
+                    exc_info=bool(raise_exception),
+                    extra={
+                        "duration_real": malleable_ANY(
+                            # a double-closure here to get around python's weird behaviour when capturing iterated
+                            # variables (in this case `sleep_time`)
+                            (lambda st: lambda val: st * 0.95 < val < st * 1.5)(sleep_time)
+                        ),
+                        "duration_process": mock.ANY,
+                    },
+                )
+            ] if _expect_log(
+                sampling_decision,
+                sleep_time,
+                message,
+                log_level,
+                condition,
+                raise_exception,
+            ) else []
+        ) for  # noqa - i don't know what you want me to do here flake8 nor do i care
+            sampling_decision,
+            sleep_time,
+            message,
+            log_level,
+            condition,
+            raise_exception
+        in _parameter_combinations
+    )
+)
+def test_logged_duration_mock_logger(
+    app,
+    sampling_decision,
+    sleep_time,
+    message,
+    log_level,
+    condition,
+    raise_exception,
+    expected_call_args_list,
+):
+    with app.test_request_context("/", headers={}):
+        request.sampling_decision = sampling_decision
+        mock_logger = mock.Mock(spec_set=("log",))
+
+        with (null_context_manager() if raise_exception is None else pytest.raises(raise_exception)):
+            with timing.logged_duration(
+                logger=mock_logger,
+                message=message,
+                log_level=log_level,
+                condition=condition,
+            ):
+                assert mock_logger.log.call_args_list == []
+                sleep(sleep_time)
+                if raise_exception is not None:
+                    raise raise_exception("Boo")
+
+    assert mock_logger.log.call_args_list == expected_call_args_list
+
+
+@pytest.mark.parametrize(
+    (
+        "sampling_decision",
+        "sleep_time",
+        "message",
+        "log_level",
+        "condition",
+        "raise_exception",
+        "expected_logs",
+    ),
+    tuple(
+        (
+            sampling_decision,
+            sleep_time,
+            message,
+            log_level,
+            condition,
+            raise_exception,
+            (  # expected_logs
+                ANY_superset_of({
+                    "name": "conftest.foobar",
+                    "levelname": logging.getLevelName(log_level),
+                    "message": _messages_expected[message][1],
+                    "duration_real": malleable_ANY(
+                        # a double-closure here to get around python's weird behaviour when capturing iterated
+                        # variables (in this case `sleep_time`)
+                        (lambda st: lambda val: st * 0.95 < val < st * 1.5)(sleep_time)
+                    ),
+                    "duration_process": malleable_ANY(lambda value: isinstance(value, Number)),
+                    **(
+                        {
+                            "exc_info": ANY_string_matching(
+                                r".*{}.*".format(re.escape(raise_exception.__name__)),
+                                flags=re.DOTALL,
+                            ),
+                        } if raise_exception else {}
+                    ),
+                }),
+            ) if _expect_log(
+                sampling_decision,
+                sleep_time,
+                message,
+                log_level,
+                condition,
+                raise_exception,
+            ) else ()
+        ) for  # noqa - i don't know what you want me to do here flake8 nor do i care
+            sampling_decision,
+            sleep_time,
+            message,
+            log_level,
+            condition,
+            raise_exception
+        in _parameter_combinations
+    )
+)
+def test_logged_duration_real_logger(
+    app_logtofile,
+    sampling_decision,
+    sleep_time,
+    message,
+    log_level,
+    condition,
+    raise_exception,
+    expected_logs,
+):
+    with open(app_logtofile.config["DM_LOG_PATH"], "r") as log_file:
+        # consume log initialization line
+        log_file.read()
+
+        with app_logtofile.test_request_context("/", headers={}):
+            request.sampling_decision = sampling_decision
+
+            with (null_context_manager() if raise_exception is None else pytest.raises(raise_exception)):
+                with timing.logged_duration(
+                    logger=app_logtofile.logger.getChild("foobar"),
+                    message=message,
+                    log_level=log_level,
+                    condition=condition,
+                ):
+                    sleep(sleep_time)
+                    if raise_exception is not None:
+                        raise raise_exception("Boo")
+
+        # ensure buffers are flushed
+        logging.shutdown()
+
+        assert tuple(json.loads(line) for line in log_file.read().splitlines()) == expected_logs


### PR DESCRIPTION
Here is a generic context manager that can be used to log the time taken to execute a given block of code. There should be enough flexibility built into it to use it both for logging normal events that have a duration we're interested in (calls to various APIs etc) or to use for micro-profiling sections of our production code. When execution leaves the wrapped block, a `condition` is called to determine whether a message should be logged in this particular case.

In the default condition, any current Flask `request` is inspected and a message is only logged if the the zipkin "trace" header has been specified - this would allow us to enable detailed profiling only for chosen requests sent by ourselves, however I fully expect people to be creative with the flexibility given here. Perhaps we could choose to log only blocks whose execution took longer than a certain threshold, or only those that completed successfully (didn't result in an exception).

Example, extremely minimal use:

```
with logged_duration(
    logger=logging.getLogger("boring.thing"),
    message="Spent {duration_real}s doing a boring thing",
):
    do_my()
    boring = thing()
```

**Update:**  those paying attention will notice that I've added another ability to the context manager. The object that the manager *yields* is now the dictionary that will be used to base `log_context` on. This allows the block to annotate the dictionary with e.g. results of the activity, e.g.:

```
with logged_duration(message="Received result {foo} in {duration_real}s") as log_context:
    ...
    log_context["foo"] = do_something()
    ...
```

This should make it more capable of taking over as the general log event emitted by e.g. api calls.