### PR TITLE
Add formatters

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '36.7.0'
+__version__ = '36.8.0'

--- a/dmutils/api_stubs.py
+++ b/dmutils/api_stubs.py
@@ -65,7 +65,8 @@ def framework(framework_id=1,
               clarifications_publish_at=dt(2000, 1, 2),
               applications_close_at=dt(2000, 1, 3),
               intention_to_award_at=dt(2000, 1, 4),
-              framework_live_at=dt(2000, 1, 5)):
+              framework_live_at=dt(2000, 1, 5),
+              framework_expires_at=dt(2000, 1, 6)):
     if name:
         pass
     elif slug.startswith('g-cloud'):
@@ -115,6 +116,7 @@ def framework(framework_id=1,
             'applicationsCloseAtUTC': format_datetime(applications_close_at),
             'intentionToAwardAtUTC': format_datetime(intention_to_award_at),
             'frameworkLiveAtUTC': format_datetime(framework_live_at),
+            'frameworkExpiresAtUTC': format_datetime(framework_expires_at),
         }
     }
 

--- a/dmutils/dates.py
+++ b/dmutils/dates.py
@@ -63,4 +63,5 @@ def update_framework_with_formatted_dates(framework):
         'applicationsCloseAt': utctoshorttimelongdateformat(framework['applicationsCloseAtUTC']),
         'intentionToAwardAt': dateformat(framework['intentionToAwardAtUTC']),
         'frameworkLiveAt': dateformat(framework['frameworkLiveAtUTC']),
+        'frameworkExpiresAt': dateformat(framework['frameworkExpiresAtUTC']),
     })

--- a/dmutils/dates.py
+++ b/dmutils/dates.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from workdays import workday
 
-from dmutils.formats import dateformat, utctoshorttimelongdateformat
+from .formats import dateformat, utctoshorttimelongdateformat
 
 
 def get_publishing_dates(brief):

--- a/dmutils/dates.py
+++ b/dmutils/dates.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta
 from workdays import workday
 
+from dmutils.formats import dateformat, utctoshorttimelongdateformat
+
 
 def get_publishing_dates(brief):
     APPLICATION_OPEN_DAYS = {'1 week': 7, '2 weeks': 14}
@@ -48,3 +50,17 @@ def _get_todays_date():
 
 def _get_length_of_brief(brief):
     return brief['requirementsLength'] if brief.get('requirementsLength') else '2 weeks'
+
+
+def update_framework_with_formatted_dates(framework):
+    """Takes a framework record (as returned by eg data_api_client.get_framework) and inserts new keys
+    for any date/time values that should be displayed consistently on the frontends.
+
+    This is currently used for important framework lifecycle/application dates."""
+    framework.update({
+        'clarificationsCloseAt': utctoshorttimelongdateformat(framework['clarificationsCloseAtUTC']),
+        'clarificationsPublishAt': utctoshorttimelongdateformat(framework['clarificationsPublishAtUTC']),
+        'applicationsCloseAt': utctoshorttimelongdateformat(framework['applicationsCloseAtUTC']),
+        'intentionToAwardAt': dateformat(framework['intentionToAwardAtUTC']),
+        'frameworkLiveAt': dateformat(framework['frameworkLiveAtUTC']),
+    })

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -59,6 +59,7 @@ def init_app(
     application.add_template_filter(formats.shortdateformat)
     application.add_template_filter(formats.timeformat)
     application.add_template_filter(formats.utcdatetimeformat)
+    application.add_template_filter(formats.utctoshorttimelongdateformat)
 
     @application.context_processor
     def inject_global_template_variables():

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -5,6 +5,7 @@ import re
 
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_FORMAT = "%Y-%m-%d"
+DISPLAY_MONTH_YEAR_FORMAT = "%B %Y"
 DISPLAY_SHORT_DATE_FORMAT = '%-d %B'
 DISPLAY_DATE_FORMAT = '%A %-d %B %Y'
 DISPLAY_TIME_FORMAT = '%H:%M:%S'
@@ -52,6 +53,18 @@ def dateformat(value, default_value=None):
     return _format_date(value, default_value, DISPLAY_DATE_FORMAT, localize=False)
 
 
+def monthyearformat(value, default_value=None):
+    """
+    Example value: datetime.strptime("2018-07-25 10:15:00", "%Y-%m-%d %H:%M:%S") OR "2010-01-01T13:00:00.000000Z"
+    Example output: 'July 2018'
+
+    This is used when precision is not required and we are trying to remind a user roughly when a historical event
+    occurred. The only place this is currently used is when offering a supplier the ability to reuse their declaration
+    from a previous framework and we want to remind them roughly when those answers were provided.
+    """
+    return _format_date(value, default_value, DISPLAY_MONTH_YEAR_FORMAT, localize=False)
+
+
 def datetimeformat(value, default_value=None, localize=True):
     """
     Example value: datetime.strptime("2018-07-25 23:59:59", "%Y-%m-%d %H:%M:%S")
@@ -71,7 +84,7 @@ def datetimeformat(value, default_value=None, localize=True):
 
 def utctoshorttimelongdateformat(value, default_value=None, localize=True):
     """
-    Example value: datetime.strptime("2010-01-01 13:00:00", "%Y-%m-%d %H:%M:%S") OR "2010-01-01T13:00:00Z"
+    Example value: datetime.strptime("2010-01-01 13:00:00", "%Y-%m-%d %H:%M:%S") OR "2010-01-01T13:00:00.000000Z"
     Example output: '1pm GMT, Friday 1 January 2010'
 
     "utctoshorttimelongdateformat" takes a datetime object or ISO8601 datetime string, localizes it to GMT/BST (as

--- a/tests/test_api_stubs.py
+++ b/tests/test_api_stubs.py
@@ -102,6 +102,7 @@ class TestFramework:
                 'applicationsCloseAtUTC': '2000-01-03T00:00:00.000000Z',
                 'intentionToAwardAtUTC': '2000-01-04T00:00:00.000000Z',
                 'frameworkLiveAtUTC': '2000-01-05T00:00:00.000000Z',
+                'frameworkExpiresAtUTC': '2000-01-06T00:00:00.000000Z',
             }
         }
 
@@ -126,6 +127,7 @@ class TestFramework:
                 'applicationsCloseAtUTC': '2000-01-03T00:00:00.000000Z',
                 'intentionToAwardAtUTC': '2000-01-04T00:00:00.000000Z',
                 'frameworkLiveAtUTC': '2000-01-05T00:00:00.000000Z',
+                'frameworkExpiresAtUTC': '2000-01-06T00:00:00.000000Z',
             }
         }
 
@@ -150,6 +152,7 @@ class TestFramework:
                 'applicationsCloseAtUTC': '2000-01-03T00:00:00.000000Z',
                 'intentionToAwardAtUTC': '2000-01-04T00:00:00.000000Z',
                 'frameworkLiveAtUTC': '2000-01-05T00:00:00.000000Z',
+                'frameworkExpiresAtUTC': '2000-01-06T00:00:00.000000Z',
             }
         }
 
@@ -174,6 +177,7 @@ class TestFramework:
                 'applicationsCloseAtUTC': '2000-01-03T00:00:00.000000Z',
                 'intentionToAwardAtUTC': '2000-01-04T00:00:00.000000Z',
                 'frameworkLiveAtUTC': '2000-01-05T00:00:00.000000Z',
+                'frameworkExpiresAtUTC': '2000-01-06T00:00:00.000000Z',
             }
         }
 
@@ -182,7 +186,8 @@ class TestFramework:
                                    clarifications_publish_at=dt(2010, 2, 2),
                                    applications_close_at=dt(2010, 3, 3),
                                    intention_to_award_at=dt(2010, 4, 4),
-                                   framework_live_at=dt(2010, 5, 5)) == {
+                                   framework_live_at=dt(2010, 5, 5),
+                                   framework_expires_at=dt(2010, 6, 6)) == {
             "frameworks": {
                 "id": 1,
                 "name": "G-Cloud 7",
@@ -201,6 +206,7 @@ class TestFramework:
                 'applicationsCloseAtUTC': '2010-03-03T00:00:00.000000Z',
                 'intentionToAwardAtUTC': '2010-04-04T00:00:00.000000Z',
                 'frameworkLiveAtUTC': '2010-05-05T00:00:00.000000Z',
+                'frameworkExpiresAtUTC': '2010-06-06T00:00:00.000000Z',
             }
         }
 

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -243,3 +243,28 @@ class TestPublishingDates():
         assert dates['questions_close'] == datetime.datetime(2016, 1, 11, 23, 59, 59)
         assert dates['answers_close'] == datetime.datetime(2016, 1, 15, 23, 59, 59)
         assert dates['closing_date'] == datetime.datetime(2016, 1, 18, 23, 59, 59)
+
+
+def test_update_framework_with_formatted_dates():
+    framework = {
+        'clarificationsCloseAtUTC': '2000-01-01T12:00:00.000000Z',
+        'clarificationsPublishAtUTC': '2000-01-02T12:00:00.000000Z',
+        'applicationsCloseAtUTC': '2000-01-03T17:00:00.000000Z',
+        'intentionToAwardAtUTC': '2000-01-04T12:00:00.000000Z',
+        'frameworkLiveAtUTC': '2000-01-05T12:00:00.000000Z',
+    }
+
+    dates_package.update_framework_with_formatted_dates(framework)
+
+    assert framework == {
+        'clarificationsCloseAtUTC': '2000-01-01T12:00:00.000000Z',
+        'clarificationsPublishAtUTC': '2000-01-02T12:00:00.000000Z',
+        'applicationsCloseAtUTC': '2000-01-03T17:00:00.000000Z',
+        'intentionToAwardAtUTC': '2000-01-04T12:00:00.000000Z',
+        'frameworkLiveAtUTC': '2000-01-05T12:00:00.000000Z',
+        'clarificationsCloseAt': '12pm GMT, Saturday 1 January 2000',
+        'clarificationsPublishAt': '12pm GMT, Sunday 2 January 2000',
+        'applicationsCloseAt': '5pm GMT, Monday 3 January 2000',
+        'intentionToAwardAt': 'Tuesday 4 January 2000',
+        'frameworkLiveAt': 'Wednesday 5 January 2000',
+    }

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -252,6 +252,7 @@ def test_update_framework_with_formatted_dates():
         'applicationsCloseAtUTC': '2000-01-03T17:00:00.000000Z',
         'intentionToAwardAtUTC': '2000-01-04T12:00:00.000000Z',
         'frameworkLiveAtUTC': '2000-01-05T12:00:00.000000Z',
+        'frameworkExpiresAtUTC': '2000-01-06T12:00:00.000000Z',
     }
 
     dates_package.update_framework_with_formatted_dates(framework)
@@ -262,9 +263,11 @@ def test_update_framework_with_formatted_dates():
         'applicationsCloseAtUTC': '2000-01-03T17:00:00.000000Z',
         'intentionToAwardAtUTC': '2000-01-04T12:00:00.000000Z',
         'frameworkLiveAtUTC': '2000-01-05T12:00:00.000000Z',
+        'frameworkExpiresAtUTC': '2000-01-06T12:00:00.000000Z',
         'clarificationsCloseAt': '12pm GMT, Saturday 1 January 2000',
         'clarificationsPublishAt': '12pm GMT, Sunday 2 January 2000',
         'applicationsCloseAt': '5pm GMT, Monday 3 January 2000',
         'intentionToAwardAt': 'Tuesday 4 January 2000',
         'frameworkLiveAt': 'Wednesday 5 January 2000',
+        'frameworkExpiresAt': 'Thursday 6 January 2000',
     }

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from dmutils.formats import (
-    timeformat, shortdateformat, dateformat, datetimeformat, datetodatetimeformat,
+    timeformat, shortdateformat, dateformat, monthyearformat, datetimeformat, datetodatetimeformat,
     utcdatetimeformat, utctoshorttimelongdateformat
 )
 import pytz
@@ -46,6 +46,23 @@ def test_shortdateformat(dt, formatted_date):
 ))
 def test_dateformat(dt, formatted_date):
     assert dateformat(dt) == formatted_date
+
+
+@pytest.mark.parametrize("dt, default_value, formatted_date", (
+    (datetime(2012, 11, 10, 9, 8, 7, 6), None, "November 2012"),
+    ("2012-11-10T09:08:07.0Z", None, "November 2012"),
+    (datetime(2012, 8, 10, 9, 8, 7, 6), None, "August 2012"),
+    ("2012-08-10T09:08:07.0Z", None, "August 2012"),
+    (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), None, "August 2012"),
+    ("2016-04-27T23:59:59.0Z", None, "April 2016"),
+    (datetime(2016, 4, 27, 23, 59, 59, 0), None, "April 2016"),
+    (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), None, "August 2012"),
+
+    # Check fall back to default_value if no date provided
+    (None, 'default-value', 'default-value')
+))
+def test_monthyearformat(dt, default_value, formatted_date):
+    assert monthyearformat(dt, default_value=default_value) == formatted_date
 
 
 @pytest.mark.parametrize("dt, formatted_datetime", (

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from dmutils.formats import (
     timeformat, shortdateformat, dateformat, datetimeformat, datetodatetimeformat,
-    utcdatetimeformat
+    utcdatetimeformat, utctoshorttimelongdateformat
 )
 import pytz
 from datetime import datetime
@@ -64,6 +64,33 @@ def test_dateformat(dt, formatted_date):
 ))
 def test_datetimeformat(dt, formatted_datetime):
     assert datetimeformat(dt) == formatted_datetime
+
+
+@pytest.mark.parametrize("dt, localize, default_value, formatted_datetime", (
+    (datetime(2012, 11, 10, 9, 8, 7, 6), True, None, "9am GMT, Saturday 10 November 2012"),
+    ("2012-11-10T09:08:07.0Z", True, None, "9am GMT, Saturday 10 November 2012"),
+    (datetime(2012, 8, 10, 9, 8, 7, 6), True, None, "10am BST, Friday 10 August 2012"),
+    ("2012-08-10T09:08:07.0Z", True, None, "10am BST, Friday 10 August 2012"),
+    (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), True, None, "10am BST, Friday 10 August 2012"),
+    (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), True, None, "10am BST, Wednesday 1 August 2012"),
+    (datetime(2012, 8, 1, 22, 59, 7, 6, tzinfo=pytz.utc), True, None, "11pm BST, Wednesday 1 August 2012"),
+
+    # Daylight savings edge case
+    (datetime(2012, 3, 25, 0, 59, 7, 6, tzinfo=pytz.utc), True, None, "12am GMT, Sunday 25 March 2012"),
+    (datetime(2012, 3, 25, 1, 59, 7, 6, tzinfo=pytz.utc), True, None, "2am BST, Sunday 25 March 2012"),
+
+    # Check localization can be disabled
+    (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), False, None, "9am UTC, Wednesday 1 August 2012"),
+
+    # Check default_value returned if no value specified
+    (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), True, 'my-default-value', "10am BST, Wednesday 1 August 2012"),
+    (None, False, 'my-default-value', "my-default-value"),
+
+    # Fall back to default if no valid date supplied
+    (None, True, None, None),
+))
+def test_utctoshorttimelongdateformat(dt, localize, default_value, formatted_datetime):
+    assert utctoshorttimelongdateformat(dt, localize=localize, default_value=default_value) == formatted_datetime
 
 
 @pytest.mark.parametrize("dt, formatted_datetime", (


### PR DESCRIPTION
 ## Summary
We are going to store important framework lifecycle datetimes on the
API, so we need to be able to format these correctly for display on the
frontend. We currently use a different display format for these, so this
adds a formatter that will give the desired display e.g. '5pm BST,
Monday 1 July 2010'.

Also adds a second formatter `monthyearformatter`, currently used to
display the month and year when a supplier completed a previous
declaration when applying to a framework.

Also moves some style guide formatting to a more central function so

Bump version to 36.8.0

 ## Ticket
https://trello.com/c/BVPgZRZc/65-store-datetimes-relating-to-the-framework-lifecycle-on-the-api