### PR TITLE
Move api stubs here from dm-apiclient

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '36.5.1'
+__version__ = '36.6.0'

--- a/dmutils/api_stubs.py
+++ b/dmutils/api_stubs.py
@@ -3,12 +3,64 @@ from datetime import datetime as dt
 from .formats import DATETIME_FORMAT
 
 
-def framework(status="open",
+def lot(lot_id=1, slug="some-lot", name=None, allows_brief=False, one_service_limit=False, unit_singular='service',
+        unit_plural='services'):
+    if not name:
+        name = slug.replace("-", " ").title()
+
+    return {
+        "id": lot_id,
+        "slug": slug,
+        "name": name,
+        "allowsBrief": allows_brief,
+        "oneServiceLimit": one_service_limit,
+        "unitSingular": unit_singular,
+        "unitPlural": unit_plural,
+    }
+
+
+def framework_agreement_details(slug='g-cloud-7',
+                                framework_agreement_version='RM1557x',
+                                framework_variations=None,
+                                lots=None):
+    if not lots:
+        lots = []
+
+    lot_descriptions = {}
+    for i, one_lot in enumerate(lots):
+        lot_descriptions[one_lot['slug']] = f"Lot {i+1}: {one_lot['name']}"
+
+    lot_order = [one_lot['slug'] for one_lot in lots]
+
+    if not framework_variations:
+        framework_variations = {}
+
+    return {
+        "contractNoticeNumber": "2010/ABC-DEF",
+        "frameworkAgreementVersion": framework_agreement_version,
+        "frameworkEndDate": "01 January 2001",
+        "frameworkExtensionLength": "12 months",
+        "frameworkRefDate": "29-06-2000",
+        "frameworkStartDate": "05 January 2000",
+        "frameworkURL": f"https://www.gov.uk/government/publications/{slug}",
+        "lotDescriptions": lot_descriptions,
+        "lotOrder": lot_order,
+        "pageTotal": 99,
+        "signaturePageNumber": 98,
+        "variations": framework_variations
+    }
+
+
+def framework(framework_id=1,
+              status="open",
               slug="g-cloud-7",
               name=None,
               clarification_questions_open=True,
               lots=None,
               framework_family=None,
+              framework_agreement_version='RM1557x',
+              framework_variations=None,
+              allow_declaration_reuse=True,
               clarifications_close_at=dt(2000, 1, 1),
               clarifications_publish_at=dt(2000, 1, 2),
               applications_close_at=dt(2000, 1, 3),
@@ -35,34 +87,35 @@ def framework(status="open",
 
     lots = lots or []
 
+    agreement_details = framework_agreement_details(slug=slug,
+                                                    framework_agreement_version=framework_agreement_version,
+                                                    framework_variations=framework_variations,
+                                                    lots=lots)
+
     def format_datetime(datetime_utc):
         assert isinstance(datetime_utc, dt)
         return datetime_utc.strftime(DATETIME_FORMAT)
 
     return {
         "frameworks": {
+            "id": framework_id,
+            "name": name,
+            "slug": slug,
             "framework": framework_family,
             "status": status,
             "clarificationQuestionsOpen": clarification_questions_open,
-            "name": name,
-            "slug": slug,
             "lots": lots,
+            "allowDeclarationReuse": allow_declaration_reuse,
+            "frameworkAgreementDetails": agreement_details,
+            "countersignerName": agreement_details.get('countersignerName'),
+            "frameworkAgreementVersion": agreement_details.get('frameworkAgreementVersion'),
+            "variations": agreement_details.get('variations'),
             'clarificationsCloseAtUTC': format_datetime(clarifications_close_at),
             'clarificationsPublishAtUTC': format_datetime(clarifications_publish_at),
             'applicationsCloseAtUTC': format_datetime(applications_close_at),
             'intentionToAwardAtUTC': format_datetime(intention_to_award_at),
             'frameworkLiveAtUTC': format_datetime(framework_live_at),
         }
-    }
-
-
-def lot(slug="some-lot", allows_brief=False, one_service_limit=False):
-    return {
-        "id": 1,
-        "slug": slug,
-        "name": slug.replace("-", " ").title(),
-        "allowsBrief": allows_brief,
-        "oneServiceLimit": one_service_limit,
     }
 
 

--- a/dmutils/api_stubs.py
+++ b/dmutils/api_stubs.py
@@ -1,0 +1,156 @@
+from datetime import datetime as dt
+
+from .formats import DATETIME_FORMAT
+
+
+def framework(status="open",
+              slug="g-cloud-7",
+              name=None,
+              clarification_questions_open=True,
+              lots=None,
+              framework_family=None,
+              clarifications_close_at=dt(2000, 1, 1),
+              clarifications_publish_at=dt(2000, 1, 2),
+              applications_close_at=dt(2000, 1, 3),
+              intention_to_award_at=dt(2000, 1, 4),
+              framework_live_at=dt(2000, 1, 5)):
+    if name:
+        pass
+    elif slug.startswith('g-cloud'):
+        name = 'G-Cloud {}'.format(slug.split('-')[-1])
+    elif slug.startswith("digital-outcomes-and-specialists"):
+        name = slug.replace("-", " ").title()
+        name = name.replace('And', 'and')
+    else:
+        name = slug.replace("-", " ").title()
+
+    if framework_family:
+        pass
+    elif slug.startswith('g-cloud'):
+        framework_family = 'g-cloud'
+    elif slug.startswith("digital-outcomes-and-specialists"):
+        framework_family = 'digital-outcomes-and-specialists'
+    else:
+        framework_family = slug
+
+    lots = lots or []
+
+    def format_datetime(datetime_utc):
+        assert isinstance(datetime_utc, dt)
+        return datetime_utc.strftime(DATETIME_FORMAT)
+
+    return {
+        "frameworks": {
+            "framework": framework_family,
+            "status": status,
+            "clarificationQuestionsOpen": clarification_questions_open,
+            "name": name,
+            "slug": slug,
+            "lots": lots,
+            'clarificationsCloseAtUTC': format_datetime(clarifications_close_at),
+            'clarificationsPublishAtUTC': format_datetime(clarifications_publish_at),
+            'applicationsCloseAtUTC': format_datetime(applications_close_at),
+            'intentionToAwardAtUTC': format_datetime(intention_to_award_at),
+            'frameworkLiveAtUTC': format_datetime(framework_live_at),
+        }
+    }
+
+
+def lot(slug="some-lot", allows_brief=False, one_service_limit=False):
+    return {
+        "id": 1,
+        "slug": slug,
+        "name": slug.replace("-", " ").title(),
+        "allowsBrief": allows_brief,
+        "oneServiceLimit": one_service_limit,
+    }
+
+
+def brief(status="draft",
+          framework_slug="digital-outcomes-and-specialists",
+          lot_slug="digital-specialists",
+          user_id=123,
+          framework_name="Digital Outcomes and Specialists",
+          framework_framework="digital-outcomes-and-specialists",
+          clarification_questions=None,
+          clarification_questions_closed=False):
+    brief = {
+        "briefs": {
+            "id": 1234,
+            "title": "I need a thing to do a thing",
+            "frameworkSlug": framework_slug,
+            "frameworkName": framework_name,
+            "frameworkFramework": framework_framework,
+            "lotSlug": lot_slug,
+            "status": status,
+            "users": [{"active": True,
+                       "role": "buyer",
+                       "emailAddress": "buyer@email.com",
+                       "id": user_id,
+                       "name": "Buyer User"}],
+            "createdAt": "2016-03-29T10:11:12.000000Z",
+            "updatedAt": "2016-03-29T10:11:13.000000Z",
+            "clarificationQuestions": clarification_questions or [],
+        }
+    }
+    if status in ("live", "closed"):
+        brief['briefs']['publishedAt'] = "2016-03-29T10:11:14.000000Z"
+        brief['briefs']['applicationsClosedAt'] = "2016-04-07T00:00:00.000000Z"
+        brief['briefs']['clarificationQuestionsClosedAt'] = "2016-04-02T00:00:00.000000Z"
+        brief['briefs']['clarificationQuestionsAreClosed'] = clarification_questions_closed
+
+    return brief
+
+
+def supplier(id=1234, contact_id=4321, other_company_registration_number=0, company_details_confirmed=True):
+    data = {
+        "suppliers": {
+            "companiesHouseNumber": "12345678",
+            "companyDetailsConfirmed": company_details_confirmed,
+            "contactInformation": [
+                {
+                    "address1": "123 Fake Road",
+                    "city": "Madeupolis",
+                    "contactName": "Mr E Man",
+                    "email": "mre@company.com",
+                    "id": contact_id,
+                    "links": {
+                        "self": "http://localhost:5000/suppliers/{id}/contact-information/{contact_id}".format(
+                            id=id, contact_id=contact_id
+                        )
+                    },
+                    "phoneNumber": "01234123123",
+                    "postcode": "A11 1AA",
+                    "website": "https://www.mre.company"
+                }
+            ],
+            "description": "I'm a supplier.",
+            "dunsNumber": "123456789",
+            "id": id,
+            "links": {
+                "self": "http://localhost:5000/suppliers/{id}".format(id=id)
+            },
+            "name": "My Little Company",
+            "organisationSize": "micro",
+            "registeredName": "My Little Registered Company",
+            "registrationCountry": "country:GB",
+            "service_counts": {
+                "G-Cloud 9": 109,
+                "G-Cloud 8": 108,
+                "G-Cloud 7": 107,
+                "G-Cloud 6": 106,
+                "G-Cloud 5": 105,
+            },
+            "tradingStatus": "limited company",
+            "vatNumber": "111222333"
+        }
+    }
+
+    if other_company_registration_number:
+        data['suppliers']['otherCompanyRegistrationNumber'] = other_company_registration_number
+        # We allow one or other of these registration numbers, but not both
+        del data['suppliers']['companiesHouseNumber']
+        # Companies without a Companies House number aren't necessarily overseas, but they might well be
+        data['suppliers']['registrationCountry'] = 'country:NZ'
+
+    return data

--- a/tests/test_api_stubs.py
+++ b/tests/test_api_stubs.py
@@ -2,111 +2,207 @@ from datetime import datetime as dt
 from dmutils import api_stubs
 
 
-def test_framework():
-    assert api_stubs.framework() == {
-        "frameworks": {
-            "clarificationQuestionsOpen": True,
-            "lots": [],
-            "name": "G-Cloud 7",
-            "slug": "g-cloud-7",
-            "framework": "g-cloud",
-            "status": "open",
-            'clarificationsCloseAtUTC': '2000-01-01T00:00:00.000000Z',
-            'clarificationsPublishAtUTC': '2000-01-02T00:00:00.000000Z',
-            'applicationsCloseAtUTC': '2000-01-03T00:00:00.000000Z',
-            'intentionToAwardAtUTC': '2000-01-04T00:00:00.000000Z',
-            'frameworkLiveAtUTC': '2000-01-05T00:00:00.000000Z',
+class TestLot:
+    def test_default_values(self):
+        assert api_stubs.lot() == {
+            "id": 1,
+            "slug": "some-lot",
+            "name": "Some Lot",
+            "allowsBrief": False,
+            "oneServiceLimit": False,
+            "unitSingular": "service",
+            "unitPlural": "services",
         }
-    }
 
-    assert api_stubs.framework(slug='digital-outcomes-and-specialists') == {
-        "frameworks": {
-            "clarificationQuestionsOpen": True,
-            "lots": [],
-            "name": "Digital Outcomes and Specialists",
-            "slug": "digital-outcomes-and-specialists",
-            "framework": "digital-outcomes-and-specialists",
-            "status": "open",
-            'clarificationsCloseAtUTC': '2000-01-01T00:00:00.000000Z',
-            'clarificationsPublishAtUTC': '2000-01-02T00:00:00.000000Z',
-            'applicationsCloseAtUTC': '2000-01-03T00:00:00.000000Z',
-            'intentionToAwardAtUTC': '2000-01-04T00:00:00.000000Z',
-            'frameworkLiveAtUTC': '2000-01-05T00:00:00.000000Z',
+    def test_override_values(self):
+        assert api_stubs.lot(lot_id=2, slug="my-special-lot", allows_brief=True, one_service_limit=True,
+                             unit_singular='brief', unit_plural='briefs') == {
+            "id": 2,
+            "slug": "my-special-lot",
+            "name": "My Special Lot",
+            "allowsBrief": True,
+            "oneServiceLimit": True,
+            "unitSingular": "brief",
+            "unitPlural": "briefs",
         }
-    }
 
-    assert api_stubs.framework(status='live', clarification_questions_open=False,
-                               name='My overriden name', slug='my-fake-framework') == {
-        "frameworks": {
-            "clarificationQuestionsOpen": False,
-            "lots": [],
-            "name": "My overriden name",
-            "slug": "my-fake-framework",
-            "framework": "my-fake-framework",
-            "status": "live",
-            'clarificationsCloseAtUTC': '2000-01-01T00:00:00.000000Z',
-            'clarificationsPublishAtUTC': '2000-01-02T00:00:00.000000Z',
-            'applicationsCloseAtUTC': '2000-01-03T00:00:00.000000Z',
-            'intentionToAwardAtUTC': '2000-01-04T00:00:00.000000Z',
-            'frameworkLiveAtUTC': '2000-01-05T00:00:00.000000Z',
+
+class TestFrameworkAgreementDetails:
+    def test_default_values(self):
+        assert api_stubs.framework_agreement_details() == {
+            "contractNoticeNumber": "2010/ABC-DEF",
+            "frameworkAgreementVersion": "RM1557x",
+            "frameworkEndDate": "01 January 2001",
+            "frameworkExtensionLength": "12 months",
+            "frameworkRefDate": "29-06-2000",
+            "frameworkStartDate": "05 January 2000",
+            "frameworkURL": f"https://www.gov.uk/government/publications/g-cloud-7",
+            "lotDescriptions": {},
+            "lotOrder": [],
+            "pageTotal": 99,
+            "signaturePageNumber": 98,
+            "variations": {}
         }
-    }
 
-    assert api_stubs.framework(lots=['cloud-hosting', 'cloud-support']) == {
-        "frameworks": {
-            "clarificationQuestionsOpen": True,
-            "lots": ['cloud-hosting', 'cloud-support'],
-            "name": "G-Cloud 7",
-            "slug": "g-cloud-7",
-            "framework": "g-cloud",
-            "status": "open",
-            'clarificationsCloseAtUTC': '2000-01-01T00:00:00.000000Z',
-            'clarificationsPublishAtUTC': '2000-01-02T00:00:00.000000Z',
-            'applicationsCloseAtUTC': '2000-01-03T00:00:00.000000Z',
-            'intentionToAwardAtUTC': '2000-01-04T00:00:00.000000Z',
-            'frameworkLiveAtUTC': '2000-01-05T00:00:00.000000Z',
+    def test_override_slug_version_and_variation(self):
+        assert api_stubs.framework_agreement_details(slug='my-custom-slug',
+                                                     framework_agreement_version='v0.0.1',
+                                                     framework_variations={"1": "blah"}) == {
+            "contractNoticeNumber": "2010/ABC-DEF",
+            "frameworkAgreementVersion": "v0.0.1",
+            "frameworkEndDate": "01 January 2001",
+            "frameworkExtensionLength": "12 months",
+            "frameworkRefDate": "29-06-2000",
+            "frameworkStartDate": "05 January 2000",
+            "frameworkURL": f"https://www.gov.uk/government/publications/my-custom-slug",
+            "lotDescriptions": {},
+            "lotOrder": [],
+            "pageTotal": 99,
+            "signaturePageNumber": 98,
+            "variations": {"1": "blah"},
         }
-    }
 
-    assert api_stubs.framework(clarifications_close_at=dt(2010, 1, 1),
-                               clarifications_publish_at=dt(2010, 2, 2),
-                               applications_close_at=dt(2010, 3, 3),
-                               intention_to_award_at=dt(2010, 4, 4),
-                               framework_live_at=dt(2010, 5, 5)) == {
-        "frameworks": {
-            "clarificationQuestionsOpen": True,
-            "lots": [],
-            "name": "G-Cloud 7",
-            "slug": "g-cloud-7",
-            "framework": "g-cloud",
-            "status": "open",
-            'clarificationsCloseAtUTC': '2010-01-01T00:00:00.000000Z',
-            'clarificationsPublishAtUTC': '2010-02-02T00:00:00.000000Z',
-            'applicationsCloseAtUTC': '2010-03-03T00:00:00.000000Z',
-            'intentionToAwardAtUTC': '2010-04-04T00:00:00.000000Z',
-            'frameworkLiveAtUTC': '2010-05-05T00:00:00.000000Z',
+    def test_with_lots(self):
+        lots = [api_stubs.lot(slug='cloud-hosting'), api_stubs.lot(slug='cloud-support')]
+        assert api_stubs.framework_agreement_details(lots=lots) == {
+            "contractNoticeNumber": "2010/ABC-DEF",
+            "frameworkAgreementVersion": "RM1557x",
+            "frameworkEndDate": "01 January 2001",
+            "frameworkExtensionLength": "12 months",
+            "frameworkRefDate": "29-06-2000",
+            "frameworkStartDate": "05 January 2000",
+            "frameworkURL": f"https://www.gov.uk/government/publications/g-cloud-7",
+            "lotDescriptions": {"cloud-hosting": "Lot 1: Cloud Hosting",
+                                "cloud-support": "Lot 2: Cloud Support"},
+            "lotOrder": ["cloud-hosting", "cloud-support"],
+            "pageTotal": 99,
+            "signaturePageNumber": 98,
+            "variations": {}
         }
-    }
 
 
-def test_framework_name_changes_with_slug():
-    assert api_stubs.framework(slug='digital-outcomes-and-specialists')["frameworks"]["name"] == \
-        "Digital Outcomes and Specialists"
-    assert api_stubs.framework(slug="my-framework")["frameworks"]["name"] == "My Framework"
+class TestFramework:
+    def test_default_values(self):
+        assert api_stubs.framework() == {
+            "frameworks": {
+                "id": 1,
+                "name": "G-Cloud 7",
+                "slug": "g-cloud-7",
+                "framework": "g-cloud",
+                "status": "open",
+                "clarificationQuestionsOpen": True,
+                "lots": [],
+                "allowDeclarationReuse": True,
+                "frameworkAgreementDetails": api_stubs.framework_agreement_details(),
+                "countersignerName": None,
+                "frameworkAgreementVersion": "RM1557x",
+                "variations": {},
+                'clarificationsCloseAtUTC': '2000-01-01T00:00:00.000000Z',
+                'clarificationsPublishAtUTC': '2000-01-02T00:00:00.000000Z',
+                'applicationsCloseAtUTC': '2000-01-03T00:00:00.000000Z',
+                'intentionToAwardAtUTC': '2000-01-04T00:00:00.000000Z',
+                'frameworkLiveAtUTC': '2000-01-05T00:00:00.000000Z',
+            }
+        }
 
+    def test_custom_slug_derives_name_and_framework(self):
+        framework_agreement_details = api_stubs.framework_agreement_details(slug='digital-outcomes-and-specialists')
+        assert api_stubs.framework(slug='digital-outcomes-and-specialists') == {
+            "frameworks": {
+                "id": 1,
+                "name": "Digital Outcomes and Specialists",
+                "slug": "digital-outcomes-and-specialists",
+                "framework": "digital-outcomes-and-specialists",
+                "status": "open",
+                "clarificationQuestionsOpen": True,
+                "lots": [],
+                "allowDeclarationReuse": True,
+                "frameworkAgreementDetails": framework_agreement_details,
+                "countersignerName": None,
+                "frameworkAgreementVersion": "RM1557x",
+                "variations": {},
+                'clarificationsCloseAtUTC': '2000-01-01T00:00:00.000000Z',
+                'clarificationsPublishAtUTC': '2000-01-02T00:00:00.000000Z',
+                'applicationsCloseAtUTC': '2000-01-03T00:00:00.000000Z',
+                'intentionToAwardAtUTC': '2000-01-04T00:00:00.000000Z',
+                'frameworkLiveAtUTC': '2000-01-05T00:00:00.000000Z',
+            }
+        }
 
-def test_lot_name_default_is_made_from_slug():
-    assert api_stubs.lot(slug="my-lot")["name"] == "My Lot"
+    def test_override_status_slug_name_and_clarification_questions(self):
+        assert api_stubs.framework(status='live', slug='my-fake-framework', name='My overriden name',
+                                   clarification_questions_open=False) == {
+            "frameworks": {
+                "id": 1,
+                "name": "My overriden name",
+                "slug": "my-fake-framework",
+                "framework": "my-fake-framework",
+                "status": "live",
+                "clarificationQuestionsOpen": False,
+                "lots": [],
+                "allowDeclarationReuse": True,
+                "frameworkAgreementDetails": api_stubs.framework_agreement_details(slug='my-fake-framework'),
+                "countersignerName": None,
+                "frameworkAgreementVersion": "RM1557x",
+                "variations": {},
+                'clarificationsCloseAtUTC': '2000-01-01T00:00:00.000000Z',
+                'clarificationsPublishAtUTC': '2000-01-02T00:00:00.000000Z',
+                'applicationsCloseAtUTC': '2000-01-03T00:00:00.000000Z',
+                'intentionToAwardAtUTC': '2000-01-04T00:00:00.000000Z',
+                'frameworkLiveAtUTC': '2000-01-05T00:00:00.000000Z',
+            }
+        }
 
+    def test_with_lots(self):
+        lots = [api_stubs.lot(slug='cloud-hosting'), api_stubs.lot(slug='cloud-support')]
+        assert api_stubs.framework(lots=lots) == {
+            "frameworks": {
+                "id": 1,
+                "name": "G-Cloud 7",
+                "slug": "g-cloud-7",
+                "framework": "g-cloud",
+                "status": "open",
+                "clarificationQuestionsOpen": True,
+                "lots": lots,
+                "allowDeclarationReuse": True,
+                "frameworkAgreementDetails": api_stubs.framework_agreement_details(lots=lots),
+                "countersignerName": None,
+                "frameworkAgreementVersion": "RM1557x",
+                "variations": {},
+                'clarificationsCloseAtUTC': '2000-01-01T00:00:00.000000Z',
+                'clarificationsPublishAtUTC': '2000-01-02T00:00:00.000000Z',
+                'applicationsCloseAtUTC': '2000-01-03T00:00:00.000000Z',
+                'intentionToAwardAtUTC': '2000-01-04T00:00:00.000000Z',
+                'frameworkLiveAtUTC': '2000-01-05T00:00:00.000000Z',
+            }
+        }
 
-def test_lot():
-    assert api_stubs.lot(slug="foo") == {
-        "id": 1,
-        "slug": "foo",
-        "name": "Foo",
-        "allowsBrief": False,
-        "oneServiceLimit": False,
-    }
+    def test_custom_dates(self):
+        assert api_stubs.framework(clarifications_close_at=dt(2010, 1, 1),
+                                   clarifications_publish_at=dt(2010, 2, 2),
+                                   applications_close_at=dt(2010, 3, 3),
+                                   intention_to_award_at=dt(2010, 4, 4),
+                                   framework_live_at=dt(2010, 5, 5)) == {
+            "frameworks": {
+                "id": 1,
+                "name": "G-Cloud 7",
+                "slug": "g-cloud-7",
+                "framework": "g-cloud",
+                "status": "open",
+                "clarificationQuestionsOpen": True,
+                "lots": [],
+                "allowDeclarationReuse": True,
+                "frameworkAgreementDetails": api_stubs.framework_agreement_details(),
+                "countersignerName": None,
+                "frameworkAgreementVersion": "RM1557x",
+                "variations": {},
+                'clarificationsCloseAtUTC': '2010-01-01T00:00:00.000000Z',
+                'clarificationsPublishAtUTC': '2010-02-02T00:00:00.000000Z',
+                'applicationsCloseAtUTC': '2010-03-03T00:00:00.000000Z',
+                'intentionToAwardAtUTC': '2010-04-04T00:00:00.000000Z',
+                'frameworkLiveAtUTC': '2010-05-05T00:00:00.000000Z',
+            }
+        }
 
 
 def test_brief():

--- a/tests/test_api_stubs.py
+++ b/tests/test_api_stubs.py
@@ -1,0 +1,437 @@
+from datetime import datetime as dt
+from dmutils import api_stubs
+
+
+def test_framework():
+    assert api_stubs.framework() == {
+        "frameworks": {
+            "clarificationQuestionsOpen": True,
+            "lots": [],
+            "name": "G-Cloud 7",
+            "slug": "g-cloud-7",
+            "framework": "g-cloud",
+            "status": "open",
+            'clarificationsCloseAtUTC': '2000-01-01T00:00:00.000000Z',
+            'clarificationsPublishAtUTC': '2000-01-02T00:00:00.000000Z',
+            'applicationsCloseAtUTC': '2000-01-03T00:00:00.000000Z',
+            'intentionToAwardAtUTC': '2000-01-04T00:00:00.000000Z',
+            'frameworkLiveAtUTC': '2000-01-05T00:00:00.000000Z',
+        }
+    }
+
+    assert api_stubs.framework(slug='digital-outcomes-and-specialists') == {
+        "frameworks": {
+            "clarificationQuestionsOpen": True,
+            "lots": [],
+            "name": "Digital Outcomes and Specialists",
+            "slug": "digital-outcomes-and-specialists",
+            "framework": "digital-outcomes-and-specialists",
+            "status": "open",
+            'clarificationsCloseAtUTC': '2000-01-01T00:00:00.000000Z',
+            'clarificationsPublishAtUTC': '2000-01-02T00:00:00.000000Z',
+            'applicationsCloseAtUTC': '2000-01-03T00:00:00.000000Z',
+            'intentionToAwardAtUTC': '2000-01-04T00:00:00.000000Z',
+            'frameworkLiveAtUTC': '2000-01-05T00:00:00.000000Z',
+        }
+    }
+
+    assert api_stubs.framework(status='live', clarification_questions_open=False,
+                               name='My overriden name', slug='my-fake-framework') == {
+        "frameworks": {
+            "clarificationQuestionsOpen": False,
+            "lots": [],
+            "name": "My overriden name",
+            "slug": "my-fake-framework",
+            "framework": "my-fake-framework",
+            "status": "live",
+            'clarificationsCloseAtUTC': '2000-01-01T00:00:00.000000Z',
+            'clarificationsPublishAtUTC': '2000-01-02T00:00:00.000000Z',
+            'applicationsCloseAtUTC': '2000-01-03T00:00:00.000000Z',
+            'intentionToAwardAtUTC': '2000-01-04T00:00:00.000000Z',
+            'frameworkLiveAtUTC': '2000-01-05T00:00:00.000000Z',
+        }
+    }
+
+    assert api_stubs.framework(lots=['cloud-hosting', 'cloud-support']) == {
+        "frameworks": {
+            "clarificationQuestionsOpen": True,
+            "lots": ['cloud-hosting', 'cloud-support'],
+            "name": "G-Cloud 7",
+            "slug": "g-cloud-7",
+            "framework": "g-cloud",
+            "status": "open",
+            'clarificationsCloseAtUTC': '2000-01-01T00:00:00.000000Z',
+            'clarificationsPublishAtUTC': '2000-01-02T00:00:00.000000Z',
+            'applicationsCloseAtUTC': '2000-01-03T00:00:00.000000Z',
+            'intentionToAwardAtUTC': '2000-01-04T00:00:00.000000Z',
+            'frameworkLiveAtUTC': '2000-01-05T00:00:00.000000Z',
+        }
+    }
+
+    assert api_stubs.framework(clarifications_close_at=dt(2010, 1, 1),
+                               clarifications_publish_at=dt(2010, 2, 2),
+                               applications_close_at=dt(2010, 3, 3),
+                               intention_to_award_at=dt(2010, 4, 4),
+                               framework_live_at=dt(2010, 5, 5)) == {
+        "frameworks": {
+            "clarificationQuestionsOpen": True,
+            "lots": [],
+            "name": "G-Cloud 7",
+            "slug": "g-cloud-7",
+            "framework": "g-cloud",
+            "status": "open",
+            'clarificationsCloseAtUTC': '2010-01-01T00:00:00.000000Z',
+            'clarificationsPublishAtUTC': '2010-02-02T00:00:00.000000Z',
+            'applicationsCloseAtUTC': '2010-03-03T00:00:00.000000Z',
+            'intentionToAwardAtUTC': '2010-04-04T00:00:00.000000Z',
+            'frameworkLiveAtUTC': '2010-05-05T00:00:00.000000Z',
+        }
+    }
+
+
+def test_framework_name_changes_with_slug():
+    assert api_stubs.framework(slug='digital-outcomes-and-specialists')["frameworks"]["name"] == \
+        "Digital Outcomes and Specialists"
+    assert api_stubs.framework(slug="my-framework")["frameworks"]["name"] == "My Framework"
+
+
+def test_lot_name_default_is_made_from_slug():
+    assert api_stubs.lot(slug="my-lot")["name"] == "My Lot"
+
+
+def test_lot():
+    assert api_stubs.lot(slug="foo") == {
+        "id": 1,
+        "slug": "foo",
+        "name": "Foo",
+        "allowsBrief": False,
+        "oneServiceLimit": False,
+    }
+
+
+def test_brief():
+    assert api_stubs.brief() \
+        == {
+        "briefs": {
+            "id": 1234,
+            "title": "I need a thing to do a thing",
+            "frameworkSlug": "digital-outcomes-and-specialists",
+            "frameworkName": "Digital Outcomes and Specialists",
+            "frameworkFramework": "digital-outcomes-and-specialists",
+            "lotSlug": "digital-specialists",
+            "status": "draft",
+            "users": [{"active": True,
+                       "role": "buyer",
+                       "emailAddress": "buyer@email.com",
+                       "id": 123,
+                       "name": "Buyer User"}],
+            "createdAt": "2016-03-29T10:11:12.000000Z",
+            "updatedAt": "2016-03-29T10:11:13.000000Z",
+            "clarificationQuestions": [],
+        }
+    }
+
+    assert api_stubs.brief(
+        status='live',
+        framework_slug='a-framework-slug',
+        lot_slug='a-lot-slug', user_id=234,
+        framework_name='A Framework Name',
+        framework_framework='a framework framework') \
+        == {
+        "briefs": {
+            "id": 1234,
+            "title": "I need a thing to do a thing",
+            "frameworkSlug": "a-framework-slug",
+            "frameworkName": "A Framework Name",
+            "frameworkFramework": "a framework framework",
+            "lotSlug": "a-lot-slug",
+            "status": "live",
+            "users": [{"active": True,
+                       "role": "buyer",
+                       "emailAddress": "buyer@email.com",
+                       "id": 234,
+                       "name": "Buyer User"}],
+            "createdAt": "2016-03-29T10:11:12.000000Z",
+            "updatedAt": "2016-03-29T10:11:13.000000Z",
+            "publishedAt": "2016-03-29T10:11:14.000000Z",
+            "applicationsClosedAt": "2016-04-07T00:00:00.000000Z",
+            "clarificationQuestionsClosedAt": "2016-04-02T00:00:00.000000Z",
+            "clarificationQuestionsAreClosed": False,
+            "clarificationQuestions": [],
+        }
+    }
+
+    assert api_stubs.brief(clarification_questions=[{"question": "Why?", "answer": "Because"}]) \
+        == {
+        "briefs": {
+            "id": 1234,
+            "title": "I need a thing to do a thing",
+            "frameworkSlug": "digital-outcomes-and-specialists",
+            "frameworkName": "Digital Outcomes and Specialists",
+            "frameworkFramework": "digital-outcomes-and-specialists",
+            "lotSlug": "digital-specialists",
+            "status": "draft",
+            "users": [{"active": True,
+                       "role": "buyer",
+                       "emailAddress": "buyer@email.com",
+                       "id": 123,
+                       "name": "Buyer User"}],
+            "createdAt": "2016-03-29T10:11:12.000000Z",
+            "updatedAt": "2016-03-29T10:11:13.000000Z",
+            "clarificationQuestions": [{
+                "question": "Why?",
+                "answer": "Because"
+            }],
+        }
+    }
+
+    assert api_stubs.brief(status='live', clarification_questions_closed=True) \
+        == {
+        "briefs": {
+            "id": 1234,
+            "title": "I need a thing to do a thing",
+            "frameworkSlug": "digital-outcomes-and-specialists",
+            "frameworkName": "Digital Outcomes and Specialists",
+            "frameworkFramework": "digital-outcomes-and-specialists",
+            "lotSlug": "digital-specialists",
+            "status": "live",
+            "users": [{"active": True,
+                       "role": "buyer",
+                       "emailAddress": "buyer@email.com",
+                       "id": 123,
+                       "name": "Buyer User"}],
+            "createdAt": "2016-03-29T10:11:12.000000Z",
+            "updatedAt": "2016-03-29T10:11:13.000000Z",
+            "publishedAt": "2016-03-29T10:11:14.000000Z",
+            "applicationsClosedAt": "2016-04-07T00:00:00.000000Z",
+            "clarificationQuestionsClosedAt": "2016-04-02T00:00:00.000000Z",
+            "clarificationQuestionsAreClosed": True,
+            "clarificationQuestions": [],
+        }
+    }
+
+    assert api_stubs.brief(
+        status='closed',
+        framework_slug='a-framework-slug',
+        lot_slug='a-lot-slug', user_id=234,
+        framework_name='A Framework Name') \
+        == {
+        "briefs": {
+            "id": 1234,
+            "title": "I need a thing to do a thing",
+            "frameworkSlug": "a-framework-slug",
+            "frameworkName": "A Framework Name",
+            "frameworkFramework": "digital-outcomes-and-specialists",
+            "lotSlug": "a-lot-slug",
+            "status": "closed",
+            "users": [{"active": True,
+                       "role": "buyer",
+                       "emailAddress": "buyer@email.com",
+                       "id": 234,
+                       "name": "Buyer User"}],
+            "createdAt": "2016-03-29T10:11:12.000000Z",
+            "updatedAt": "2016-03-29T10:11:13.000000Z",
+            "publishedAt": "2016-03-29T10:11:14.000000Z",
+            "applicationsClosedAt": "2016-04-07T00:00:00.000000Z",
+            "clarificationQuestionsClosedAt": "2016-04-02T00:00:00.000000Z",
+            "clarificationQuestionsAreClosed": False,
+            "clarificationQuestions": [],
+        }
+    }
+
+
+def test_supplier():
+    assert api_stubs.supplier() == {
+        'suppliers': {
+            'companyDetailsConfirmed': True,
+            'companiesHouseNumber': '12345678',
+            'contactInformation': [{
+                'address1': '123 Fake Road',
+                'city': 'Madeupolis',
+                'contactName': 'Mr E Man',
+                'email': 'mre@company.com',
+                'id': 4321,
+                'links': {
+                    'self': 'http://localhost:5000/suppliers/1234/contact-information/4321'
+                },
+                'phoneNumber': '01234123123',
+                'postcode': 'A11 1AA',
+                "website": "https://www.mre.company"
+            }],
+            'description': "I'm a supplier.",
+            'dunsNumber': '123456789',
+            'id': 1234,
+            'links': {
+                'self': 'http://localhost:5000/suppliers/1234'
+            },
+            'name': 'My Little Company',
+            'organisationSize': 'micro',
+            'registeredName': 'My Little Registered Company',
+            'registrationCountry': 'country:GB',
+            'service_counts': {
+                "G-Cloud 9": 109,
+                "G-Cloud 8": 108,
+                "G-Cloud 7": 107,
+                "G-Cloud 6": 106,
+                "G-Cloud 5": 105,
+            },
+            'tradingStatus': 'limited company',
+            'vatNumber': '111222333'
+        }
+    }
+
+    assert api_stubs.supplier(id=9999) == {
+        'suppliers': {
+            'companyDetailsConfirmed': True,
+            'companiesHouseNumber': '12345678',
+            'contactInformation': [{
+                'address1': '123 Fake Road',
+                'city': 'Madeupolis',
+                'contactName': 'Mr E Man',
+                'email': 'mre@company.com',
+                'id': 4321,
+                'links': {
+                    'self': 'http://localhost:5000/suppliers/9999/contact-information/4321'
+                },
+                'phoneNumber': '01234123123',
+                'postcode': 'A11 1AA',
+                "website": "https://www.mre.company"
+            }],
+            'description': "I'm a supplier.",
+            'dunsNumber': '123456789',
+            'id': 9999,
+            'links': {
+                'self': 'http://localhost:5000/suppliers/9999'
+            },
+            'name': 'My Little Company',
+            'organisationSize': 'micro',
+            'registeredName': 'My Little Registered Company',
+            'registrationCountry': 'country:GB',
+            'service_counts': {
+                "G-Cloud 9": 109,
+                "G-Cloud 8": 108,
+                "G-Cloud 7": 107,
+                "G-Cloud 6": 106,
+                "G-Cloud 5": 105,
+            },
+            'tradingStatus': 'limited company',
+            'vatNumber': '111222333'
+        }
+    }
+
+    assert api_stubs.supplier(contact_id=9999) == {
+        'suppliers': {
+            'companyDetailsConfirmed': True,
+            'companiesHouseNumber': '12345678',
+            'contactInformation': [{
+                'address1': '123 Fake Road',
+                'city': 'Madeupolis',
+                'contactName': 'Mr E Man',
+                'email': 'mre@company.com',
+                'id': 9999,
+                'links': {
+                    'self': 'http://localhost:5000/suppliers/1234/contact-information/9999'
+                },
+                'phoneNumber': '01234123123',
+                'postcode': 'A11 1AA',
+                "website": "https://www.mre.company"
+            }],
+            'description': "I'm a supplier.",
+            'dunsNumber': '123456789',
+            'id': 1234,
+            'links': {
+                'self': 'http://localhost:5000/suppliers/1234'
+            },
+            'name': 'My Little Company',
+            'organisationSize': 'micro',
+            'registeredName': 'My Little Registered Company',
+            'registrationCountry': 'country:GB',
+            'service_counts': {
+                "G-Cloud 9": 109,
+                "G-Cloud 8": 108,
+                "G-Cloud 7": 107,
+                "G-Cloud 6": 106,
+                "G-Cloud 5": 105,
+            },
+            'tradingStatus': 'limited company',
+            'vatNumber': '111222333'
+        }
+    }
+
+    assert api_stubs.supplier(other_company_registration_number=123456) == {
+        'suppliers': {
+            'companyDetailsConfirmed': True,
+            'contactInformation': [{
+                'address1': '123 Fake Road',
+                'city': 'Madeupolis',
+                'contactName': 'Mr E Man',
+                'email': 'mre@company.com',
+                'id': 4321,
+                'links': {
+                    'self': 'http://localhost:5000/suppliers/1234/contact-information/4321'
+                },
+                'phoneNumber': '01234123123',
+                'postcode': 'A11 1AA',
+                "website": "https://www.mre.company"
+            }],
+            'description': "I'm a supplier.",
+            'dunsNumber': '123456789',
+            'id': 1234,
+            'links': {
+                'self': 'http://localhost:5000/suppliers/1234'
+            },
+            'name': 'My Little Company',
+            'otherCompanyRegistrationNumber': 123456,
+            'organisationSize': 'micro',
+            'registeredName': 'My Little Registered Company',
+            'registrationCountry': 'country:NZ',
+            'service_counts': {
+                "G-Cloud 9": 109,
+                "G-Cloud 8": 108,
+                "G-Cloud 7": 107,
+                "G-Cloud 6": 106,
+                "G-Cloud 5": 105,
+            },
+            'tradingStatus': 'limited company',
+            'vatNumber': '111222333'
+        }
+    }
+
+    assert api_stubs.supplier(company_details_confirmed=False) == {
+        'suppliers': {
+            'companyDetailsConfirmed': False,
+            'companiesHouseNumber': '12345678',
+            'contactInformation': [{
+                'address1': '123 Fake Road',
+                'city': 'Madeupolis',
+                'contactName': 'Mr E Man',
+                'email': 'mre@company.com',
+                'id': 4321,
+                'links': {
+                    'self': 'http://localhost:5000/suppliers/1234/contact-information/4321'
+                },
+                'phoneNumber': '01234123123',
+                'postcode': 'A11 1AA',
+                "website": "https://www.mre.company"
+            }],
+            'description': "I'm a supplier.",
+            'dunsNumber': '123456789',
+            'id': 1234,
+            'links': {
+                'self': 'http://localhost:5000/suppliers/1234'
+            },
+            'name': 'My Little Company',
+            'organisationSize': 'micro',
+            'registeredName': 'My Little Registered Company',
+            'registrationCountry': 'country:GB',
+            'service_counts': {
+                "G-Cloud 9": 109,
+                "G-Cloud 8": 108,
+                "G-Cloud 7": 107,
+                "G-Cloud 6": 106,
+                "G-Cloud 5": 105,
+            },
+            'tradingStatus': 'limited company',
+            'vatNumber': '111222333'
+        }
+    }


### PR DESCRIPTION
 ## Summary
API stubs used to be defined in the apiclient, however they now require
some formatting that's held in this repository. Rather than introduce an
extra dependency to the apiclient, which would likely introduce
dependency conflicts when both libs are required by a frontend app,
we'll move the stubs to utils.

Bump to 36.6.0.

 ## Ticket
https://trello.com/c/BVPgZRZc/65-store-datetimes-relating-to-the-framework-lifecycle-on-the-api