### PR TITLE
Handle MailChimp responses with naughty json

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '36.6.0'
+__version__ = '36.7.0'


### PR DESCRIPTION
If we get a RequestException from the MailChimp client when calling
`subscribe_new_email_to_list`, we inspect the response which is
integrated into the error. We do this is a special case we handle
depending on the reason for the failure. This includes looking at the
json data. If the response doesn't have any data (which we've seen), or
the data is malformed, we get a JSONDecodeError. We should handle this
properly as it's already thrown one of our scripts off.