### PR TITLE
Bump flask-script to 2.0.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     include_package_data=True,
     install_requires=[
          'Flask-FeatureFlags==0.6',
-         'Flask-Script==2.0.5',
+         'Flask-Script==2.0.6',
          'Flask-WTF==0.14.2',
          'Flask==0.10.1',
          'Flask-Login>=0.2.11',


### PR DESCRIPTION
This is the latest available version of `flask-script`. It is now deprecated and we should consider using the flask command line interface instead: http://flask.pocoo.org/docs/1.0/cli/

This is primarily so that we can remove the incompatibility warnings in the apps that use a different version of `flask-script` in their dependencies.