### PR TITLE
Password reset token timing

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '36.9.0'
+__version__ = '36.10.0'

--- a/dmutils/email/tokens.py
+++ b/dmutils/email/tokens.py
@@ -119,6 +119,10 @@ def decode_password_reset_token(token, data_api_client):
         current_app.logger.info("Error changing password: Token generated earlier than password was last changed.")
         return {'error': 'token_invalid'}
 
+    if token_timestamp > datetime.utcnow():
+        current_app.logger.info("Error changing password: cannot use token generated in the future.")
+        return {'error': 'token_invalid'}
+
     return {
         'user': user['users']['id'],
         'email': user['users']['emailAddress']

--- a/dmutils/email/tokens.py
+++ b/dmutils/email/tokens.py
@@ -2,7 +2,7 @@ import base64
 import json
 import struct
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from cryptography import fernet
 from flask import current_app
@@ -113,8 +113,9 @@ def decode_password_reset_token(token, data_api_client):
         DATETIME_FORMAT
     )
 
-    # If the token was created before the last password change
-    if token_timestamp < user_last_changed_password_at:
+    # Check if the token was created before the last password change
+    # (allow 1 second leeway for reset tokens generated for the 'Your password was changed' email link)
+    if token_timestamp + timedelta(seconds=1) < user_last_changed_password_at:
         current_app.logger.info("Error changing password: Token generated earlier than password was last changed.")
         return {'error': 'token_invalid'}
 

--- a/tests/email/test_tokens.py
+++ b/tests/email/test_tokens.py
@@ -126,6 +126,7 @@ class TestDecodePasswordReset:
 
     @pytest.mark.parametrize(
         'decode_time, expected_result', [
+            ('2016-01-02 03:04:04', 'error'),  # Cannot decode before the token has been generated
             ('2016-01-02 03:04:05', 'ok'),
             ('2016-01-03 03:04:05', 'ok'),
             ('2016-01-03 03:04:06', 'error'),
@@ -138,7 +139,6 @@ class TestDecodePasswordReset:
             with freeze_time('2016-01-02 03:04:05'):
                 token = generate_token(password_reset_token, "Key", 'PassSalt')
 
-        with email_app.app_context():
             with freeze_time(decode_time):
                 if expected_result == 'ok':
                     assert decode_password_reset_token(token, data_api_client) == password_reset_token

--- a/tests/email/test_tokens.py
+++ b/tests/email/test_tokens.py
@@ -41,200 +41,195 @@ def password_reset_token():
     return {'user': 123, 'email': 'test@example.com'}
 
 
-def test_can_generate_and_decode_token():
+class TestDecodeToken:
 
-    with freeze_time('2016-01-01T12:00:00Z'):
-        encrypted_token = generate_token(
-            {'key1': 'value1', 'key2': 'value2'},
+    def test_can_generate_and_decode_token(self):
+
+        with freeze_time('2016-01-01T12:00:00Z'):
+            encrypted_token = generate_token(
+                {'key1': 'value1', 'key2': 'value2'},
+                secret_key='1234567890',
+                namespace='0987654321'
+            )
+            token, timestamp = decode_token(encrypted_token, '1234567890', '0987654321')
+        assert token == {'key1': 'value1', 'key2': 'value2'}
+        assert timestamp == datetime(2016, 1, 1, 12, 0, 0)
+
+    def test_cant_decode_token_with_wrong_salt(self):
+        token = generate_token({
+            'key1': 'value1',
+            'key2': 'value2'},
             secret_key='1234567890',
-            namespace='0987654321'
-        )
-        token, timestamp = decode_token(encrypted_token, '1234567890', '0987654321')
-    assert token == {'key1': 'value1', 'key2': 'value2'}
-    assert timestamp == datetime(2016, 1, 1, 12, 0, 0)
+            namespace='1234567890')
+
+        with pytest.raises(fernet.InvalidToken):
+            decode_token(token, '1234567890', 'failed')
+
+    def test_cant_decode_token_with_wrong_key(self):
+        token = generate_token({
+            'key1': 'value1',
+            'key2': 'value2'},
+            secret_key='1234567890',
+            namespace='1234567890')
+
+        with pytest.raises(fernet.InvalidToken):
+            decode_token(token, 'failed', '1234567890')
+
+    @pytest.mark.parametrize('test, expected', [
+        (u'test@example.com', b'lz3-Rj7IV4X1-Vr1ujkG7tstkxwk5pgkqJ6mXbpOgTs='),
+        (u'☃@example.com', b'jGgXle8WEBTTIFhP25dF8Ck-FxQSCZ_N0iWYBWve4Ps='),
+    ])
+    def test_hash_string(self, test, expected):
+        expected = expected.decode('utf-8')
+        result = hash_string(test)
+        assert result == expected
+
+    def test_generate_token_does_not_contain_plaintext_email(self, email_app, data_api_client, password_reset_token):
+        with email_app.app_context(), freeze_time('2016-01-01T12:00:00.30Z'):
+            token = generate_token(password_reset_token, 'Secret', 'PassSalt')
+
+        # a fernet string always starts with the version, which should be 128
+        assert token[:4] == 'gAAA'
+
+        token = token.encode('utf-8')
+
+        # Personally identifiable information should not be readable without secret key
+        assert b'test@example.com' not in base64.urlsafe_b64decode(token)
+
+        # a fernet string contains the timestamp at which it was encrypted
+        assert _parse_fernet_timestamp(token) == datetime(2016, 1, 1, 12)
+
+    def test_decrypt_token_ok_for_known_good_token(self):
+        # encrypted on 2016-01-01T12:00:00.30Z with secret 'Secret' and namespace 'PassSalt'
+        token = 'gAAAAABWhmpA1ecLpuzdKiIcJ_drdA1Vf4ip07TH3UqZ_fA-pD9yYlGMqSTi-Mpbd58Z-wlZfa5sXGE6FVHPilTpsZWEiMDRLdCBlccvBPbY9IOO5F3uabjkrk87mrlPxaSbMAza5Nku'  # noqa
+
+        with freeze_time('2016-01-01T12:00:00.30Z'):
+            data = decode_token(token, 'Secret', 'PassSalt')
+
+        assert data == ({'email': 'test@example.com', 'user': 123}, datetime(2016, 1, 1, 12, 0, 0))
 
 
-def test_cant_decode_token_with_wrong_salt():
-    token = generate_token({
-        'key1': 'value1',
-        'key2': 'value2'},
-        secret_key='1234567890',
-        namespace='1234567890')
+class TestDecodePasswordReset:
 
-    with pytest.raises(fernet.InvalidToken):
-        decode_token(token, '1234567890', 'failed')
-
-
-def test_cant_decode_token_with_wrong_key():
-    token = generate_token({
-        'key1': 'value1',
-        'key2': 'value2'},
-        secret_key='1234567890',
-        namespace='1234567890')
-
-    with pytest.raises(fernet.InvalidToken):
-        decode_token(token, 'failed', '1234567890')
-
-
-@pytest.mark.parametrize('test, expected', [
-    (u'test@example.com', b'lz3-Rj7IV4X1-Vr1ujkG7tstkxwk5pgkqJ6mXbpOgTs='),
-    (u'☃@example.com', b'jGgXle8WEBTTIFhP25dF8Ck-FxQSCZ_N0iWYBWve4Ps='),
-])
-def test_hash_string(test, expected):
-    expected = expected.decode('utf-8')
-    result = hash_string(test)
-    assert result == expected
-
-
-def test_generate_token_does_not_contain_plaintext_email(email_app, data_api_client, password_reset_token):
-    with email_app.app_context(), freeze_time('2016-01-01T12:00:00.30Z'):
-        token = generate_token(password_reset_token, 'Secret', 'PassSalt')
-
-    # a fernet string always starts with the version, which should be 128
-    assert token[:4] == 'gAAA'
-
-    token = token.encode('utf-8')
-
-    # Personally identifiable information should not be readable without secret key
-    assert b'test@example.com' not in base64.urlsafe_b64decode(token)
-
-    # a fernet string contains the timestamp at which it was encrypted
-    assert _parse_fernet_timestamp(token) == datetime(2016, 1, 1, 12)
-
-
-def test_decrypt_token_ok_for_known_good_token():
-    # encrypted on 2016-01-01T12:00:00.30Z with secret 'Secret' and namespace 'PassSalt'
-    token = 'gAAAAABWhmpA1ecLpuzdKiIcJ_drdA1Vf4ip07TH3UqZ_fA-pD9yYlGMqSTi-Mpbd58Z-wlZfa5sXGE6FVHPilTpsZWEiMDRLdCBlccvBPbY9IOO5F3uabjkrk87mrlPxaSbMAza5Nku'  # noqa
-
-    with freeze_time('2016-01-01T12:00:00.30Z'):
-        data = decode_token(token, 'Secret', 'PassSalt')
-
-    assert data == ({'email': 'test@example.com', 'user': 123}, datetime(2016, 1, 1, 12, 0, 0))
-
-
-def test_decode_password_reset_token_ok_for_good_token(email_app, data_api_client, password_reset_token):
-    with email_app.app_context():
-        token = generate_token(password_reset_token, "Key", 'PassSalt')
-        assert decode_password_reset_token(token, data_api_client) == password_reset_token
-    data_api_client.get_user.assert_called_once_with(123)
-
-
-def test_decode_password_reset_token_does_not_work_if_bad_token(email_app, data_api_client, password_reset_token):
-    token = generate_token(password_reset_token, "Key", 'PassSalt')[1:]
-
-    with email_app.app_context():
-        assert decode_password_reset_token(token, data_api_client) == {'error': 'token_invalid'}
-
-
-@pytest.mark.parametrize(
-    'decode_time, expected_result', [
-        ('2016-01-02 03:04:05', 'ok'),
-        ('2016-01-03 03:04:05', 'ok'),
-        ('2016-01-03 03:04:06', 'error'),
-    ]
-)
-def test_decode_password_reset_token_is_only_valid_within_a_day_of_token_creation(
-    decode_time, expected_result, email_app, data_api_client, password_reset_token
-):
-    with email_app.app_context():
-        with freeze_time('2016-01-02 03:04:05'):
+    def test_decode_password_reset_token_ok_for_good_token(self, email_app, data_api_client, password_reset_token):
+        with email_app.app_context():
             token = generate_token(password_reset_token, "Key", 'PassSalt')
+            assert decode_password_reset_token(token, data_api_client) == password_reset_token
+        data_api_client.get_user.assert_called_once_with(123)
 
-    with email_app.app_context():
-        with freeze_time(decode_time):
-            if expected_result == 'ok':
-                assert decode_password_reset_token(token, data_api_client) == password_reset_token
-            else:
-                assert decode_password_reset_token(token, data_api_client) == {'error': 'token_invalid'}
+    def test_decode_password_reset_token_does_not_work_if_bad_token(
+            self, email_app, data_api_client, password_reset_token):
+        token = generate_token(password_reset_token, "Key", 'PassSalt')[1:]
 
-
-def test_decode_password_reset_token_does_not_work_if_password_changed_later_than_token(
-    email_app, data_api_client, password_reset_token
-):
-    with freeze_time('2016-01-01T11:00:00.30Z'):
-        # Token was generated an hour earlier than password was changed
-        token = generate_token(password_reset_token, "Key", 'PassSalt')
-
-    with freeze_time('2016-01-01T13:00:00.30Z'):
-        # Token is two hours old; password was changed an hour ago
         with email_app.app_context():
             assert decode_password_reset_token(token, data_api_client) == {'error': 'token_invalid'}
 
-
-def test_decode_invitation_token_decodes_ok(email_app):
-    with email_app.app_context():
-        # works with arbitrary fields
-        data = {
-            'email_address': 'test-user@email.com',
-            'supplier_id': 1234,
-            'foo': 'bar',
-            'role': 'supplier'
-        }
-        token = generate_token(data, 'Key', 'Salt')
-        assert decode_invitation_token(token) == data
-
-
-def test_decode_invitation_token_returns_an_error_if_token_invalid(email_app):
-    with email_app.app_context():
-        data = {
-            'email_address': 'test-user@email.com',
-            'supplier_id': 1234,
-            'supplier_name': 'A. Supplier',
-            'role': 'supplier'
-        }
-        token = generate_token(data, email_app.config['SHARED_EMAIL_KEY'], email_app.config['INVITE_EMAIL_SALT'])[1:]
-
-        assert decode_invitation_token(token) == {'error': 'token_invalid'}
-
-
-@pytest.mark.parametrize(
-    'decode_time, expected_result', [
-        ('2015-01-02 03:04:05', 'ok'),
-        ('2015-01-09 03:04:05', 'ok'),
-        ('2015-01-09 03:04:06', 'error'),
-    ]
-)
-def test_decode_invitation_token_returns_an_error_and_role_if_token_expired(decode_time, expected_result, email_app):
-    with freeze_time('2015-01-02 03:04:05'):
-        data = {
-            'email_address': 'test-user@email.com',
-            'supplier_id': 1234,
-            'supplier_name': 'A. Supplier',
-            'role': 'supplier'
-        }
-        token = generate_token(data, email_app.config['SHARED_EMAIL_KEY'], email_app.config['INVITE_EMAIL_SALT'])
-
-    with freeze_time(decode_time):
+    @pytest.mark.parametrize(
+        'decode_time, expected_result', [
+            ('2016-01-02 03:04:05', 'ok'),
+            ('2016-01-03 03:04:05', 'ok'),
+            ('2016-01-03 03:04:06', 'error'),
+        ]
+    )
+    def test_decode_password_reset_token_is_only_valid_within_a_day_of_token_creation(
+        self, decode_time, expected_result, email_app, data_api_client, password_reset_token
+    ):
         with email_app.app_context():
-            if expected_result == 'ok':
-                assert decode_invitation_token(token) == data
-            else:
-                assert decode_invitation_token(token) == {'error': 'token_expired', 'role': 'supplier'}
+            with freeze_time('2016-01-02 03:04:05'):
+                token = generate_token(password_reset_token, "Key", 'PassSalt')
+
+        with email_app.app_context():
+            with freeze_time(decode_time):
+                if expected_result == 'ok':
+                    assert decode_password_reset_token(token, data_api_client) == password_reset_token
+                else:
+                    assert decode_password_reset_token(token, data_api_client) == {'error': 'token_invalid'}
+
+    def test_decode_password_reset_token_does_not_work_if_password_changed_later_than_token(
+        self, email_app, data_api_client, password_reset_token
+    ):
+        with freeze_time('2016-01-01T11:00:00.30Z'):
+            # Token was generated an hour earlier than password was changed
+            token = generate_token(password_reset_token, "Key", 'PassSalt')
+
+        with freeze_time('2016-01-01T13:00:00.30Z'):
+            # Token is two hours old; password was changed an hour ago
+            with email_app.app_context():
+                assert decode_password_reset_token(token, data_api_client) == {'error': 'token_invalid'}
 
 
-def test_decode_invitation_token_adds_the_role_key_to_expired_old_style_buyer_tokens(email_app):
-    with freeze_time('2015-01-02 03:04:05'):
-        data = {'email_address': 'test-user@email.com'}
-        token = generate_token(data, 'Key', 'Salt')
+class TestDecodeInvitationToken:
 
-    with email_app.app_context():
-        assert decode_invitation_token(token) == {
-            'error': 'token_expired',
-            'role': 'buyer'
-        }
+    def test_decode_invitation_token_decodes_ok(self, email_app):
+        with email_app.app_context():
+            # works with arbitrary fields
+            data = {
+                'email_address': 'test-user@email.com',
+                'supplier_id': 1234,
+                'foo': 'bar',
+                'role': 'supplier'
+            }
+            token = generate_token(data, 'Key', 'Salt')
+            assert decode_invitation_token(token) == data
 
+    def test_decode_invitation_token_returns_an_error_if_token_invalid(self, email_app):
+        with email_app.app_context():
+            data = {
+                'email_address': 'test-user@email.com',
+                'supplier_id': 1234,
+                'supplier_name': 'A. Supplier',
+                'role': 'supplier'
+            }
+            token = generate_token(data, email_app.config['SHARED_EMAIL_KEY'], email_app.config['INVITE_EMAIL_SALT'])[1:]
 
-def test_decode_invitation_token_adds_the_role_key_to_expired_old_style_supplier_tokens(email_app):
-    with freeze_time('2015-01-02 03:04:05'):
-        data = {
-            'email_address': 'test-user@email.com',
-            'supplier_id': 1234,
-            'supplier_name': 'A. Supplier',
-        }
-        token = generate_token(data, 'Key', 'Salt')
+            assert decode_invitation_token(token) == {'error': 'token_invalid'}
 
-    with email_app.app_context():
-        assert decode_invitation_token(token) == {
-            'error': 'token_expired',
-            'role': 'supplier'
-        }
+    @pytest.mark.parametrize(
+        'decode_time, expected_result', [
+            ('2015-01-02 03:04:05', 'ok'),
+            ('2015-01-09 03:04:05', 'ok'),
+            ('2015-01-09 03:04:06', 'error'),
+        ]
+    )
+    def test_decode_invitation_token_returns_an_error_and_role_if_token_expired(self, decode_time, expected_result, email_app):
+        with freeze_time('2015-01-02 03:04:05'):
+            data = {
+                'email_address': 'test-user@email.com',
+                'supplier_id': 1234,
+                'supplier_name': 'A. Supplier',
+                'role': 'supplier'
+            }
+            token = generate_token(data, email_app.config['SHARED_EMAIL_KEY'], email_app.config['INVITE_EMAIL_SALT'])
+
+        with freeze_time(decode_time):
+            with email_app.app_context():
+                if expected_result == 'ok':
+                    assert decode_invitation_token(token) == data
+                else:
+                    assert decode_invitation_token(token) == {'error': 'token_expired', 'role': 'supplier'}
+
+    def test_decode_invitation_token_adds_the_role_key_to_expired_old_style_buyer_tokens(self, email_app):
+        with freeze_time('2015-01-02 03:04:05'):
+            data = {'email_address': 'test-user@email.com'}
+            token = generate_token(data, 'Key', 'Salt')
+
+        with email_app.app_context():
+            assert decode_invitation_token(token) == {
+                'error': 'token_expired',
+                'role': 'buyer'
+            }
+
+    def test_decode_invitation_token_adds_the_role_key_to_expired_old_style_supplier_tokens(self, email_app):
+        with freeze_time('2015-01-02 03:04:05'):
+            data = {
+                'email_address': 'test-user@email.com',
+                'supplier_id': 1234,
+                'supplier_name': 'A. Supplier',
+            }
+            token = generate_token(data, 'Key', 'Salt')
+
+        with email_app.app_context():
+            assert decode_invitation_token(token) == {
+                'error': 'token_expired',
+                'role': 'supplier'
+            }

--- a/tests/email/test_tokens.py
+++ b/tests/email/test_tokens.py
@@ -147,8 +147,7 @@ class TestDecodePasswordReset:
 
     @pytest.mark.parametrize(
         'generation_time, expected_result', [
-            ('2016-01-01 12:00:01', 'ok'),
-            ('2016-01-01 12:00:00', 'error'),  # TODO: allow 1 second leeway
+            ('2016-01-01 12:00:00', 'ok'),  # Allow 1 second leeway (following password change)
             ('2016-01-01 11:59:59', 'error')
         ]
     )


### PR DESCRIPTION
Trello: https://trello.com/c/TieWrBG5/44-password-reset-link-from-logged-in-session

When a user changes their password, a confirmation email is sent containing a reset link (alerting them in case the change was made by a malicious user). 

The token used in that link is created within a few milliseconds of the password change, however  `decode_password_reset_token` currently requires the most recent password change to be at least 1 second prior to that token's generation time. 

Therefore we need to relax the restriction by 1 second, to enable a valid email link to be generated immediately following a password change.

(I also tidied `test_tokens` into classes, as the module was getting confusing.)