### PR TITLE
Wrap any and all errors ocurring in mandrill code

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '36.10.0'
+__version__ = '36.10.1'

--- a/dmutils/email/dm_mandrill.py
+++ b/dmutils/email/dm_mandrill.py
@@ -3,7 +3,7 @@
 from flask import current_app
 from flask._compat import string_types
 
-from mandrill import Mandrill, Error
+from mandrill import Mandrill
 from dmutils.email.exceptions import EmailError
 from dmutils.email.helpers import hash_string
 
@@ -41,8 +41,10 @@ def send_email(to_email_addresses, email_body, api_key, subject, from_email, fro
         }
 
         result = mandrill_client.messages.send(message=message, async=True)
-    except Error as e:
-        # Mandrill errors are thrown as exceptions
+    except Exception as e:
+        # Anything that Mandrill throws will be rethrown in a manner consistent with out other email backends.
+        # Note that this isn't just `mandrill.Error` exceptions, because the mandrill client also sometimes throws
+        # things like JSONDecodeError (sad face).
         logger.error("Failed to send an email: {error}", extra={'error': e})
         raise EmailError(e)
     logger.info("Sent {tags} response: id={id}, email={email_hash}",

--- a/tests/email/test_dm_mandrill.py
+++ b/tests/email/test_dm_mandrill.py
@@ -3,7 +3,6 @@
 
 import mock
 import pytest
-from mandrill import Error
 
 from dmutils.config import init_app
 from dmutils.email.dm_mandrill import send_email
@@ -139,8 +138,8 @@ def test_calls_send_email_with_alternative_reply_to(email_app, mandrill):
 
 def test_should_throw_exception_if_mandrill_fails(email_app, mandrill):
     with email_app.app_context():
-
-        mandrill.messages.send.side_effect = Error('this is an error')
+        something_bad = Exception('this is an error')
+        mandrill.messages.send.side_effect = something_bad
 
         with pytest.raises(EmailError) as e:
             send_email(
@@ -154,3 +153,4 @@ def test_should_throw_exception_if_mandrill_fails(email_app, mandrill):
 
             )
         assert str(e.value) == 'this is an error'
+        assert e.value.__context__ == something_bad


### PR DESCRIPTION
We no longer restrict to just mandrill's own error class, as in fact that library can throw other exceptions, and we want to wrap all of them.

https://trello.com/c/s7rmFSjk/295-mandrill-email-crash-2018-05-10-1824