### PR TITLE
Log duration of calls to S3

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '36.10.1'
+__version__ = '36.11.0'


### PR DESCRIPTION
 ## Summary
We think we have some performance issues with calls to S3 on certain
views. This replaces the existing logs for these calls and inserts the
duration of the call so that we can start to investigate the issue more
thoroughly.

It also adds logs/durations to any calls out to S3 that were missing
them, with a more restrictive condition that the call must be 'slow' or
sampled.

This PR also defines a 'slow' request to an external provider as one
that takes 250ms or longer.

---

Open to conversation on where to draw the line for a 'slow' request, but this feels like a reasonable (if not generous) limit to set in the first instance.