### PR TITLE
Log duration of email calls

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '36.11.1'
+__version__ = '36.12.0'

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -7,6 +7,8 @@ from requests.exceptions import RequestException, HTTPError
 
 from mailchimp3 import MailChimp
 
+from dmutils.timing import logged_duration_for_external_request as log_external_request
+
 PAGINATION_SIZE = 1000
 
 
@@ -33,7 +35,8 @@ class DMMailChimpClient(object):
         def wrapper(*args, **kwargs):
             for i in range(1 + self.retries):
                 try:
-                    return method(*args, **kwargs)
+                    with log_external_request(service='Mailchimp'):
+                        return method(*args, **kwargs)
                 except HTTPError as e:
                     exception = e
                     if exception.response.status_code == 504:
@@ -45,12 +48,13 @@ class DMMailChimpClient(object):
 
     def create_campaign(self, campaign_data):
         try:
-            campaign = self._client.campaigns.create(campaign_data)
+            with log_external_request(service='Mailchimp'):
+                campaign = self._client.campaigns.create(campaign_data)
             return campaign['id']
         except RequestException as e:
             self.logger.error(
-                "Mailchimp failed to create campaign for '{0}'".format(
-                    campaign_data.get("settings").get("title")
+                "Mailchimp failed to create campaign for '{campaign_title}'".format(
+                    campaign_title=campaign_data.get("settings", {}).get("title")
                 ),
                 extra={"error": str(e)}
             )
@@ -58,7 +62,8 @@ class DMMailChimpClient(object):
 
     def set_campaign_content(self, campaign_id, content_data):
         try:
-            return self._client.campaigns.content.update(campaign_id, content_data)
+            with log_external_request(service='Mailchimp'):
+                return self._client.campaigns.content.update(campaign_id, content_data)
         except RequestException as e:
             self.logger.error(
                 "Mailchimp failed to set content for campaign id '{0}'".format(campaign_id),
@@ -68,7 +73,8 @@ class DMMailChimpClient(object):
 
     def send_campaign(self, campaign_id):
         try:
-            self._client.campaigns.actions.send(campaign_id)
+            with log_external_request(service='Mailchimp'):
+                self._client.campaigns.actions.send(campaign_id)
             return True
         except RequestException as e:
             self.logger.error(
@@ -81,14 +87,15 @@ class DMMailChimpClient(object):
         """ Will subscribe email address to list if they do not already exist in that list else do nothing"""
         hashed_email = self.get_email_hash(email_address)
         try:
-            return self._client.lists.members.create_or_update(
-                list_id,
-                hashed_email,
-                {
-                    "email_address": email_address,
-                    "status_if_new": "subscribed"
-                }
-            )
+            with log_external_request(service='Mailchimp'):
+                return self._client.lists.members.create_or_update(
+                    list_id,
+                    hashed_email,
+                    {
+                        "email_address": email_address,
+                        "status_if_new": "subscribed"
+                    }
+                )
         except RequestException as e:
             # As defined in mailchimp API documentation, this particular error message may arise if a user has requested
             # mailchimp to never add them to mailchimp lists. In this case, we resort to allowing a failed API call (but
@@ -99,10 +106,8 @@ class DMMailChimpClient(object):
                     "looks fake or invalid, please enter a real email address." in e.response.json().get("detail", "")
                 ):
                     self.logger.error(
-                        "Expected error: Mailchimp failed to add user ({}) to list ({}). API error: The email address looks fake or invalid, please enter a real email address.".format(  # noqa
-                            hashed_email,
-                            list_id
-                        ),
+                        f"Expected error: Mailchimp failed to add user ({hashed_email}) to list ({list_id}). "
+                        "API error: The email address looks fake or invalid, please enter a real email address.",
                         extra={"error": str(e)}
                     )
                     return True
@@ -120,8 +125,9 @@ class DMMailChimpClient(object):
     def subscribe_new_emails_to_list(self, list_id, email_addresses):
         success = True
         for email_address in email_addresses:
-            if not self.subscribe_new_email_to_list(list_id, email_address):
-                success = False
+            with log_external_request(service='Mailchimp'):
+                if not self.subscribe_new_email_to_list(list_id, email_address):
+                    success = False
         return success
 
     def get_email_addresses_from_list(self, list_id, pagination_size=100):

--- a/dmutils/email/dm_notify.py
+++ b/dmutils/email/dm_notify.py
@@ -46,8 +46,7 @@ class DMNotifyClient:
 
     def get_delivered_notifications(self, **kwargs):
         """Wrapper for notifications_python_client.notifications.NotificationsAPIClient::get_all_notifications"""
-        with log_external_request(service='Notify'):
-            return self.get_all_notifications(status='delivered', **kwargs)
+        return self.get_all_notifications(status='delivered', **kwargs)
 
     def get_delivered_references(self, invalidate_cache=False):
         """Get the references of all notifications that have already been delivered."""

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,4 +12,4 @@ pytest-cov==2.5.1
 python-coveralls==2.5.0
 testfixtures==6.0.2
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@1.2.0#egg=digitalmarketplace-test-utils==1.2.0
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@1.4.0#egg=digitalmarketplace-test-utils==1.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,5 +10,6 @@ moto==0.4.31
 pytest==3.2.3
 pytest-cov==2.5.1
 python-coveralls==2.5.0
+testfixtures==6.0.2
 
 git+https://github.com/alphagov/digitalmarketplace-test-utils.git@1.2.0#egg=digitalmarketplace-test-utils==1.2.0

--- a/tests/email/test_dm_mandrill.py
+++ b/tests/email/test_dm_mandrill.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tests for the Digital Marketplace Mandrill integration."""
 
+import logging
 import mock
 import pytest
 import json
@@ -8,6 +9,7 @@ import json
 from dmutils.config import init_app
 from dmutils.email.dm_mandrill import send_email
 from dmutils.email.exceptions import EmailError
+from helpers import assert_external_service_log_entry, PatchExternalServiceLogConditionMixin
 
 
 @pytest.yield_fixture
@@ -27,116 +29,6 @@ def email_app(app):
     yield app
 
 
-def test_calls_send_email_with_correct_params(email_app, mandrill):
-    with email_app.app_context():
-        mandrill.messages.send.return_value = [
-            {'_id': '123', 'email': '123'}
-        ]
-
-        expected_call = {
-            'html': 'body',
-            'subject': 'subject',
-            'from_email': 'from_email',
-            'from_name': 'from_name',
-            'to': [{
-                'email': 'email_address',
-                'type': 'to'
-            }],
-            'important': False,
-            'track_opens': False,
-            'track_clicks': False,
-            'auto_text': True,
-            'tags': ['password-resets'],
-            'headers': {'Reply-To': 'from_email'},  # noqa
-            'metadata': None,
-            'preserve_recipients': False,
-            'recipient_metadata': [{
-                'rcpt': 'email_address'
-            }]
-        }
-
-        send_email(
-            'email_address',
-            'body',
-            'api_key',
-            'subject',
-            'from_email',
-            'from_name',
-            ['password-resets']
-        )
-
-        mandrill.messages.send.assert_called_once_with(message=expected_call, async=True)
-
-
-def test_calls_send_email_to_multiple_addresses(email_app, mandrill):
-    with email_app.app_context():
-
-        mandrill.messages.send.return_value = [
-            {'_id': '123', 'email': '123'}]
-
-        send_email(
-            ['email_address1', 'email_address2'],
-            'body',
-            'api_key',
-            'subject',
-            'from_email',
-            'from_name',
-            ['password-resets']
-
-        )
-
-        assert mandrill.messages.send.call_args[1]['message']['to'] == [
-            {'email': 'email_address1', 'type': 'to'},
-            {'email': 'email_address2', 'type': 'to'},
-        ]
-
-        assert mandrill.messages.send.call_args[1]['message']['recipient_metadata'] == [
-            {'rcpt': 'email_address1'},
-            {'rcpt': 'email_address2'},
-        ]
-
-
-def test_calls_send_email_with_alternative_reply_to(email_app, mandrill):
-    with email_app.app_context():
-        mandrill.messages.send.return_value = [
-            {'_id': '123', 'email': '123'}]
-
-        expected_call = {
-            'html': 'body',
-            'subject': 'subject',
-            'from_email': 'from_email',
-            'from_name': 'from_name',
-            'to': [{
-                'email': 'email_address',
-                'type': 'to'
-            }],
-            'important': False,
-            'track_opens': False,
-            'track_clicks': False,
-            'auto_text': True,
-            'tags': ['password-resets'],
-            'metadata': None,
-            'headers': {'Reply-To': 'reply_address'},
-            'preserve_recipients': False,
-            'recipient_metadata': [{
-                'rcpt': 'email_address'
-            }]
-        }
-
-        send_email(
-            'email_address',
-            'body',
-            'api_key',
-            'subject',
-            'from_email',
-            'from_name',
-            ['password-resets'],
-            reply_to='reply_address'
-        )
-
-        mandrill.messages.send.assert_called_once_with(message=expected_call, async=True)
-
-
 def _get_json_decode_error():
     try:
         json.loads('')
@@ -144,23 +36,142 @@ def _get_json_decode_error():
         return e
 
 
-@pytest.mark.parametrize("exception", [
-    Exception('this is an error'),  # all exceptions should be caught and turned into an EmailError
-    _get_json_decode_error(),  # but we are particularly interested in knowing that JSON errors are handled
-])
-def test_should_throw_exception_if_mandrill_fails(email_app, mandrill, exception):
-    with email_app.app_context():
-        mandrill.messages.send.side_effect = exception
+class TestMandrill(PatchExternalServiceLogConditionMixin):
+    def setup(self):
+        super().setup()
+        self.logger = logging.getLogger('mandrill')
 
-        with pytest.raises(EmailError) as e:
-            send_email(
-                'email_address',
-                'body',
-                'api_key',
-                'subject',
-                'from_email',
-                'from_name',
-                ['password-resets']
+    def test_calls_send_email_with_correct_params(self, email_app, mandrill):
+        with email_app.app_context():
+            mandrill.messages.send.return_value = [
+                {'_id': '123', 'email': '123'}
+            ]
 
-            )
-        assert e.value.__context__ == exception
+            expected_call = {
+                'html': 'body',
+                'subject': 'subject',
+                'from_email': 'from_email',
+                'from_name': 'from_name',
+                'to': [{
+                    'email': 'email_address',
+                    'type': 'to'
+                }],
+                'important': False,
+                'track_opens': False,
+                'track_clicks': False,
+                'auto_text': True,
+                'tags': ['password-resets'],
+                'headers': {'Reply-To': 'from_email'},  # noqa
+                'metadata': None,
+                'preserve_recipients': False,
+                'recipient_metadata': [{
+                    'rcpt': 'email_address'
+                }]
+            }
+
+            with assert_external_service_log_entry(extra_modules=['mandrill']):
+                send_email(
+                    'email_address',
+                    'body',
+                    'api_key',
+                    'subject',
+                    'from_email',
+                    'from_name',
+                    ['password-resets'],
+                    logger=self.logger
+                )
+
+            mandrill.messages.send.assert_called_once_with(message=expected_call, async=True)
+
+    def test_calls_send_email_to_multiple_addresses(self, email_app, mandrill):
+        with email_app.app_context():
+
+            mandrill.messages.send.return_value = [
+                {'_id': '123', 'email': '123'}]
+
+            with assert_external_service_log_entry(extra_modules=['mandrill']):
+                send_email(
+                    ['email_address1', 'email_address2'],
+                    'body',
+                    'api_key',
+                    'subject',
+                    'from_email',
+                    'from_name',
+                    ['password-resets'],
+                    logger=self.logger
+                )
+
+            assert mandrill.messages.send.call_args[1]['message']['to'] == [
+                {'email': 'email_address1', 'type': 'to'},
+                {'email': 'email_address2', 'type': 'to'},
+            ]
+
+            assert mandrill.messages.send.call_args[1]['message']['recipient_metadata'] == [
+                {'rcpt': 'email_address1'},
+                {'rcpt': 'email_address2'},
+            ]
+
+    def test_calls_send_email_with_alternative_reply_to(self, email_app, mandrill):
+        with email_app.app_context():
+            mandrill.messages.send.return_value = [
+                {'_id': '123', 'email': '123'}]
+
+            expected_call = {
+                'html': 'body',
+                'subject': 'subject',
+                'from_email': 'from_email',
+                'from_name': 'from_name',
+                'to': [{
+                    'email': 'email_address',
+                    'type': 'to'
+                }],
+                'important': False,
+                'track_opens': False,
+                'track_clicks': False,
+                'auto_text': True,
+                'tags': ['password-resets'],
+                'metadata': None,
+                'headers': {'Reply-To': 'reply_address'},
+                'preserve_recipients': False,
+                'recipient_metadata': [{
+                    'rcpt': 'email_address'
+                }]
+            }
+
+            with assert_external_service_log_entry(extra_modules=['mandrill']):
+                send_email(
+                    'email_address',
+                    'body',
+                    'api_key',
+                    'subject',
+                    'from_email',
+                    'from_name',
+                    ['password-resets'],
+                    reply_to='reply_address',
+                    logger=self.logger
+                )
+
+            mandrill.messages.send.assert_called_once_with(message=expected_call, async=True)
+
+    @pytest.mark.parametrize("exception", [
+        Exception('this is an error'),  # all exceptions should be caught and turned into an EmailError
+        _get_json_decode_error(),  # but we are particularly interested in knowing that JSON errors are handled
+    ])
+    def test_should_throw_exception_if_mandrill_fails(self, email_app, mandrill, exception):
+        with email_app.app_context():
+            mandrill.messages.send.side_effect = exception
+
+            with pytest.raises(EmailError) as e:
+                with assert_external_service_log_entry(successful_call=False, extra_modules=['mandrill']):
+                    send_email(
+                        'email_address',
+                        'body',
+                        'api_key',
+                        'subject',
+                        'from_email',
+                        'from_name',
+                        ['password-resets'],
+                        logger=self.logger
+                    )
+
+            assert e.value.__context__ == exception

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,12 @@
+from contextlib import contextmanager
 from datetime import datetime
+from functools import lru_cache
 from io import BytesIO
+import re
+import six
+
+import mock
+from testfixtures import logcapture
 
 
 class IsDatetime(object):
@@ -21,3 +28,95 @@ class MockFile(BytesIO):
     def filename(self):
         # weird flask property
         return self._filename
+
+
+class MalleableAny:
+    def __init__(self, condition):
+        self._condition = condition
+
+    def __eq__(self, other):
+        return self._condition(other)
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self._condition})"
+
+    def __hash__(self):
+        return None
+
+
+class AnySupersetOf(MalleableAny):
+    def __init__(self, subset_dict):
+        self._subset_dict = subset_dict
+        super().__init__(lambda other: self._subset_dict == {k: v for k, v in other.items() if k in self._subset_dict})
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self._subset_dict})"
+
+
+class AnyStringMatching(MalleableAny):
+    _cached_re_compile = staticmethod(lru_cache(maxsize=32)(re.compile))
+
+    def __init__(self, *args, **kwargs):
+        self._regex = self._cached_re_compile(*args, **kwargs)
+        super().__init__(lambda other: isinstance(other, six.string_types) and self._regex.match(other))
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self._regex})"
+
+
+@contextmanager
+def assert_log_entry(modules, message, count=1):
+    """A context manager that can be used to wrap a block of code under test to assert that a specific message is
+    logged. Works well with the AnyStringMatching malleable above to assert a message meeting a given format.
+
+    This is designed to most easily assert a single kind of message being logged one or more times, but if you
+    assign the context manager to a variable you can access the `records` attribute to see all log records and make
+    further inspections.
+
+    Example:
+        with assert_log_entry(message=AnyStringMatching('^My unknown string with a random word \w+$', count=2)) as logs:
+            do_something_that_produces_a_log()
+
+        assert any('some other log message' in record.msg for record in logs.records)
+    """
+    log_catcher = logcapture.LogCapture(names=modules, install=False)
+
+    log_catcher.install()
+
+    try:
+        yield log_catcher
+
+    finally:
+        log_catcher.uninstall_all()
+
+        matching_records = [True for record in log_catcher.records if message == record.msg]
+        assert len(matching_records) == count, f'{len(matching_records)} log records were seen that matched ' \
+                                               f'`{message}`: expected {count}'
+
+
+def assert_external_service_log_entry(service='\w+', description='.+', successful_call=True, extra_modules=None,
+                                      count=1):
+    """A subclass of AssertLogEntry specialised to inspect for the standardised message that is logged when
+    making calls to backing services (Notify, Mandrill, S3, etc)."""
+    if successful_call:
+        expected_message = r'Call to {service} \({description}\) executed in {{duration_real}}s'
+    else:
+        expected_message = r'Exception from call to {service} \({description}\) after {{duration_real}}s'
+
+    expected_message = expected_message.format(service=service, description=description)
+
+    modules = ['dmutils.timing']
+    if extra_modules:
+        modules += extra_modules
+
+    return assert_log_entry(modules=tuple(modules), message=AnyStringMatching(expected_message), count=count)
+
+
+class PatchExternalServiceLogConditionMixin:
+    def setup(self):
+        self.log_condition_patch = mock.patch('dmutils.timing.request_context_and_any_of_slow_call_or_sampled_request')
+        self.log_condition = self.log_condition_patch.start()
+        self.log_condition.return_value = True
+
+    def teardown(self):
+        self.log_condition_patch.stop()

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,5 +1,5 @@
 from dmutils import timing
-from helpers import MalleableAny, AnySupersetOf, AnyStringMatching
+from dmtestutils.comparisons import RestrictedAny, AnySupersetOf, AnyStringMatching
 
 from collections import OrderedDict
 from contextlib import contextmanager
@@ -205,7 +205,7 @@ def _expect_log(
                         _messages_expected[message][0].get('error' if raise_exception else 'success'),
                         exc_info=bool(raise_exception),
                         extra={
-                            "duration_real": MalleableAny(
+                            "duration_real": RestrictedAny(
                                 # a double-closure here to get around python's weird behaviour when capturing iterated
                                 # variables (in this case `sleep_time`)
                                 (lambda st: lambda val: st * 0.95 < val < st * 1.5)(sleep_time)
@@ -265,8 +265,8 @@ def _expect_log(
                     extra={
                         "key": "D#",
                         "keyes": "House Of",
-                        "duration_real": MalleableAny(lambda value: 0.48 < value < 0.6),
-                        "duration_process": MalleableAny(lambda value: isinstance(value, Number)),
+                        "duration_real": RestrictedAny(lambda value: 0.48 < value < 0.6),
+                        "duration_process": RestrictedAny(lambda value: isinstance(value, Number)),
                     },
                 )],
             ),
@@ -293,8 +293,8 @@ def _expect_log(
                     "The obedient {item}s feeding in {exc_info}",
                     exc_info=True,
                     extra={
-                        "duration_real": MalleableAny(lambda value: 0.18 < value < 0.35),
-                        "duration_process": MalleableAny(lambda value: isinstance(value, Number)),
+                        "duration_real": RestrictedAny(lambda value: 0.18 < value < 0.35),
+                        "duration_process": RestrictedAny(lambda value: isinstance(value, Number)),
                     },
                 )],
             ),
@@ -381,12 +381,12 @@ def test_logged_duration_mock_logger(
                         "name": "conftest.foobar",
                         "levelname": logging.getLevelName(log_level),
                         "message": _messages_expected[message][1].get('error' if raise_exception else 'success'),
-                        "duration_real": MalleableAny(
+                        "duration_real": RestrictedAny(
                             # a double-closure here to get around python's weird behaviour when capturing iterated
                             # variables (in this case `sleep_time`)
                             (lambda st: lambda val: st * 0.95 < val < st * 1.5)(sleep_time)
                         ),
-                        "duration_process": MalleableAny(lambda value: isinstance(value, Number)),
+                        "duration_process": RestrictedAny(lambda value: isinstance(value, Number)),
                         **(inject_context or {}),
                         **(
                             {
@@ -445,8 +445,8 @@ def test_logged_duration_mock_logger(
                     "message": AnyStringMatching(r"Touched the obedient D#s for [0-9Ee.-]+s"),
                     "levelname": "WARNING",
                     "key": "D#",
-                    "duration_real": MalleableAny(lambda value: 0.48 < value < 0.6),
-                    "duration_process": MalleableAny(lambda value: isinstance(value, Number)),
+                    "duration_real": RestrictedAny(lambda value: 0.48 < value < 0.6),
+                    "duration_process": RestrictedAny(lambda value: isinstance(value, Number)),
                     "name": "conftest.foobar",
                 }),),
             ),
@@ -483,8 +483,8 @@ def test_logged_duration_mock_logger(
                             r".*ValueError.*",
                             flags=re.DOTALL,
                         ),
-                        "duration_real": MalleableAny(lambda value: 0.18 < value < 0.35),
-                        "duration_process": MalleableAny(lambda value: isinstance(value, Number)),
+                        "duration_real": RestrictedAny(lambda value: 0.18 < value < 0.35),
+                        "duration_process": RestrictedAny(lambda value: isinstance(value, Number)),
                         "name": "conftest.foobar",
                     }),
                 ),

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,8 +1,8 @@
 from dmutils import timing
+from helpers import MalleableAny, AnySupersetOf, AnyStringMatching
 
 from collections import OrderedDict
 from contextlib import contextmanager
-from functools import lru_cache
 from itertools import chain, product
 import json
 import logging
@@ -15,41 +15,6 @@ import time
 
 from flask import request
 import pytest
-import six
-
-
-class MalleableAny:
-    def __init__(self, condition):
-        self._condition = condition
-
-    def __eq__(self, other):
-        return self._condition(other)
-
-    def __repr__(self):
-        return f"{self.__class__.__name__}({self._condition})"
-
-    def __hash__(self):
-        return None
-
-
-class AnySupersetOf(MalleableAny):
-    def __init__(self, subset_dict):
-        self._subset_dict = subset_dict
-        super().__init__(lambda other: self._subset_dict == {k: v for k, v in other.items() if k in self._subset_dict})
-
-    def __repr__(self):
-        return f"{self.__class__.__name__}({self._subset_dict})"
-
-
-class AnyStringMatching(MalleableAny):
-    _cached_re_compile = staticmethod(lru_cache(maxsize=32)(re.compile))
-
-    def __init__(self, *args, **kwargs):
-        self._regex = self._cached_re_compile(*args, **kwargs)
-        super().__init__(lambda other: isinstance(other, six.string_types) and self._regex.match(other))
-
-    def __repr__(self):
-        return f"{self.__class__.__name__}({self._regex})"
 
 
 @contextmanager


### PR DESCRIPTION
 ## Summary
We now log the duration of calls to AWS S3, but we should expand this to
our other third party providers. This PR introduces `logged_duration`
wrappers around the main calls to Mailchimp, Mandrill, and Notify. It
also introduces a generic partial that can be used to quickly wrap calls
to third-party providers and emit a consistent log entry, which involved
refactoring the current S3 logged_duration calls slightly.

 ## Ticket
https://trello.com/c/M0hAGLYT/303