### PR TITLE
Add a wtform error formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,29 @@
 
 Records breaking changes from major version bumps
 
+## 37.0.0
+
+PR [#398](https://github.com/alphagov/digitalmarketplace-utils/pull/398)
+
+This bump introduces a new method to format errors from Flask-WTForms in a consistent way. While this is not technically a breaking change, we should still make changes when this is pulled in to make sure all errors from WTForms are passed into templates in a consistent way. Where we might have referenced errors in templates either from the form directly on `form.errors`, or passed them in as `form_errors`, we should now pass **all** errors into the templating engine as an `errors` variable.
+
+Old code
+```python
+errors = {
+    key: {'question': form[key].label.text, 'input_name': key, 'message': form[key].errors[0]}
+    for key, value in form.errors.items()
+}
+return render_template('blah', form_errors=errors)
+```
+
+New code:
+```python
+return render_template('blah', errors=get_errors_from_wtform(form))
+```
+
 ## 36.0.0
 
-PR [#?376](https://github.com/alphagov/digitalmarketplace-utils/pull/376)
+PR [#376](https://github.com/alphagov/digitalmarketplace-utils/pull/376)
 
 DMMailChimpClient's `get_email_addresses_from_list` method is now a generator and has a reduced default page size of 100 (down from 1000) in an effort to reduce timeouts with the Mailchimp servers. Any code that uses email addresses from `get_email_addresses_from_list` will need to be updated to take account of the fact it returns a generator object rather than a list - mainly, where the result object is iterated over multiple times, this will fail without refactoring or converting the generator to a list object first (though this should be avoided to reap the most benefit from it being a generator).
 

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '36.12.0'
+__version__ = '37.0.0'

--- a/dmutils/forms.py
+++ b/dmutils/forms.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from itertools import chain
 import re
 
@@ -56,3 +57,16 @@ def remove_csrf_token(data):
         del cleaned_data['csrf_token']
 
     return cleaned_data
+
+
+def get_errors_from_wtform(form):
+    """Converts errors from a Flask-WTForm into the same format we generate from content-loader forms. This allows us
+    to treat errors from both content-loader forms and wtforms the same way inside templates.
+    :param form: A Flask-WTForm
+    :return: A dict with three keys: `input_name`, `question`, and `message` suitable for passing into templates.
+    """
+    return OrderedDict(
+        (key, {'input_name': key, 'question': form[key].label.text, 'message': form[key].errors[0]})
+        for key in
+        form.errors.keys()
+    )


### PR DESCRIPTION
 ## Summary
We want to format errors with a standard interface so that we can pass
them into templates and always interact with them in the same way,
enhancing the capabilities of our templates to react to errors in a
consistent way. This adds a method `dmutils.forms.format_wtform_errors`
for parsing and formatting errors from Flask-WTForms into the same
format generated by content-loader form errors.

 ## Ticket
https://trello.com/c/RSYEM3FL/448