### PR TITLE
Update API stubs for frameworks and lots

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '38.1.1'
+__version__ = '38.2.0'

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '38.1.0'
+__version__ = '38.1.1'

--- a/dmutils/api_stubs.py
+++ b/dmutils/api_stubs.py
@@ -15,8 +15,7 @@ def _derive_framework_family(slug):
 def lot(lot_id=1, slug="some-lot", name=None, allows_brief=False, one_service_limit=False, unit_singular='service',
         unit_plural='services'):
     if not name:
-        name = slug.replace("-", " ")
-        name = name[:1].upper() + name[1:]
+        name = slug.replace("-", " ").capitalize()
 
     return {
         "id": lot_id,
@@ -57,10 +56,13 @@ g_cloud_10_lots = __cloud_lots
 
 def dos_lots():
     return [
-        lot(lot_id=5, slug='digital-outcomes', name='Digital outcomes', allows_brief=True),
-        lot(lot_id=6, slug='digital-specialists', name='Digital specialists', allows_brief=True),
-        lot(lot_id=7, slug='user-research-studios', name='User research studios'),
-        lot(lot_id=8, slug='user-research-participants', name='User research participants', allows_brief=True)
+        lot(lot_id=5, slug='digital-outcomes', name='Digital outcomes', allows_brief=True, one_service_limit=True),
+        lot(lot_id=6, slug='digital-specialists', name='Digital specialists', allows_brief=True,
+            one_service_limit=True),
+        lot(lot_id=7, slug='user-research-studios', name='User research studios', unit_singular='lab',
+            unit_plural='labs'),
+        lot(lot_id=8, slug='user-research-participants', name='User research participants', allows_brief=True,
+            one_service_limit=True)
     ]
 
 

--- a/dmutils/api_stubs.py
+++ b/dmutils/api_stubs.py
@@ -15,7 +15,8 @@ def _derive_framework_family(slug):
 def lot(lot_id=1, slug="some-lot", name=None, allows_brief=False, one_service_limit=False, unit_singular='service',
         unit_plural='services'):
     if not name:
-        name = slug.replace("-", " ").title()
+        name = slug.replace("-", " ")
+        name = name[:1].upper() + name[1:]
 
     return {
         "id": lot_id,
@@ -76,19 +77,24 @@ def framework(framework_id=1,
               intention_to_award_at=dt(2000, 1, 4),
               framework_live_at=dt(2000, 1, 5),
               framework_expires_at=dt(2000, 1, 6),
-              has_direct_award=True,
-              has_further_competition=False):
-    if name:
-        pass
-    elif slug.startswith('g-cloud'):
-        name = 'G-Cloud {}'.format(slug.split('-')[-1])
-    elif slug.startswith("digital-outcomes-and-specialists"):
-        name = slug.replace("-", " ").title()
-        name = name.replace('And', 'and')
-    else:
-        name = slug.replace("-", " ").title()
+              has_direct_award=None,
+              has_further_competition=None):
+    framework_family = framework_family or _derive_framework_family(slug)
 
-    framework_family = _derive_framework_family(slug) if not framework_family else framework_family
+    if slug.startswith('g-cloud'):
+        name = name or 'G-Cloud {}'.format(slug.split('-')[-1])
+        has_direct_award = has_direct_award if has_direct_award is not None else True
+        has_further_competition = has_further_competition if has_further_competition is not None else False
+
+    elif slug.startswith('digital-outcomes-and-specialists'):
+        name = name or slug.replace("-", " ").title().replace('And', 'and')
+        has_direct_award = has_direct_award if has_direct_award is not None else False
+        has_further_competition = has_further_competition if has_further_competition is not None else True
+
+    else:
+        name = name or slug.replace("-", " ").title()
+        has_direct_award = has_direct_award if has_direct_award is not None else True
+        has_further_competition = has_further_competition if has_further_competition is not None else True
 
     lots = lots or []
 

--- a/dmutils/api_stubs.py
+++ b/dmutils/api_stubs.py
@@ -29,6 +29,41 @@ def lot(lot_id=1, slug="some-lot", name=None, allows_brief=False, one_service_li
     }
 
 
+def __as_a_service_lots():
+    return [
+        lot(lot_id=1, slug='saas', name='Software as a Service'),
+        lot(lot_id=2, slug='paas', name='Platform as a Service'),
+        lot(lot_id=3, slug='iaas', name='Infrastructure as a Service'),
+        lot(lot_id=4, slug='scs', name='Specialist Cloud Services')
+    ]
+
+
+def __cloud_lots():
+    return [
+        lot(lot_id=9, slug='cloud-hosting', name='Cloud hosting'),
+        lot(lot_id=10, slug='cloud-software', name='Cloud software'),
+        lot(lot_id=11, slug='cloud-support', name='Cloud support')
+    ]
+
+
+g_cloud_4_lots = __as_a_service_lots
+g_cloud_5_lots = __as_a_service_lots
+g_cloud_6_lots = __as_a_service_lots
+g_cloud_7_lots = __as_a_service_lots
+g_cloud_8_lots = __as_a_service_lots
+g_cloud_9_lots = __cloud_lots
+g_cloud_10_lots = __cloud_lots
+
+
+def dos_lots():
+    return [
+        lot(lot_id=5, slug='digital-outcomes', name='Digital outcomes', allows_brief=True),
+        lot(lot_id=6, slug='digital-specialists', name='Digital specialists', allows_brief=True),
+        lot(lot_id=7, slug='user-research-studios', name='User research studios'),
+        lot(lot_id=8, slug='user-research-participants', name='User research participants', allows_brief=True)
+    ]
+
+
 def framework_agreement_details(slug='g-cloud-7',
                                 framework_agreement_version='RM1557x',
                                 framework_variations=None,
@@ -85,18 +120,20 @@ def framework(framework_id=1,
         name = name or 'G-Cloud {}'.format(slug.split('-')[-1])
         has_direct_award = has_direct_award if has_direct_award is not None else True
         has_further_competition = has_further_competition if has_further_competition is not None else False
+        framework_iteration = int(slug.split('-')[-1])
+        lots = lots if lots else (__as_a_service_lots() if framework_iteration <= 8 else __cloud_lots())
 
     elif slug.startswith('digital-outcomes-and-specialists'):
         name = name or slug.replace("-", " ").title().replace('And', 'and')
         has_direct_award = has_direct_award if has_direct_award is not None else False
         has_further_competition = has_further_competition if has_further_competition is not None else True
+        lots = lots if lots else dos_lots()
 
     else:
         name = name or slug.replace("-", " ").title()
         has_direct_award = has_direct_award if has_direct_award is not None else True
         has_further_competition = has_further_competition if has_further_competition is not None else True
-
-    lots = lots or []
+        lots = lots or []
 
     agreement_details = framework_agreement_details(slug=slug,
                                                     framework_agreement_version=framework_agreement_version,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -79,12 +79,6 @@ def assert_external_service_log_entry(service='\w+', description='.+', successfu
 
 
 class PatchExternalServiceLogConditionMixin:
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.log_condition_patch = None
-        self.log_condition = None
-
     def setup(self):
         self.log_condition_patch = mock.patch('dmutils.timing.request_context_and_any_of_slow_call_or_sampled_request')
         self.log_condition = self.log_condition_patch.start()

--- a/tests/test_api_stubs.py
+++ b/tests/test_api_stubs.py
@@ -82,6 +82,10 @@ class TestFrameworkAgreementDetails:
 
 
 class TestFramework:
+    def setup(self):
+        self.g7_lots = api_stubs.g_cloud_7_lots()
+        self.dos_lots = api_stubs.dos_lots()
+
     def test_default_values(self):
         assert api_stubs.framework() == {
             "frameworks": {
@@ -91,9 +95,9 @@ class TestFramework:
                 "framework": "g-cloud",
                 "status": "open",
                 "clarificationQuestionsOpen": True,
-                "lots": [],
+                "lots": self.g7_lots,
                 "allowDeclarationReuse": True,
-                "frameworkAgreementDetails": api_stubs.framework_agreement_details(),
+                "frameworkAgreementDetails": api_stubs.framework_agreement_details(lots=self.g7_lots),
                 "countersignerName": None,
                 "frameworkAgreementVersion": "RM1557x",
                 "variations": {},
@@ -109,7 +113,8 @@ class TestFramework:
         }
 
     def test_custom_slug_derives_name_and_framework(self):
-        framework_agreement_details = api_stubs.framework_agreement_details(slug='digital-outcomes-and-specialists')
+        framework_agreement_details = api_stubs.framework_agreement_details(slug='digital-outcomes-and-specialists',
+                                                                            lots=self.dos_lots)
         assert api_stubs.framework(slug='digital-outcomes-and-specialists') == {
             "frameworks": {
                 "id": 1,
@@ -118,7 +123,7 @@ class TestFramework:
                 "framework": "digital-outcomes-and-specialists",
                 "status": "open",
                 "clarificationQuestionsOpen": True,
-                "lots": [],
+                "lots": self.dos_lots,
                 "allowDeclarationReuse": True,
                 "frameworkAgreementDetails": framework_agreement_details,
                 "countersignerName": None,
@@ -203,9 +208,9 @@ class TestFramework:
                 "framework": "g-cloud",
                 "status": "open",
                 "clarificationQuestionsOpen": True,
-                "lots": [],
+                "lots": self.g7_lots,
                 "allowDeclarationReuse": True,
-                "frameworkAgreementDetails": api_stubs.framework_agreement_details(),
+                "frameworkAgreementDetails": api_stubs.framework_agreement_details(lots=self.g7_lots),
                 "countersignerName": None,
                 "frameworkAgreementVersion": "RM1557x",
                 "variations": {},
@@ -229,9 +234,9 @@ class TestFramework:
                 "framework": "g-cloud",
                 "status": "open",
                 "clarificationQuestionsOpen": True,
-                "lots": [],
+                "lots": self.g7_lots,
                 "allowDeclarationReuse": True,
-                "frameworkAgreementDetails": api_stubs.framework_agreement_details(),
+                "frameworkAgreementDetails": api_stubs.framework_agreement_details(lots=self.g7_lots),
                 "countersignerName": None,
                 "frameworkAgreementVersion": "RM1557x",
                 "variations": {},

--- a/tests/test_api_stubs.py
+++ b/tests/test_api_stubs.py
@@ -7,7 +7,7 @@ class TestLot:
         assert api_stubs.lot() == {
             "id": 1,
             "slug": "some-lot",
-            "name": "Some Lot",
+            "name": "Some lot",
             "allowsBrief": False,
             "oneServiceLimit": False,
             "unitSingular": "service",
@@ -19,7 +19,7 @@ class TestLot:
                              unit_singular='brief', unit_plural='briefs') == {
             "id": 2,
             "slug": "my-special-lot",
-            "name": "My Special Lot",
+            "name": "My special lot",
             "allowsBrief": True,
             "oneServiceLimit": True,
             "unitSingular": "brief",
@@ -72,8 +72,8 @@ class TestFrameworkAgreementDetails:
             "frameworkRefDate": "29-06-2000",
             "frameworkStartDate": "05 January 2000",
             "frameworkURL": f"https://www.gov.uk/government/publications/g-cloud-7",
-            "lotDescriptions": {"cloud-hosting": "Lot 1: Cloud Hosting",
-                                "cloud-support": "Lot 2: Cloud Support"},
+            "lotDescriptions": {"cloud-hosting": "Lot 1: Cloud hosting",
+                                "cloud-support": "Lot 2: Cloud support"},
             "lotOrder": ["cloud-hosting", "cloud-support"],
             "pageTotal": 99,
             "signaturePageNumber": 98,
@@ -130,8 +130,8 @@ class TestFramework:
                 'intentionToAwardAtUTC': '2000-01-04T00:00:00.000000Z',
                 'frameworkLiveAtUTC': '2000-01-05T00:00:00.000000Z',
                 'frameworkExpiresAtUTC': '2000-01-06T00:00:00.000000Z',
-                'hasDirectAward': True,
-                'hasFurtherCompetition': False,
+                'hasDirectAward': False,
+                'hasFurtherCompetition': True,
             }
         }
 
@@ -158,7 +158,7 @@ class TestFramework:
                 'frameworkLiveAtUTC': '2000-01-05T00:00:00.000000Z',
                 'frameworkExpiresAtUTC': '2000-01-06T00:00:00.000000Z',
                 'hasDirectAward': True,
-                'hasFurtherCompetition': False,
+                'hasFurtherCompetition': True,
             }
         }
 


### PR DESCRIPTION
 ## Summary
Fix lot capitalisation to only capitalise the first letter, and set
further_competition/direct_award flags based on framework family.

There are lots of places in frontend apps where we want to create known
lots for G-Cloud/Digital Outcomes and Specialists frameworks, so let's
simplify this by creating simple pre-configured lots. We'll also update
the framework stub to populate these lots correctly for our two known
frameworks if no argument is supplied.