### PR TITLE
Centralise Notify domain overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 Records breaking changes from major version bumps
 
+## 39.0.0
+
+PR [?]
+
+All of our apps have duplicated configuration for `DM_NOTIFY_REDIRECT_DOMAINS_TO_ADDRESS`, which defines email domains that should be redirected by the DMNotifyClient to point at Amazon SES's 'fake-success' email addresses. This config should be held locally as it's unlikely to change per app, and we also need to inject the same configuration into scripts that use Notify. Holding it in utils seems sensible. Therefore, apps that pull in this version of utils should update config to use the new variable exposed in dmutils.email.dm_notify at `DEFAULT_NOTIFY_REDIRECT_DOMAINS_TO_ADDRESS`.
+
+Old
+```python
+class Live(Config):
+    ...
+
+    DM_NOTIFY_REDIRECT_DOMAINS_TO_ADDRESS = {
+        "example.com": "success@simulator.amazonses.com",
+        "example.gov.uk": "success@simulator.amazonses.com",
+        "user.marketplace.team": "success@simulator.amazonses.com",
+    }
+    ...
+```
+
+New
+```python
+from dmutils.email.dm_notify import DEFAULT_NOTIFY_REDIRECT_DOMAINS_TO_ADDRESS
+...
+class Live(Config):
+    ...
+
+    DM_NOTIFY_REDIRECT_DOMAINS_TO_ADDRESS = DEFAULT_NOTIFY_REDIRECT_DOMAINS_TO_ADDRESS
+    ...
+```
+
+
 ## 38.0.0
 
 PR [#397](https://github.com/alphagov/digitalmarketplace-utils/pull/397)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '38.2.0'
+__version__ = '39.0.0'

--- a/dmutils/email/dm_notify.py
+++ b/dmutils/email/dm_notify.py
@@ -9,6 +9,15 @@ from dmutils.email.helpers import hash_string
 from dmutils.timing import logged_duration_for_external_request as log_external_request
 
 
+# These are listed here so that we have a central definition that can be imported and used by apps/scripts. These
+# domains are *not* injected into all DMNotifyClients automatically.
+DEFAULT_NOTIFY_REDIRECT_DOMAINS_TO_ADDRESS = {
+    "example.com": "success@simulator.amazonses.com",
+    "example.gov.uk": "success@simulator.amazonses.com",
+    "user.marketplace.team": "success@simulator.amazonses.com",
+}
+
+
 class DMNotifyClient:
     """Digital Marketplace wrapper around the Notify python client."""
 


### PR DESCRIPTION
 ## Summary
All of our apps define some email domains that Notify should not
actually send emails to (e.g. the email domains we use for test accounts
on dev environments). These are currently duplicated across all of the
apps. Our scripts also need access to these override domains, so it
seems sensible to centralise them - since I doubt they need to change
much per app/script.

This does a major version bump to 39.0.0 so that we can enforce the
update as utils is pulled into things.

## Ticket
https://trello.com/c/YIJ25eiP/479