### PR TITLE
Add date format for signature pages

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '39.0.1'
+__version__ = '39.1.0'

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -7,6 +7,7 @@ DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_FORMAT = "%Y-%m-%d"
 DISPLAY_MONTH_YEAR_FORMAT = "%B %Y"
 DISPLAY_SHORT_DATE_FORMAT = '%-d %B'
+DISPLAY_NO_DAY_DATE_FORMAT = '%-d %B %Y'
 DISPLAY_DATE_FORMAT = '%A %-d %B %Y'
 DISPLAY_TIME_FORMAT = '%H:%M:%S'
 DISPLAY_DATETIME_FORMAT = '%A %-d %B %Y at %I:%M%p %Z'
@@ -36,6 +37,17 @@ def shortdateformat(value, default_value=None):
     ** USE OUR STANDARD dateformat RATHER THAN THIS UNLESS THERE IS A GOOD REASON NOT TO **
     """
     return _format_date(value, default_value, DISPLAY_SHORT_DATE_FORMAT, localize=False)
+
+
+def nodaydateformat(value, default_value=None):
+    """
+    Example value: datetime.strptime("2018-07-25 10:15:00", "%Y-%m-%d %H:%M:%S")
+    Example output: '25 July 2018'
+
+    `nodaydateformat` is used *only* when generating framework agreement signature pages. If you're thinking about
+    using this, you probably want to use `dateformat` instead.
+    """
+    return _format_date(value, default_value, DISPLAY_NO_DAY_DATE_FORMAT, localize=False)
 
 
 def dateformat(value, default_value=None):

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 from dmutils.formats import (
-    timeformat, shortdateformat, dateformat, monthyearformat, datetimeformat, datetodatetimeformat,
-    utcdatetimeformat, utctoshorttimelongdateformat
+    dateformat,
+    datetimeformat,
+    datetodatetimeformat,
+    monthyearformat,
+    nodaydateformat,
+    shortdateformat,
+    timeformat,
+    utcdatetimeformat,
+    utctoshorttimelongdateformat,
 )
 import pytz
 from datetime import datetime
@@ -32,6 +39,20 @@ def test_timeformat(dt, formatted_time):
 ))
 def test_shortdateformat(dt, formatted_date):
     assert shortdateformat(dt) == formatted_date
+
+
+@pytest.mark.parametrize("dt, formatted_date", (
+    (datetime(2012, 11, 10, 9, 8, 7, 6), "10 November 2012"),
+    ("2012-11-10T09:08:07.0Z", "10 November 2012"),
+    (datetime(2012, 8, 10, 9, 8, 7, 6), "10 August 2012"),
+    ("2012-08-10T09:08:07.0Z", "10 August 2012"),
+    (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "10 August 2012"),
+    ("2016-04-27T23:59:59.0Z", "27 April 2016"),
+    (datetime(2016, 4, 27, 23, 59, 59, 0), "27 April 2016"),
+    (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), "1 August 2012"),
+))
+def test_nodaydateformat(dt, formatted_date):
+    assert nodaydateformat(dt) == formatted_date
 
 
 @pytest.mark.parametrize("dt, formatted_date", (


### PR DESCRIPTION
 ## Summary
When generating framework agreement signature pages, we want to display
the date without the day in it.