### PR TITLE
tracing: include zipkin sampled & debug headers in log output

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '39.1.0'
+__version__ = '39.2.0'

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -162,19 +162,19 @@ class JSONFormatter(BaseJSONFormatter):
 
         log_record['logType'] = "application"
 
-        missing_keys = []
+        missing_keys = {}
         for attempt in range(self._max_missing_key_attempts):
             try:
-                log_record['message'] = log_record['message'].format(**log_record)
-
+                log_record['message'] = log_record['message'].format(**log_record, **missing_keys)
+            except KeyError as e:
+                missing_keys[e.args[0]] = f"{{{e.args[0]}: missing key}}"
+            else:
+                # execution should only ever reach this point once - when the .format() succeeds
                 if missing_keys:
-                    logger.warning("Missing keys when formatting log message: {}".format(missing_keys))
+                    logger.warning("Missing keys when formatting log message: {}".format(tuple(missing_keys.keys())))
 
                 break
 
-            except KeyError as e:
-                missing_keys.append(e.args[0])
-                log_record[e.args[0]] = f"{{{e.args[0]}: missing key}}"
         else:
             logger.exception("Too many missing keys when attempting to format log message: gave up")
 

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -12,9 +12,13 @@ LOG_FORMAT = '%(asctime)s %(app_name)s %(name)s %(levelname)s ' \
              '%(trace_id)s "%(message)s" [in %(pathname)s:%(lineno)d]'
 
 
+# fields named in LOG_FORMAT and LOG_FORMAT_EXTRA_JSON_KEYS will always be included in json log output even if
+# no such field was supplied in the log record, substituting a None value if necessary.
 LOG_FORMAT_EXTRA_JSON_KEYS = (
     "span_id",
     "parent_span_id",
+    "is_sampled",
+    "debug_flag",
 )
 
 
@@ -148,6 +152,8 @@ class JSONFormatter(BaseJSONFormatter):
             ("span_id", "spanId",),
             ("parent_span_id", "parentSpanId",),
             ("app_name", "application",),
+            ("is_sampled", "isSampled",),
+            ("debug_flag", "debugFlag",),
         ):
             try:
                 log_record[newkey] = log_record.pop(key)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -11,6 +11,8 @@ import mock
 
 from flask import request
 
+from dmtestutils.comparisons import AnySupersetOf
+
 from dmutils.logging import init_app, RequestExtraContextFilter, JSONFormatter, CustomLogFormatter
 from dmutils.logging import LOG_FORMAT, get_json_log_format
 
@@ -193,6 +195,59 @@ class TestJSONFormatter(object):
         result = json.loads(raw_result)
 
         assert result['message'].startswith("Too many missing keys when attempting to format")
+
+
+def test_log_context_handling_in_initialized_app_high_level(app_logtofile):
+    with open(app_logtofile.config["DM_LOG_PATH"], "r") as log_file:
+        # consume log initialization line
+        log_file.read()
+
+        with app_logtofile.test_request_context('/'):
+            test_extra_log_context = {
+                "ankles": "thinsocked",
+                "span_id": "beesWaxed",
+            }
+
+            request.get_extra_log_context = mock.Mock(spec_set=[])
+            request.get_extra_log_context.return_value = test_extra_log_context
+
+            app_logtofile.logger.info(
+                "Charming day {ankles}, {underleaves}, {parent_span_id}",
+                extra={"underleaves": "ample"},
+            )
+
+        # ensure buffers are flushed
+        logging.shutdown()
+
+        all_lines = tuple(json.loads(line) for line in log_file.read().splitlines())
+        assert all_lines == (
+            AnySupersetOf({
+                'message': "Missing keys when formatting log message: ('parent_span_id',)",
+            }),
+            AnySupersetOf({
+                "time": mock.ANY,
+                "application": mock.ANY,
+                "message": "Charming day thinsocked, ample, {parent_span_id: missing key}",
+                "underleaves": "ample",
+                "ankles": "thinsocked",
+                "spanId": "beesWaxed",
+                "parentSpanId": None,
+                "requestId": None,
+                "debugFlag": None,
+                "isSampled": None,
+            }),
+        )
+
+        for unexpected_key in (
+            "span_id",
+            "trace_id",
+            "traceId",
+            "request_id",
+            "debug_flag",
+            "is_sampled",
+            "parent_span_id",  # also ensuring "missing key" functionality didn't add a value for this
+        ):
+            assert not any(unexpected_key in line for line in all_lines)
 
 
 class TestCustomLogFormatter(object):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -176,7 +176,7 @@ class TestJSONFormatter(object):
         raw_result = self.dmbuffer.getvalue()
         result = json.loads(raw_result)
 
-        assert result['message'].startswith("Missing keys when formatting log message: ['barry']")
+        assert result['message'].startswith("Missing keys when formatting log message: ('barry',)")
         assert result['levelname'] == 'WARNING'
 
     def test_two_missing_keys_when_formatting_logs_a_warning(self):
@@ -184,7 +184,7 @@ class TestJSONFormatter(object):
         raw_result = self.dmbuffer.getvalue()
         result = json.loads(raw_result)
 
-        assert result['message'].startswith("Missing keys when formatting log message: ['barry', 'paul']")
+        assert result['message'].startswith("Missing keys when formatting log message: ('barry', 'paul')")
         assert result['levelname'] == 'WARNING'
 
     def test_failed_log_message_formatting_logs_an_error(self):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -146,6 +146,10 @@ class TestJSONFormatter(object):
         assert 'span_id' not in result
         assert 'parentSpanId' in result
         assert 'parent_span_id' not in result
+        assert 'isSampled' in result
+        assert 'is_sampled' not in result
+        assert 'debugFlag' in result
+        assert 'debug_flag' not in result
 
     def test_log_type_is_set_to_application(self):
         self.logger.info("hello")


### PR DESCRIPTION
If I'm going to be going to the effort of bumping utils out to everything, may as well include these.

This includes the values of the "sampled" and "debug" zipkin flags in log output. Please only take issue with the json key names `tracingIsSampled` & `tracingDebugFlag` if you have a significantly better suggestion as this is something we could discuss forever...