### PR TITLE
tracing: change design to perform "promotion" of span ids in-app 

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '39.2.0'
+__version__ = '39.3.0'


### PR DESCRIPTION
Trello https://trello.com/c/UOXf4vZZ/308-make-use-of-zipkin-headers-in-preference-to-request-id

Relying on the hosting platform to promote `X-B3-SpanId` header values to `X-B3-ParentSpanId` headers and assign fresh `X-B3-SpanId` values appears to be deprecated behaviour.