### PR TITLE
Add dependency on Flask-FeatureFlags v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Records breaking changes from major version bumps
 
+## 40.0.0
+
+PR [414](https://github.com/alphagov/digitalmarketplace-utils/pull/414)
+
+Updated dependency on Flask-FeatureFlags v1.0 must be added to `requirements-app.txt` as this version is not on PyPI.
+
 ## 39.0.0
 
 PR [407](https://github.com/alphagov/digitalmarketplace-utils/pull/407)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '39.6.0'
+__version__ = '40.0.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 -e .
+
+# Dependencies not on PyPI must be listed here as well as in setup.py
+git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
+

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-         'Flask-FeatureFlags==0.6',
+         'Flask-FeatureFlags==1.0',
          'Flask-Script==2.0.6',
          'Flask-WTF==0.14.2',
          'Flask==0.10.1',


### PR DESCRIPTION
No breaking code change, but as this version is not on PyPI, a manual update to `requirements-app.txt` will be required.

https://trello.com/c/MF5RbH7K/425-flask-feature-flags-deprecation-warning