### PR TITLE
External route for opportunities list page

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '39.4.1'
+__version__ = '39.5.0'

--- a/dmutils/external.py
+++ b/dmutils/external.py
@@ -15,6 +15,11 @@ def get_brief_by_id(framework_family, brief_id):
     raise NotImplementedError()
 
 
+@external.route('/<framework_family>/opportunities')
+def list_opportunities(framework_family):
+    raise NotImplementedError()
+
+
 @external.route('/g-cloud/suppliers')
 def suppliers_list_by_prefix():
     raise NotImplementedError()


### PR DESCRIPTION
A lovely new external route, so our apps can avoid hardcoding URLs (see https://github.com/alphagov/digitalmarketplace-brief-responses-frontend/pull/65).