### PR TITLE
Add formatter to create ISO datetime strings.

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '40.0.0'
+__version__ = '40.1.0'

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -94,6 +94,17 @@ def datetimeformat(value, default_value=None, localize=True):
     return _format_date(value, default_value, DISPLAY_DATETIME_FORMAT, localize=localize)
 
 
+def iso_datetime_format(value, default_value=None):
+    """
+    Example value: datetime.strptime("2018-07-25 23:59:59", "%Y-%m-%d %H:%M:%S")
+    Example output: '2018-07-25T23:59:59.000000Z'
+    :param value: some datetime that you want to format using ISO 8601 formatting
+    :param default_value: default to return if value is None
+    :return: string formatted per ISO 8601 in UTC, assuming the datetime passed in was UTC
+    """
+    return _format_date(value, default_value, DATETIME_FORMAT, localize=False)
+
+
 def utctoshorttimelongdateformat(value, default_value=None, localize=True):
     """
     Example value: datetime.strptime("2010-01-01 13:00:00", "%Y-%m-%d %H:%M:%S") OR "2010-01-01T13:00:00.000000Z"

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -2,6 +2,7 @@
 from dmutils.formats import (
     dateformat,
     datetimeformat,
+    iso_datetime_format,
     datetodatetimeformat,
     monthyearformat,
     nodaydateformat,
@@ -102,6 +103,18 @@ def test_monthyearformat(dt, default_value, formatted_date):
 ))
 def test_datetimeformat(dt, formatted_datetime):
     assert datetimeformat(dt) == formatted_datetime
+
+
+@pytest.mark.parametrize("dt, formatted_datetime", (
+    (datetime(2012, 11, 10, 9, 8, 7, 6), "2012-11-10T09:08:07.000006Z"),
+    ("2012-11-10T09:08:07.0Z", "2012-11-10T09:08:07.000000Z"),
+    (datetime(2012, 8, 10, 9, 8, 7, 6), "2012-08-10T09:08:07.000006Z"),
+    ("2012-08-10T09:08:07.0Z", "2012-08-10T09:08:07.000000Z"),
+    # Fall back to default if no valid date supplied
+    (None, 'my_default'),
+))
+def test_iso_datetime_format(dt, formatted_datetime):
+    assert iso_datetime_format(dt, 'my_default') == formatted_datetime
 
 
 @pytest.mark.parametrize("dt, localize, default_value, formatted_datetime", (


### PR DESCRIPTION
In many places where we construct API responses we call `strftime(DATETIME_FORMAT)`, but including a null check every time (for nullable fields) creates unnecessarily verbose code.

For example, instead of
```
"lockedAt": self.locked_at.strftime(DATETIME_FORMAT) if self.locked_at is not None else None,
```
we can now have
```
"lockedAt": iso_datetime_format(self.locked_at),
```

Pretty sure I have previously claimed this was unnecessary, but now I'm adding the 4th or 5th field that needs this kind of treatment, I think I regret that claim :-)