### PR TITLE
Move env helpers from scripts to utils

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '40.3.0'
+__version__ = '40.4.0'

--- a/dmutils/email/dm_mandrill.py
+++ b/dmutils/email/dm_mandrill.py
@@ -53,3 +53,9 @@ def send_email(to_email_addresses, email_body, api_key, subject, from_email, fro
 
     logger.info("Sent {tags} response: id={id}, email={email_hash}",
                 extra={'tags': tags, 'id': result[0]['_id'], 'email_hash': hash_string(result[0]['email'])})
+
+
+def get_sent_emails(mandrill_api_key, tags, date_from=None):
+    mandrill_client = Mandrill(mandrill_api_key)
+
+    return mandrill_client.messages.search(tags=tags, date_from=date_from, limit=1000)

--- a/dmutils/env_helpers.py
+++ b/dmutils/env_helpers.py
@@ -1,0 +1,49 @@
+def get_api_endpoint_from_stage(stage, app='api'):
+    """Return the full URL of given API or Search API environment.
+
+    :param stage: environment name. Can be one of 'preview', 'staging',
+                  'production' or 'dev' (aliases: 'local', 'development').
+    :param app: should be either 'api' or 'search-api'
+
+    """
+
+    stage_domains = {
+        'preview': 'https://{}.preview.marketplace.team'.format(app),
+        'staging': 'https://{}.staging.marketplace.team'.format(app),
+        'production': 'https://{}.digitalmarketplace.service.gov.uk'.format(app),
+    }
+
+    dev_ports = {
+        'api': 5000,
+        'search-api': 5001,
+    }
+
+    if stage in ['local', 'dev', 'development']:
+        return 'http://localhost:{}'.format(dev_ports[app])
+
+    return stage_domains[stage]
+
+
+def get_web_url_from_stage(stage):
+    """Return the full URL of given web environment.
+
+    :param stage: environment name. Can be one of 'preview', 'staging',
+                  'production' or 'dev' (aliases: 'local', 'development').
+    """
+    if stage in ['local', 'dev', 'development']:
+        return 'http://localhost'
+
+    stage_domains = {
+        'preview': 'https://www.preview.marketplace.team',
+        'staging': 'https://www.staging.marketplace.team',
+        'production': 'https://www.digitalmarketplace.service.gov.uk',
+    }
+    return stage_domains[stage]
+
+
+def get_assets_endpoint_from_stage(stage):
+    if stage in ['local', 'dev', 'development']:
+        # Static files are not served via nginx for local environments
+        raise NotImplementedError()
+
+    return get_api_endpoint_from_stage(stage, 'assets')

--- a/tests/test_env_helpers.py
+++ b/tests/test_env_helpers.py
@@ -1,0 +1,72 @@
+import pytest
+from dmutils.env_helpers import get_api_endpoint_from_stage, get_assets_endpoint_from_stage, get_web_url_from_stage
+
+
+class TestGetAPIEndpointFromStage:
+
+    @pytest.mark.parametrize('stage', ['local', 'dev', 'development'])
+    def test_get_api_endpoint_for_dev_environments(self, stage):
+        assert get_api_endpoint_from_stage(stage) == 'http://localhost:5000'
+
+    @pytest.mark.parametrize(
+        'stage, expected_result',
+        [
+            ('preview', 'https://api.preview.marketplace.team'),
+            ('staging', 'https://api.staging.marketplace.team'),
+            ('production', 'https://api.digitalmarketplace.service.gov.uk')
+        ]
+    )
+    def test_get_api_endpoint_for_non_dev_environments(self, stage, expected_result):
+        assert get_api_endpoint_from_stage(stage) == expected_result
+
+    @pytest.mark.parametrize('stage', ['local', 'dev', 'development'])
+    def test_get_search_api_endpoint_for_dev_environments(self, stage):
+        assert get_api_endpoint_from_stage(stage, app='search-api') == 'http://localhost:5001'
+
+    @pytest.mark.parametrize(
+        'stage, expected_result',
+        [
+            ('preview', 'https://search-api.preview.marketplace.team'),
+            ('staging', 'https://search-api.staging.marketplace.team'),
+            ('production', 'https://search-api.digitalmarketplace.service.gov.uk')
+        ]
+    )
+    def test_get_search_api_endpoint_for_non_dev_environments(self, stage, expected_result):
+        assert get_api_endpoint_from_stage(stage, app='search-api') == expected_result
+
+
+class TestGetWebUrlFromStage:
+
+    @pytest.mark.parametrize('stage', ['local', 'dev', 'development'])
+    def test_get_web_url_for_dev_environments(self, stage):
+        assert get_web_url_from_stage(stage) == 'http://localhost'
+
+    @pytest.mark.parametrize(
+        'stage, expected_result',
+        [
+            ('preview', 'https://www.preview.marketplace.team'),
+            ('staging', 'https://www.staging.marketplace.team'),
+            ('production', 'https://www.digitalmarketplace.service.gov.uk')
+        ]
+    )
+    def test_get_api_endpoint_for_non_dev_environments(self, stage, expected_result):
+        assert get_web_url_from_stage(stage) == expected_result
+
+
+class TestGetAssetsEndpointFromStage:
+
+    @pytest.mark.parametrize('stage', ['local', 'dev', 'development'])
+    def test_get_assets_endpoint_raises_error_for_dev_environments(self, stage):
+        with pytest.raises(NotImplementedError):
+            get_assets_endpoint_from_stage(stage)
+
+    @pytest.mark.parametrize(
+        'stage, expected_result',
+        [
+            ('preview', 'https://assets.preview.marketplace.team'),
+            ('staging', 'https://assets.staging.marketplace.team'),
+            ('production', 'https://assets.digitalmarketplace.service.gov.uk')
+        ]
+    )
+    def test_get_assets_endpoint_for_non_dev_environments(self, stage, expected_result):
+        assert get_assets_endpoint_from_stage(stage) == expected_result


### PR DESCRIPTION
As discussed in this issue: https://github.com/alphagov/digitalmarketplace-scripts/issues/257

The env helpers are useful for constructing dynamic fully-qualified urls within the apps, for example in email templates. I added in some tests, which revealed the static assets helper doesn't work for local envs (which makes sense, as there's no router app to handle them). For now I tweaked the function to raise a `NotImplementedError` if anyone tries to use it for local assets.

The `get_sent_emails` helper function feels like it belongs with the other Mandrill utils.

Original files can be found here:
- https://github.com/alphagov/digitalmarketplace-scripts/blob/master/dmscripts/helpers/env_helpers.py
- https://github.com/alphagov/digitalmarketplace-scripts/blob/master/dmscripts/helpers/email_helpers.py

I have left off the csv functions for now, as there was some funny stuff happening in those functions regarding unicode which I want to investigate first.

I'll do a separate PR to pull in this version of the utils to the scripts, and deprecate the old functions there.