### PR TITLE
add `timed_render_template`

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '40.2.0'
+__version__ = '40.3.0'

--- a/dmutils/flask.py
+++ b/dmutils/flask.py
@@ -1,0 +1,34 @@
+from functools import partial
+
+from flask import render_template, render_template_string
+
+from dmutils.timing import logged_duration
+
+
+SLOW_RENDER_THRESHOLD = 0.25
+
+
+_logged_duration_partial = partial(
+    logged_duration,
+    condition=lambda log_context: (
+        logged_duration.default_condition(log_context) or log_context["duration_real"] > SLOW_RENDER_THRESHOLD
+    ),
+)
+
+
+timed_render_template = _logged_duration_partial(
+    message=lambda log_context: f"Spent >{SLOW_RENDER_THRESHOLD}s in render_template",
+)(render_template)
+timed_render_template.__doc__ = """
+    This is a simple ``logged_duration``-wrapped version of flask's ``render_template`` which will output a ``DEBUG``
+    log message either when the request has been sent with zipkin "sample" mode or the request takes more than
+    ``SLOW_RENDER_THRESHOLD`` seconds. The idea being in frontends we can freely use this in place of flask's regular
+    ``render_template`` and get some insight as to the behaviour of the view "for free".
+"""
+
+timed_render_template_string = _logged_duration_partial(
+    message=lambda log_context: f"Spent >{SLOW_RENDER_THRESHOLD}s in render_template_string",
+)(render_template_string)
+timed_render_template_string.__doc__ = """
+    See ``timed_render_template``, only for ``render_template_string``.
+"""


### PR DESCRIPTION
This is a simple `logged_duration`-wrapped version of flask's `render_template` and `render_template_string` which will output a `DEBUG` log message either when the request has been sent with zipkin "sample" mode or the request takes more than `SLOW_RENDER_THRESHOLD` seconds. The idea being in frontends we can freely use this in place of flask's regular `render_template` and get some insight as to the behaviour of the view "for free". Will be quite useful for performance profiling and with any luck might give us an extra clue about weird stuff.

What do people think about 250ms? Was taken from sam's similar "external call threshold"...