### PR TITLE
request logging: add "early" log messages and timing information

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '40.4.0'
+__version__ = '40.5.0'

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -27,9 +27,35 @@ LOG_FORMAT_EXTRA_JSON_KEYS = (
 logger = logging.getLogger(__name__)
 
 
+def _common_request_extra_log_context():
+    return {
+        "method": request.method,
+        "url": request.url,
+        "endpoint": request.endpoint,
+        # pid and thread ident are both available on LogRecord by default, as `process` and `thread`
+        # respectively but I don't see a straightforward way of selectively including them only in certain
+        # log messages - they are designed to be included when the formatter is being configured. This is why
+        # I'm manually grabbing them and putting them in as `extra` here, avoiding the existing parameter names
+        # to prevent LogRecord from complaining
+        "_process": getpid(),
+        # stringifying this as it could potentially be a long that json is unable to represent accurately
+        "_thread": str(get_thread_ident()),
+    }
+
+
 def init_app(app):
     app.config.setdefault('DM_LOG_LEVEL', 'INFO')
     app.config.setdefault('DM_APP_NAME', 'none')
+
+    @app.before_request
+    def before_request():
+        if getattr(request, "is_sampled", False):
+            # emit an early log message to record that the request was received by the app
+            current_app.logger.log(
+                logging.DEBUG,
+                "Received request {method} {url}",
+                extra=_common_request_extra_log_context(),
+            )
 
     @app.after_request
     def after_request(response):
@@ -37,19 +63,10 @@ def init_app(app):
             logging.ERROR if response.status_code // 100 == 5 else logging.INFO,
             '{method} {url} {status}',
             extra={
-                'method': request.method,
-                'url': request.url,
-                'endpoint': request.endpoint,
-                'status': response.status_code,
-                # pid and thread ident are both available on LogRecord by default, as `process` and `thread`
-                # respectively but I don't see a straightforward way of selectively including them only in certain
-                # log messages - they are designed to be included when the formatter is being configured. This is why
-                # I'm manually grabbing them and putting them in as `extra` here, avoiding the existing parameter names
-                # to prevent LogRecord from complaining
-                '_process': getpid(),
-                # stringifying this as it could potentially be a long that json is unable to represent accurately
-                '_thread': str(get_thread_ident()),
-            })
+                "status": response.status_code,
+                **_common_request_extra_log_context(),
+            },
+        )
         return response
 
     logging.getLogger().addHandler(logging.NullHandler())

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -6,6 +6,7 @@ try:
 except ImportError:
     from io import StringIO
 import json
+import time
 
 import mock
 
@@ -123,6 +124,8 @@ def test_app_request_logs_responses_with_info_level(app, is_sampled):
                     "status": 404,
                     "method": "GET",
                     "endpoint": None,
+                    "duration_real": RestrictedAny(lambda value: isinstance(value, float) and 0 < value),
+                    "duration_process": RestrictedAny(lambda value: isinstance(value, float) and 0 < value),
                     "_process": RestrictedAny(lambda value: isinstance(value, int)),
                     "_thread": RestrictedAny(lambda value: isinstance(value, (str, bytes,))),
                 },
@@ -137,6 +140,7 @@ def test_app_request_logs_5xx_responses_with_error_level(app, is_sampled):
 
     @app.route('/')
     def error_route():
+        time.sleep(0.05)
         return 'error', 500
 
     # since app.logger is a read-only property we need to patch the Flask class
@@ -164,6 +168,8 @@ def test_app_request_logs_5xx_responses_with_error_level(app, is_sampled):
                     "status": 500,
                     "method": "GET",
                     "endpoint": "error_route",
+                    "duration_real": RestrictedAny(lambda value: isinstance(value, float) and 0.05 <= value),
+                    "duration_process": RestrictedAny(lambda value: isinstance(value, float) and 0 < value),
                     "_process": RestrictedAny(lambda value: isinstance(value, int)),
                     "_thread": RestrictedAny(lambda value: isinstance(value, (str, bytes,))),
                 },


### PR DESCRIPTION
This does two things to flask app request logging:

 - If the zipkin `is_sampled` property is set on the request, will cause a log message to be emitted when flask *receives* a request (`before_request`). This could be useful in cases where the app for some reason doesn't manage to log its request completing.
 - Adds timing information to the existing `after_request` log events. This should allow us to deduce how much time is spent queueing for a python thread/process.