### PR TITLE
External routes should 404 instead of going to the wrong app

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '40.5.0'
+__version__ = '40.6.0'

--- a/dmutils/external.py
+++ b/dmutils/external.py
@@ -1,9 +1,9 @@
-from flask import Blueprint
+from flask import Blueprint, abort
 
 external = Blueprint('external', __name__)
 
-# Buyer frontend
 
+# Buyer frontend
 
 @external.route('/')
 def index():
@@ -12,11 +12,17 @@ def index():
 
 @external.route('/<framework_family>/opportunities/<brief_id>')
 def get_brief_by_id(framework_family, brief_id):
+    if framework_family == 'suppliers':
+        # nginx would otherwise route this pattern to the Brief Responses FE
+        abort(404)
     raise NotImplementedError()
 
 
 @external.route('/<framework_family>/opportunities')
 def list_opportunities(framework_family):
+    if framework_family == 'suppliers':
+        # nginx would otherwise route this pattern to the Brief Responses FE
+        abort(404)
     raise NotImplementedError()
 
 

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -1,0 +1,33 @@
+import pytest
+
+from dmutils.external import external
+
+
+@pytest.mark.parametrize(
+    'url', [
+        '/suppliers/opportunities',
+        '/suppliers/opportunities/1234'
+    ]
+)
+def test_external_routes_raise_404_if_suppliers_given_as_framework_family(app, url):
+    app.register_blueprint(external)
+    client = app.test_client()
+    with app.app_context():
+        resp = client.get(url)
+        assert resp.status_code == 404
+
+
+@pytest.mark.parametrize(
+    'url', [
+        '/digital-outcomes-and-specialists/opportunities',
+        '/digital-outcomes-and-specialists/opportunities/1234',
+        '/foo/opportunities',
+        '/foo/opportunities/1234'
+    ]
+)
+def test_external_routes_raise_500_if_anything_else_given_as_framework_family(app, url):
+    app.register_blueprint(external)
+    client = app.test_client()
+    with app.app_context():
+        resp = client.get(url)
+        assert resp.status_code == 500


### PR DESCRIPTION
Trello: https://trello.com/c/9HOV64oh/362-external-route-failure-for-frameworkfamily-opportunities-when-frameworkfamily-suppliers

The Buyer FE external routes `list_opportunities` and `get_brief_by_id` have a URL pattern prefix of `<framework_family>/opportunities/...`.

The Brief Responses FE handles all requests beginning `suppliers/opportunities`. This app doesn't know about `list_opportunities`, so gives a 500 Not Implemented error if the value of `framework_family` is 'suppliers'. 

This commit changes that to a 404 as expected.

Adds some basic tests for these 2 routes only (split by expected behaviour rather than route).