### PR TITLE
timed_render_template: message fix

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '40.6.0'
+__version__ = '40.6.1'

--- a/dmutils/flask.py
+++ b/dmutils/flask.py
@@ -17,7 +17,7 @@ _logged_duration_partial = partial(
 
 
 timed_render_template = _logged_duration_partial(
-    message=lambda log_context: f"Spent >{SLOW_RENDER_THRESHOLD}s in render_template",
+    message="Spent {duration_real}s in render_template",
 )(render_template)
 timed_render_template.__doc__ = """
     This is a simple ``logged_duration``-wrapped version of flask's ``render_template`` which will output a ``DEBUG``
@@ -27,7 +27,7 @@ timed_render_template.__doc__ = """
 """
 
 timed_render_template_string = _logged_duration_partial(
-    message=lambda log_context: f"Spent >{SLOW_RENDER_THRESHOLD}s in render_template_string",
+    message="Spent {duration_real}s in render_template_string",
 )(render_template_string)
 timed_render_template_string.__doc__ = """
     See ``timed_render_template``, only for ``render_template_string``.


### PR DESCRIPTION
Change log message to remain correct if triggered by zipkin is_sampled.