### PR TITLE
timed_render_template: increase SLOW_RENDER_THRESHOLD

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '40.6.1'
+__version__ = '40.6.2'

--- a/dmutils/flask.py
+++ b/dmutils/flask.py
@@ -5,7 +5,7 @@ from flask import render_template, render_template_string
 from dmutils.timing import logged_duration
 
 
-SLOW_RENDER_THRESHOLD = 0.25
+SLOW_RENDER_THRESHOLD = 0.5
 
 
 _logged_duration_partial = partial(


### PR DESCRIPTION
to 0.5s. There are more >250ms than I thought. If we get the random zipkin sampling support we should still be able to pick out the lower-timed of these for enough of the calls.