### PR TITLE
request logging: change "process" and "thread" log parameter names 

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '40.6.2'
+__version__ = '40.6.3'

--- a/dmutils/flask.py
+++ b/dmutils/flask.py
@@ -5,7 +5,7 @@ from flask import render_template, render_template_string
 from dmutils.timing import logged_duration
 
 
-SLOW_RENDER_THRESHOLD = 0.5
+SLOW_RENDER_THRESHOLD = 0.25
 
 
 _logged_duration_partial = partial(

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -38,9 +38,9 @@ def _common_request_extra_log_context():
         # log messages - they are designed to be included when the formatter is being configured. This is why
         # I'm manually grabbing them and putting them in as `extra` here, avoiding the existing parameter names
         # to prevent LogRecord from complaining
-        "_process": getpid(),
+        "process_": getpid(),
         # stringifying this as it could potentially be a long that json is unable to represent accurately
-        "_thread": str(get_thread_ident()),
+        "thread_": str(get_thread_ident()),
     }
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -111,8 +111,8 @@ def test_app_request_logs_responses_with_info_level(app, is_sampled):
                     "url": "http://localhost/",
                     "method": "GET",
                     "endpoint": None,
-                    "_process": RestrictedAny(lambda value: isinstance(value, int)),
-                    "_thread": RestrictedAny(lambda value: isinstance(value, (str, bytes,))),
+                    "process_": RestrictedAny(lambda value: isinstance(value, int)),
+                    "thread_": RestrictedAny(lambda value: isinstance(value, (str, bytes,))),
                 },
             ),
         ] if is_sampled else []) + [
@@ -126,8 +126,8 @@ def test_app_request_logs_responses_with_info_level(app, is_sampled):
                     "endpoint": None,
                     "duration_real": RestrictedAny(lambda value: isinstance(value, float) and 0 < value),
                     "duration_process": RestrictedAny(lambda value: isinstance(value, float) and 0 < value),
-                    "_process": RestrictedAny(lambda value: isinstance(value, int)),
-                    "_thread": RestrictedAny(lambda value: isinstance(value, (str, bytes,))),
+                    "process_": RestrictedAny(lambda value: isinstance(value, int)),
+                    "thread_": RestrictedAny(lambda value: isinstance(value, (str, bytes,))),
                 },
             )
         ]
@@ -155,8 +155,8 @@ def test_app_request_logs_5xx_responses_with_error_level(app, is_sampled):
                     "url": "http://localhost/",
                     "method": "GET",
                     "endpoint": "error_route",
-                    "_process": RestrictedAny(lambda value: isinstance(value, int)),
-                    "_thread": RestrictedAny(lambda value: isinstance(value, (str, bytes,))),
+                    "process_": RestrictedAny(lambda value: isinstance(value, int)),
+                    "thread_": RestrictedAny(lambda value: isinstance(value, (str, bytes,))),
                 },
             ),
         ] if is_sampled else []) + [
@@ -170,8 +170,8 @@ def test_app_request_logs_5xx_responses_with_error_level(app, is_sampled):
                     "endpoint": "error_route",
                     "duration_real": RestrictedAny(lambda value: isinstance(value, float) and 0.05 <= value),
                     "duration_process": RestrictedAny(lambda value: isinstance(value, float) and 0 < value),
-                    "_process": RestrictedAny(lambda value: isinstance(value, int)),
-                    "_thread": RestrictedAny(lambda value: isinstance(value, (str, bytes,))),
+                    "process_": RestrictedAny(lambda value: isinstance(value, int)),
+                    "thread_": RestrictedAny(lambda value: isinstance(value, (str, bytes,))),
                 },
             ),
         ]


### PR DESCRIPTION
Our log pipeline seems to strip leading-underscore parameters

Also quietly switch `timed_render_template`'s `SLOW_RENDER_THRESHOLD` back to 0.25s - turns out this isn't quite so common after instances have warmed up their template bytecode caches...