### PR TITLE
Add urllib3.util.retry to configured loggers

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '40.6.3'
+__version__ = '40.7.0'

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -89,12 +89,17 @@ def init_app(app):
 
     handler = get_handler(app)
     loglevel = logging.getLevelName(app.config['DM_LOG_LEVEL'])
-    loggers = [app.logger, logging.getLogger('dmutils'), logging.getLogger('dmapiclient')]
+    loggers = [
+        app.logger,
+        logging.getLogger('dmutils'),
+        logging.getLogger('dmapiclient'),
+        logging.getLogger('urllib3.util.retry')
+    ]
     for logger in loggers:
         logger.addHandler(handler)
         logger.setLevel(loglevel)
 
-    app.logger.info("Logging configured")
+    app.logger.info('Logging configured')
 
 
 def configure_handler(handler, app, formatter):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -61,7 +61,6 @@ def test_request_extra_context_filter_no_method(app):
 
 
 def test_init_app_adds_stream_handler_without_log_path(app):
-    init_app(app)
 
     assert len(app.logger.handlers) == 1
     assert isinstance(app.logger.handlers[0], logging.StreamHandler)
@@ -85,6 +84,20 @@ def test_init_app_adds_stream_handler_with_plain_text_format_when_config_env_set
     assert len(app.logger.handlers) == 1
     assert isinstance(app.logger.handlers[0], logging.StreamHandler)
     assert isinstance(app.logger.handlers[0].formatter, CustomLogFormatter)
+
+
+def test_init_app_only_adds_handlers_to_defined_loggers(app):
+    for logger in logging.Logger.manager.loggerDict.values():
+        logger.handlers = []
+
+    init_app(app)
+
+    loggers = {
+        k for k, v in logging.Logger.manager.loggerDict.items() if v.handlers
+        and isinstance(v.handlers[0], logging.StreamHandler)
+    }
+
+    assert loggers == {'conftest', 'dmutils', 'dmapiclient', 'urllib3.util.retry'}
 
 
 def _set_request_class_is_sampled(app, sampled):


### PR DESCRIPTION
See [this PR on the apiclient to add retrying](https://github.com/alphagov/digitalmarketplace-apiclient/pull/152).

If the apiclient uses the inbuilt retry functionality or urllib3, via
the requests library, the log messages it creates when a request fails
and it retries could be useful.

Because the retrying is abstracted away quite far from the apiclient,
it's difficult to get any other logging out.

Here's an example of what the log messages would look like when retrying a 503 until failure - it's my local supplier frontend hitting the api (which just returns a 503).
```
2018-07-19 11:32:10,901 supplier-frontend dmapiclient.base DEBUG d02ff08fde8326c68e1ff9c24c9dc602 "API request GET http://localhost:5000/users/10525" [in /Users/christopherwynne/GDS/digitalmarketplace-apiclient/dmapiclient/base.py:176]
2018-07-19 11:32:10,921 supplier-frontend dmapiclient.base INFO d02ff08fde8326c68e1ff9c24c9dc602 "API GET request on http://localhost:5000/users/10525 finished in 0.020201185019686818" [in /Users/christopherwynne/GDS/digitalmarketplace-apiclient/dmapiclient/base.py:212]
2018-07-19 11:32:10,922 supplier-frontend dmapiclient.base DEBUG d02ff08fde8326c68e1ff9c24c9dc602 "API request GET http://localhost:5000/suppliers/92219" [in /Users/christopherwynne/GDS/digitalmarketplace-apiclient/dmapiclient/base.py:176]
2018-07-19 11:32:10,943 supplier-frontend urllib3.util.retry DEBUG d02ff08fde8326c68e1ff9c24c9dc602 "Incremented Retry for (url='/suppliers/92219'): Retry(total=2, connect=3, read=3, redirect=None, status=2)" [in /Users/christopherwynne/.virtualenvs/supplier/lib/python3.6/site-packages/urllib3/util/retry.py:389]
2018-07-19 11:32:10,966 supplier-frontend urllib3.util.retry DEBUG d02ff08fde8326c68e1ff9c24c9dc602 "Incremented Retry for (url='/suppliers/92219'): Retry(total=1, connect=3, read=3, redirect=None, status=1)" [in /Users/christopherwynne/.virtualenvs/supplier/lib/python3.6/site-packages/urllib3/util/retry.py:389]
2018-07-19 11:32:11,591 supplier-frontend urllib3.util.retry DEBUG d02ff08fde8326c68e1ff9c24c9dc602 "Incremented Retry for (url='/suppliers/92219'): Retry(total=0, connect=3, read=3, redirect=None, status=0)" [in /Users/christopherwynne/.virtualenvs/supplier/lib/python3.6/site-packages/urllib3/util/retry.py:389]
2018-07-19 11:32:12,817 supplier-frontend dmapiclient.base WARNING d02ff08fde8326c68e1ff9c24c9dc602 "API GET request on http://localhost:5000/suppliers/92219 failed with 503 '503 Server Error: SERVICE UNAVAILABLE for url: http://localhost:5000/suppliers/92219
HTTPError('503 Server Error: SERVICE UNAVAILABLE for url: http://localhost:5000/suppliers/92219',) raised 503 Server Error: SERVICE UNAVAILABLE for url: http://localhost:5000/suppliers/92219'" [in /Users/christopherwynne/GDS/digitalmarketplace-apiclient/dmapiclient/base.py:198]
2018-07-19 11:32:12,820 supplier-frontend app ERROR d02ff08fde8326c68e1ff9c24c9dc602 "GET http://localhost/suppliers 503" [in /Users/christopherwynne/GDS/digitalmarketplace-utils/dmutils/logging.py:81]
```