### PR TITLE
Add flask_wtf.csrf to configured loggers

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '40.7.0'
+__version__ = '40.8.0'

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -93,7 +93,8 @@ def init_app(app):
         app.logger,
         logging.getLogger('dmutils'),
         logging.getLogger('dmapiclient'),
-        logging.getLogger('urllib3.util.retry')
+        logging.getLogger('flask_wtf.csrf'),
+        logging.getLogger('urllib3.util.retry'),
     ]
     for logger in loggers:
         logger.addHandler(handler)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -97,7 +97,7 @@ def test_init_app_only_adds_handlers_to_defined_loggers(app):
         and isinstance(v.handlers[0], logging.StreamHandler)
     }
 
-    assert loggers == {'conftest', 'dmutils', 'dmapiclient', 'urllib3.util.retry'}
+    assert loggers == {'conftest', 'dmutils', 'dmapiclient', 'flask_wtf.csrf', 'urllib3.util.retry'}
 
 
 def _set_request_class_is_sampled(app, sampled):


### PR DESCRIPTION
Users have been reporting CSRF errors similar to those in [this tech
debt ticket][trello].

This commit adds `flask_wtf.csrf` to the list of configured loggers so
that we can see CSRF error messages in Kibana.

[trello]: https://trello.com/c/1K5ePclo