### PR TITLE
log zipkin "isSampled", "debugFlag" headers as 1|0 instead of boolean

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '40.8.0'
+__version__ = '40.9.0'

--- a/dmutils/request_id.py
+++ b/dmutils/request_id.py
@@ -118,8 +118,9 @@ class RequestIdRequestMixin(object):
             "trace_id": self.trace_id,
             "span_id": self.span_id,
             "parent_span_id": self.parent_span_id,
-            "is_sampled": self.is_sampled,
-            "debug_flag": self.debug_flag,
+            # output these as 1|0 strings to match what's easily outputtable by nginx
+            "is_sampled": "1" if self.is_sampled else "0",
+            "debug_flag": "1" if self.debug_flag else "0",
         }
 
 

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -540,8 +540,8 @@ def test_request_header(
             "trace_id": expected_trace_id,
             "span_id": expected_span_id,
             "parent_span_id": expected_parent_span_id,
-            "is_sampled": expected_is_sampled,
-            "debug_flag": expected_debug_flag,
+            "is_sampled": "1" if expected_is_sampled else "0",
+            "debug_flag": "1" if expected_debug_flag else "0",
         }
 
     assert traceid_random_mock.randrange.called is expect_trace_random_call


### PR DESCRIPTION
To match what's easily outputtable by nginx.

The alternative would be to add a couple more `map` lines to our nginx configs to make *them* output as booleans, but I think this is slightly less painful...