### PR TITLE
Do not configure urllib3 retry logger for search-api

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '40.9.0'
+__version__ = '40.9.1'

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -94,8 +94,12 @@ def init_app(app):
         logging.getLogger('dmutils'),
         logging.getLogger('dmapiclient'),
         logging.getLogger('flask_wtf.csrf'),
-        logging.getLogger('urllib3.util.retry'),
     ]
+    #  The Elasticsearch client used by the search-api uses urllib3 directly and manages retries itself.
+    #  This results in more logging than we want from urllib3, so we don't configure the logger for the search-api.
+    if app.config['DM_APP_NAME'] != 'search-api':
+        loggers.append(logging.getLogger('urllib3.util.retry'))
+
     for logger in loggers:
         logger.addHandler(handler)
         logger.setLevel(loglevel)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -100,6 +100,21 @@ def test_init_app_only_adds_handlers_to_defined_loggers(app):
     assert loggers == {'conftest', 'dmutils', 'dmapiclient', 'flask_wtf.csrf', 'urllib3.util.retry'}
 
 
+def test_urllib3_retry_logger_not_configured_for_search_api(app):
+    app.config['DM_APP_NAME'] = 'search-api'
+    for logger in logging.Logger.manager.loggerDict.values():
+        logger.handlers = []
+
+    init_app(app)
+
+    loggers = {
+        k for k, v in logging.Logger.manager.loggerDict.items() if v.handlers
+        and isinstance(v.handlers[0], logging.StreamHandler)
+    }
+
+    assert 'urllib3.util.retry' not in loggers
+
+
 def _set_request_class_is_sampled(app, sampled):
     class _Request(app.request_class):
         is_sampled = sampled


### PR DESCRIPTION
The search-api uses the Elasticsearch client. The client uses urllib3 to
make requests, but has its own logic for managing retries. When the
client sends a request via urllib3 it always sets retries to `False`.
This causes urllib3.util.retry to emit an unwanted log message, twice,
for every request. It looks like this: `Converted retries value: False
-> Retry(total=False, connect=None, read=None, redirect=0, status=None)`.

As retries are not configured via our apiclient, and there is no way to
set the retry config for urllib3 when used by Elasticsearch, we can
safely drop the logger for the search-api.