### PR TITLE
EmailValidator for wtforms: replace our own regex based routine with one stolen from Notify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Records breaking changes from major version bumps
 
+## 41.0.0
+
+PR [431](https://github.com/alphagov/digitalmarketplace-utils/pull/431)
+
+`forms.EmailValidator` no longer inherits from `wtforms.validators.Regexp` and its constructor now only accepts a
+single, keyword, argument `message`.
+
 ## 40.0.0
 
 PR [414](https://github.com/alphagov/digitalmarketplace-utils/pull/414)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '40.9.1'
+__version__ = '41.0.0'

--- a/dmutils/forms/validators.py
+++ b/dmutils/forms/validators.py
@@ -8,15 +8,66 @@ FourDigitYear -- validate that a four digit year value is provided
 
 import re
 
-from wtforms.validators import Regexp, ValidationError
+from wtforms.validators import ValidationError
 
 
-class EmailValidator(Regexp):
-    _email_re = re.compile(r"^[^@\s]+@[^@\.\s]+(\.[^@\.\s]+)+$")
+class EmailValidator:
+    # Largely copied from https://github.com/alphagov/notifications-utils/blob/\
+    #   67889886ec1476136d12e7f32787a7dbd0574cc2/notifications_utils/recipients.py
+    #
+    # regexes for use in validate_email_address.
+    # invalid local chars - whitespace, quotes and apostrophes, semicolons and colons, GBP sign
+    # Note: Normal apostrophe eg `Firstname-o'surname@domain.com` is allowed.
+    _INVALID_LOCAL_CHARS = r"\s\",;:@£“”‘’"
+    _email_regex = re.compile(r'^[^{}]+@([^.@][^@]+)$'.format(_INVALID_LOCAL_CHARS))
+    _hostname_part = re.compile(r'^(xn-|[a-z0-9]+)(-[a-z0-9]+)*$', re.IGNORECASE)
+    _tld_part = re.compile(r'^([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)$', re.IGNORECASE)
 
-    def __init__(self, **kwargs):
-        kwargs.setdefault("message", "Please enter a valid email address.")
-        super(EmailValidator, self).__init__(self._email_re, **kwargs)
+    def __init__(self, message="Please enter a valid email address."):
+        self.message = message
+
+    def __call__(self, form, field):
+        # Largely a straight copy from https://github.com/alphagov/notifications-utils/blob/\
+        #   67889886ec1476136d12e7f32787a7dbd0574cc2/notifications_utils/recipients.py#L439 onwards so that we have
+        # validity-parity with Notify and minimise nasty surprises once we attempt to send an email to this address via
+        # Notify and only find out it won't be accepted once it's too late to give the user a sane validation message
+
+        # almost exactly the same as by https://github.com/wtforms/wtforms/blob/master/wtforms/validators.py,
+        # with minor tweaks for SES compatibility - to avoid complications we are a lot stricter with the local part
+        # than neccessary - we don't allow any double quotes or semicolons to prevent SES Technical Failures
+        email_address = (field.data or "").strip()
+        match = re.match(self._email_regex, email_address)
+
+        # not an email
+        if not match:
+            raise ValidationError(self.message)
+
+        hostname = match.group(1)
+        # don't allow consecutive periods in domain names
+        if '..' in hostname:
+            raise ValidationError(self.message)
+
+        # idna = "Internationalized domain name" - this encode/decode cycle converts unicode into its accurate ascii
+        # representation as the web uses. '例え.テスト'.encode('idna') == b'xn--r8jz45g.xn--zckzah'
+        try:
+            hostname = hostname.encode('idna').decode('ascii')
+        except UnicodeError:
+            raise ValidationError(self.message)
+
+        parts = hostname.split('.')
+
+        if len(hostname) > 253 or len(parts) < 2:
+            raise ValidationError(self.message)
+
+        for part in parts:
+            if not part or len(part) > 63 or not self._hostname_part.match(part):
+                raise ValidationError(self.message)
+
+        # if the part after the last . is not a valid TLD then bail out
+        if not self._tld_part.match(parts[-1]):
+            raise ValidationError(self.message)
+
+        return
 
 
 class GreaterThan:

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -33,6 +33,10 @@ email_address_parametrization = ("email_address", (
     "@",
     "first.w@t.ch.",
     "second.w@t..h",
+    "a.b@strangeface.fellowthatsolike_sawhimbefore.chapwithawen",
+    "-@-.-",
+    "123@321.12",
+    "x@y.z",
 ))
 
 
@@ -51,13 +55,12 @@ class TestEmailFieldFormat(object):
             assert "test_email" in form.errors
 
     @pytest.mark.parametrize("email_address", (
-        "x@y.z",
+        "x@y.zz",
         "-second@wat.ch",
-        "123@321.12",
+        "123@321.go",
         "   helter-Skelter_pelter-Welter@Who.do-you.call.him\t",
-        "a..............b@strangeface.fellowthatsolike_sawhimbefore.Chapwithawen",
+        "a..............b@strangeface.fellowthatsolike-sawhimbefore.Chapwithawen",
         ".man_in_the_street.@other.man.in.the.street   \n",
-        "-@-.-",  # probably not actually valid
     ))
     def test_valid_emails(self, app, email_address):
         with app.app_context():
@@ -118,7 +121,7 @@ class EmailFieldCombinationTestForm(FlaskForm):
 
 class TestEmailFieldCombination(object):
     _invalid_address = "@inv@li..d.."
-    _valid_address = "v@li.d"
+    _valid_address = "v@l.id"
 
     _possibilities = (_valid_address, _invalid_address, "")
 


### PR DESCRIPTION
https://trello.com/c/7m7tPP83/379-email-validation-should-we-use-notifys
https://trello.com/c/LD2eVPTY/368-supplier-user-can-be-created-but-no-email-sent

This is a fairly straightforward port. You'll see the tests needed minimal changes, mostly moving addresses over from what was previously considered "valid" to what's now considered "invalid" and making up a few replacement valid ones that are a bit tamer.

~~Thinking again, I'm actually probably going to make this~~ a major bump as technically the validator's constructor call signature has changed, not accepting a regex override as the previous implementation, inheriting from the regex validator, did.