### PR TITLE
logging: add AppStackLocationFilter, include in default flask configuration

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '41.1.0'
+__version__ = '41.2.0'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,17 +9,19 @@ from dmutils.logging import init_app
 
 
 @pytest.fixture
-def app():
+def app(request):
     app = Flask(__name__)
+    app.root_path = request.fspath.dirname
     init_app(app)
     return app
 
 
 # it's deceptively difficult to capture & inspect *actual* log output in pytest (no, capfd doesn't seem to work)
 @pytest.fixture
-def app_logtofile():
+def app_logtofile(request):
     with tempfile.NamedTemporaryFile() as f:
         app = Flask(__name__)
+        app.root_path = request.fspath.dirname
         app.config['DM_LOG_PATH'] = f.name
         init_app(app)
         yield app


### PR DESCRIPTION
https://trello.com/c/U24anuJR/58-improving-profiling-and-live-debuggability

This annotates a log record to include extra information on the first stack frame that's *within* the app, as it's often more illuminating than the location deep within a utility or library function where the log message is actually output.

As configured here initially, only include this information for `WARNING` or `ERROR` messages or messages originating from a "sampled" request.