### PR TITLE
bump cryptography version to 2.3 to mitigate CVE-2018-10903 

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '41.0.0'
+__version__ = '41.1.0'

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
          'Flask-Login>=0.2.11',
          'boto3==1.4.8',
          'contextlib2==0.4.0',
-         'cryptography==1.9',
+         'cryptography==2.3',
          'inflection==0.3.1',
          'mailchimp3==2.0.11',
          'mandrill==1.0.57',


### PR DESCRIPTION
None of the breaking changes seem to affect `cryptography.fernet` which I think is the only part that we use.