### PR TITLE
AppStackLocationFilter: cope with relative co_filename paths, make _findCaller() more robust

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '41.2.0'
+__version__ = '41.2.1'


### PR DESCRIPTION
This is me being dumb and yet more proof that relative imports should be obliterated.

I should also expand the tests to cover the relative case, but want to get this out quick-ish.