### PR TITLE
Error handling in utils.flask_init

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '42.0.1'
+__version__ = '42.1.0'

--- a/dmutils/errors.py
+++ b/dmutils/errors.py
@@ -1,0 +1,56 @@
+from flask import redirect, render_template, url_for, flash, session, request, current_app
+from flask_wtf.csrf import CSRFError
+
+
+def csrf_handler(e):
+    """
+    Workaround for a bug in Flask 0.10.1.
+    CSRFErrors are caught under 400 BadRequest exceptions, so this heavy-handed solution
+     catches all 400s, and immediately discards non-CSRFError instances.
+
+    :param e: CSRF exception instance
+    :param session: Flask session instance
+    :param request: Flask request instance
+    :param logger: app logger instance
+    :return: redirect to login with flashed error message
+    """
+    if not isinstance(e, CSRFError):
+        return render_error_page(e)
+
+    if 'user_id' not in session:
+        current_app.logger.info(
+            u'csrf.session_expired: Redirecting user to log in page'
+        )
+    else:
+        current_app.logger.info(
+            u'csrf.invalid_token: Aborting request, user_id: {user_id}',
+            extra={'user_id': session['user_id']}
+        )
+
+    flash('Your session has expired. Please log in again.', "error")
+    return redirect(url_for('external.render_login', next=request.path))
+
+
+def render_error_page(e=None, status_code=None):
+    """
+    Either an exception or a status code must be supplied.
+    :param e: exception instance, e.g. Forbidden()
+    :param status_code: int status code, e.g. 403
+    :return: Flask render_template response. The error templates must be present in the app (either
+    copied from the FE Toolkit, or a custom template for that app).
+    """
+    if not e or status_code:
+        # Something's gone wrong! To save going in an endless error loop let's just render a 500
+        status_code = 500
+
+    template_map = {
+        400: "errors/500.html",
+        404: "errors/404.html",
+        500: "errors/500.html",
+        503: "errors/500.html",
+    }
+
+    if not status_code or status_code not in template_map:
+        status_code = 500 if e.code not in template_map else e.code
+
+    return render_template(template_map[status_code]), status_code

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -1,6 +1,6 @@
 import os
 from flask_featureflags.contrib.inline import InlineFeatureFlag
-from . import config, logging, proxy_fix, request_id, formats, filters
+from . import config, logging, proxy_fix, request_id, formats, filters, errors
 from flask_script import Manager, Server
 
 
@@ -66,6 +66,12 @@ def init_app(
         return dict(
             pluralize=pluralize,
             **(application.config['BASE_TEMPLATE_DATA'] or {}))
+
+    # Register error handlers for CSRF errors and common error status codes
+    application.register_error_handler(400, errors.csrf_handler)
+    application.register_error_handler(404, errors.render_error_page)
+    application.register_error_handler(503, errors.render_error_page)
+    application.register_error_handler(500, errors.render_error_page)
 
 
 def pluralize(count, singular, plural):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ def app(request):
     app = Flask(__name__)
     app.root_path = request.fspath.dirname
     init_app(app)
+    app.config['SECRET_KEY'] = 'secret_key'
     return app
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,66 @@
+import mock
+import pytest
+
+from flask import session
+from flask_wtf.csrf import CSRFError
+from werkzeug.exceptions import BadRequest, NotFound, InternalServerError, ServiceUnavailable, ImATeapot
+from dmutils.errors import csrf_handler, render_error_page
+from dmutils.external import external as external_blueprint
+
+
+@pytest.mark.parametrize('user_session', (True, False))
+@mock.patch('dmutils.errors.current_app')
+def test_csrf_handler_redirects_to_login(current_app, user_session, app):
+
+    with app.test_request_context('/'):
+        app.config['WTF_CSRF_ENABLED'] = True
+        app.register_blueprint(external_blueprint)
+
+        if user_session:
+            # Our user is logged in
+            session['user_id'] = 1234
+
+        response = csrf_handler(CSRFError())
+
+        assert response.status_code == 302
+        assert response.location == '/user/login?next=%2F'
+
+        if user_session:
+            assert current_app.logger.info.call_args_list == [
+                mock.call('csrf.invalid_token: Aborting request, user_id: {user_id}', extra={'user_id': 1234})
+            ]
+        else:
+            assert current_app.logger.info.call_args_list == [
+                mock.call('csrf.session_expired: Redirecting user to log in page')
+            ]
+
+
+@mock.patch('dmutils.errors.render_template')
+def test_csrf_handler_sends_other_400s_to_render_error_page(render_template, app):
+
+    with app.test_request_context('/'):
+        app.config['WTF_CSRF_ENABLED'] = True
+        app.register_blueprint(external_blueprint)
+
+        assert csrf_handler(BadRequest()) == (render_template.return_value, 400)
+        assert render_template.call_args_list == [mock.call('errors/500.html')]
+
+
+@pytest.mark.parametrize('exception, status_code, expected_template', [
+    (BadRequest, 400, 'errors/500.html'),
+    (NotFound, 404, 'errors/404.html'),
+    (InternalServerError, 500, 'errors/500.html'),
+    (ServiceUnavailable, 503, 'errors/500.html'),
+])
+@mock.patch('dmutils.errors.render_template')
+def test_render_error_page(render_template, exception, status_code, expected_template, app):
+    with app.test_request_context('/'):
+        assert render_error_page(exception()) == (render_template.return_value, status_code)
+        assert render_template.call_args_list == [mock.call(expected_template)]
+
+
+@mock.patch('dmutils.errors.render_template')
+def test_render_error_page_for_unknown_status_code_defaults_to_500(render_template, app):
+    with app.test_request_context('/'):
+        assert render_error_page(ImATeapot()) == (render_template.return_value, 500)
+        assert render_template.call_args_list == [mock.call('errors/500.html')]


### PR DESCRIPTION
Trello: https://trello.com/c/kqjkCP72/101-move-csrf-session-expired-message-to-utils

Copies `render_error_page` and `csrf_handler` from Brief Responses app error handlers. Now with added tests!

This should mean we only need to register handlers for 'unusual' errors in the apps themselves (eg `QuestionNotFoundError`, which can still call the new `dmutils.render_error_page` function). So Brief Responses FE's `app.main.errors` would look like this:

```
from app.main import main
from dmapiclient import APIError
from dmcontent.content_loader import QuestionNotFoundError
from dmutils.errors import render_error_page

@main.app_errorhandler(APIError)
def api_error_handler(e):
    return render_error_page(e)


@main.app_errorhandler(QuestionNotFoundError)
def content_loader_error_handler(e):
    return render_error_page(400)
```

Technically this is not a breaking change, as any 'duplicate' error handlers registered by the app in `main.errors` will overwrite those registered earlier by `flask_init.init_app`. Each app will continue using its own error templates for the moment (these will eventually be moved to the FE toolkit).

Requires a small tweak to conftest to allow access to the session during tests.