### PR TITLE
Add supplier_questions to the external routes

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '42.1.0'
+__version__ = '42.2.0'

--- a/dmutils/external.py
+++ b/dmutils/external.py
@@ -112,3 +112,8 @@ def info_page_for_starting_a_brief(framework_slug, lot_slug):
 @external.route('/buyers/frameworks/<framework_slug>/requirements/user-research-studios')
 def studios_start_page(framework_slug):
     raise NotImplementedError()
+
+
+@external.route('/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/supplier/questions')
+def supplier_questions(framework_slug, lot_slug, brief_id):
+    raise NotImplementedError()


### PR DESCRIPTION
alphagov/digitalmarketplace-brief-responses-frontend requires this route when sending emails to buyers and suppliers about clarification questions on a DOS opportunity.