### PR TITLE
Error handling bug fixes

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '42.3.0'
+__version__ = '42.4.0'

--- a/dmutils/errors.py
+++ b/dmutils/errors.py
@@ -1,5 +1,6 @@
 from flask import redirect, render_template, url_for, flash, session, request, current_app
 from flask_wtf.csrf import CSRFError
+from jinja2.exceptions import TemplateNotFound
 
 
 def csrf_handler(e):
@@ -70,4 +71,9 @@ def render_error_page(e=None, status_code=None):
     if status_code not in template_map:
         status_code = 500
 
-    return render_template(template_map[status_code]), status_code
+    try:
+        # Try app error templates first
+        return render_template(template_map[status_code]), status_code
+    except TemplateNotFound:
+        # Fall back to toolkit error templates
+        return render_template("toolkit/{}".format(template_map[status_code])), status_code

--- a/dmutils/errors.py
+++ b/dmutils/errors.py
@@ -46,7 +46,7 @@ def render_error_page(e=None, status_code=None):
     :return: Flask render_template response. The error templates must be present in the app (either
     copied from the FE Toolkit, or a custom template for that app).
     """
-    if not e or status_code:
+    if not (e or status_code):
         # Something's gone wrong! To save going in an endless error loop let's just render a 500
         status_code = 500
 
@@ -57,11 +57,17 @@ def render_error_page(e=None, status_code=None):
         503: "errors/500.html",
     }
 
-    # Handle exceptions with .status_code, not .code (e.g. dmapiclient.HTTPError)
-    if hasattr(e, 'status_code'):
-        status_code = e.status_code
+    if not status_code:
+        # Handle exceptions with .status_code, not .code (e.g. dmapiclient.HTTPError)
+        if hasattr(e, 'status_code'):
+            status_code = e.status_code
+        elif hasattr(e, 'code'):
+            status_code = e.code
+        else:
+            # Map unknown status codes to 500
+            status_code = 500
 
-    if not status_code or status_code not in template_map:
-        status_code = 500 if e.code not in template_map else e.code
+    if status_code not in template_map:
+        status_code = 500
 
     return render_template(template_map[status_code]), status_code

--- a/dmutils/errors.py
+++ b/dmutils/errors.py
@@ -50,6 +50,10 @@ def render_error_page(e=None, status_code=None):
         503: "errors/500.html",
     }
 
+    # Handle exceptions with .status_code, not .code (e.g. dmapiclient.HTTPError)
+    if hasattr(e, 'status_code'):
+        status_code = e.status_code
+
     if not status_code or status_code not in template_map:
         status_code = 500 if e.code not in template_map else e.code
 

--- a/dmutils/errors.py
+++ b/dmutils/errors.py
@@ -28,7 +28,14 @@ def csrf_handler(e):
         )
 
     flash('Your session has expired. Please log in again.', "error")
-    return redirect(url_for('external.render_login', next=request.path))
+    return redirect_to_login(e)
+
+
+def redirect_to_login(e):
+    if request.method == 'GET':
+        return redirect(url_for('external.render_login', next=request.path))
+    else:
+        return redirect(url_for('external.render_login'))
 
 
 def render_error_page(e=None, status_code=None):

--- a/dmutils/errors.py
+++ b/dmutils/errors.py
@@ -44,7 +44,7 @@ def render_error_page(e=None, status_code=None):
         status_code = 500
 
     template_map = {
-        400: "errors/500.html",
+        400: "errors/400.html",
         404: "errors/404.html",
         500: "errors/500.html",
         503: "errors/500.html",

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -69,6 +69,8 @@ def init_app(
 
     # Register error handlers for CSRF errors and common error status codes
     application.register_error_handler(400, errors.csrf_handler)
+    application.register_error_handler(401, errors.redirect_to_login)
+    application.register_error_handler(403, errors.redirect_to_login)
     application.register_error_handler(404, errors.render_error_page)
     application.register_error_handler(503, errors.render_error_page)
     application.register_error_handler(500, errors.render_error_page)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -63,11 +63,25 @@ def test_unauthorised_redirects_to_login(app):
     (NotFound, 404, 'errors/404.html'),
     (InternalServerError, 500, 'errors/500.html'),
     (ServiceUnavailable, 503, 'errors/500.html'),
+    (mock.Mock(code=None), 500, 'errors/500.html'),
 ])
 @mock.patch('dmutils.errors.render_template')
-def test_render_error_page(render_template, exception, status_code, expected_template, app):
+def test_render_error_page_with_exception(render_template, exception, status_code, expected_template, app):
     with app.test_request_context('/'):
         assert render_error_page(exception()) == (render_template.return_value, status_code)
+        assert render_template.call_args_list == [mock.call(expected_template)]
+
+
+@pytest.mark.parametrize('status_code, expected_template', [
+    (400, 'errors/400.html'),
+    (404, 'errors/404.html'),
+    (500, 'errors/500.html'),
+    (503, 'errors/500.html'),
+])
+@mock.patch('dmutils.errors.render_template')
+def test_render_error_page_with_status_code(render_template, status_code, expected_template, app):
+    with app.test_request_context('/'):
+        assert render_error_page(status_code=status_code) == (render_template.return_value, status_code)
         assert render_template.call_args_list == [mock.call(expected_template)]
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -43,11 +43,11 @@ def test_csrf_handler_sends_other_400s_to_render_error_page(render_template, app
         app.register_blueprint(external_blueprint)
 
         assert csrf_handler(BadRequest()) == (render_template.return_value, 400)
-        assert render_template.call_args_list == [mock.call('errors/500.html')]
+        assert render_template.call_args_list == [mock.call('errors/400.html')]
 
 
 @pytest.mark.parametrize('exception, status_code, expected_template', [
-    (BadRequest, 400, 'errors/500.html'),
+    (BadRequest, 400, 'errors/400.html'),
     (NotFound, 404, 'errors/404.html'),
     (InternalServerError, 500, 'errors/500.html'),
     (ServiceUnavailable, 503, 'errors/500.html'),

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -60,6 +60,17 @@ def test_render_error_page(render_template, exception, status_code, expected_tem
 
 
 @mock.patch('dmutils.errors.render_template')
+def test_render_error_page_with_custom_http_exception(render_template, app):
+    class CustomHTTPError(Exception):
+        def __init__(self):
+            self.status_code = 500
+
+    with app.test_request_context('/'):
+        assert render_error_page(CustomHTTPError()) == (render_template.return_value, 500)
+        assert render_template.call_args_list == [mock.call('errors/500.html')]
+
+
+@mock.patch('dmutils.errors.render_template')
 def test_render_error_page_for_unknown_status_code_defaults_to_500(render_template, app):
     with app.test_request_context('/'):
         assert render_error_page(ImATeapot()) == (render_template.return_value, 500)


### PR DESCRIPTION
Trello: https://trello.com/c/kqjkCP72/101-move-csrf-session-expired-message-to-utils

Fixes a bug introduced in https://github.com/alphagov/digitalmarketplace-utils/pull/435.

Errors returned by the API Client have the attribute `status_code` instead of `code`. 

Also:
- maps 400 errors to a 400.html template
- redirects 401 and 403 errors to the login page