### PR TITLE
Add value property to selection buttons

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '42.2.1'
+__version__ = '42.3.0'

--- a/dmutils/forms/fields.py
+++ b/dmutils/forms/fields.py
@@ -52,6 +52,13 @@ class DMBooleanField(DMFieldMixin, wtforms.fields.BooleanField):
     def options(self):
         return [{"label": self.label.text, "value": self.data}]
 
+    @property
+    def value(self):
+        if not self.data or self.data == "None":
+            return []
+        else:
+            return [self.data]
+
 
 class DMDecimalField(DMFieldMixin, wtforms.fields.DecimalField):
     pass
@@ -74,7 +81,7 @@ class DMIntegerField(DMFieldMixin, wtforms.fields.IntegerField):
     pass
 
 
-class DMRadioField(DMFieldMixin, DMSelectFieldMixin, wtforms.fields.RadioField):
+class DMRadioField(DMSelectFieldMixin, DMFieldMixin, wtforms.fields.RadioField):
     widget = DMRadioInput()
 
     type = "radio"

--- a/dmutils/forms/mixins.py
+++ b/dmutils/forms/mixins.py
@@ -38,7 +38,6 @@ or the very excellent `Python Cookbook`_ by David Beazley.
 from copy import copy
 
 from wtforms.compat import text_type
-from wtforms.fields import SelectField
 
 
 class DMFieldMixin:
@@ -78,7 +77,7 @@ class DMFieldMixin:
             return None
 
 
-class DMSelectFieldMixin(SelectField):
+class DMSelectFieldMixin:
     '''
     A Digital Marketplace wrapper for selection fields.
 
@@ -93,7 +92,7 @@ class DMSelectFieldMixin(SelectField):
     then `options` will take precedence.
     '''
     def __init__(self, label=None, validators=None, coerce=text_type, options=None, **kwargs):
-        super().__init__(label, validators, coerce, **kwargs)
+        super().__init__(label, validators=validators, coerce=coerce, **kwargs)
         if options:
             self.options = copy(options)
 
@@ -114,3 +113,10 @@ class DMSelectFieldMixin(SelectField):
                         'value': value,
                     }
                 )
+
+    @property
+    def value(self):
+        if not self.data or self.data == "None":
+            return None
+        else:
+            return self.data

--- a/dmutils/forms/widgets.py
+++ b/dmutils/forms/widgets.py
@@ -35,10 +35,6 @@ class DMSelectionButtonBase(DMJinjaWidgetBase):
     template_args = ["type", "inline", "options"]
     template_file = "toolkit/forms/selection-buttons.html"
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.template_args.remove("value")
-
     def __call__(self, field, **kwargs):
         kwargs["type"] = self.type
         return super().__call__(field, **kwargs)

--- a/tests/forms/test_dm_boolean_field.py
+++ b/tests/forms/test_dm_boolean_field.py
@@ -1,0 +1,14 @@
+import pytest
+
+import wtforms
+
+from dmutils.forms.fields import DMBooleanField
+
+
+class BooleanForm(wtforms.Form):
+    field = DMBooleanField()
+
+
+@pytest.fixture
+def form():
+    return BooleanForm()

--- a/tests/forms/test_dm_boolean_field.py
+++ b/tests/forms/test_dm_boolean_field.py
@@ -12,3 +12,11 @@ class BooleanForm(wtforms.Form):
 @pytest.fixture
 def form():
     return BooleanForm()
+
+
+def test_value_is_a_list(form):
+    assert isinstance(form.field.value, list)
+
+
+def test_value_is_empty_list_if_there_is_no_selection(form):
+    assert form.field.value == []

--- a/tests/forms/test_dm_radio_field.py
+++ b/tests/forms/test_dm_radio_field.py
@@ -27,6 +27,16 @@ def form():
     return RadioForm()
 
 
+@pytest.fixture(params=["yes", "no"])
+def form_with_selection(request):
+    return (RadioForm(data={"field": request.param}), request.param)
+
+
+@pytest.fixture(params=["true", "false", "garbage", ""])
+def form_with_invalid_selection(request):
+    return (RadioForm(data={"field": request.param}), request.param)
+
+
 def test_dm_radio_field_has_options_property(form):
     assert form.field.options
 
@@ -49,5 +59,31 @@ def test_constructor_accepts_choices_parameter():
     assert form.field.choices
 
 
+def test_value_is_none_if_there_is_no_selection(form):
+    assert form.field.value is None
+
+
+def test_value_is_the_selected_radio_button(form_with_selection):
+    form, selection = form_with_selection
+    assert form.field.value == selection
+
+
+def test_validation_succeeds_if_value_is_in_options(form_with_selection):
+    form, _ = form_with_selection
+    assert form.validate()
+
+
+def test_validation_fails_if_value_is_not_in_options(form_with_invalid_selection):
+    form, _ = form_with_invalid_selection
+    assert not form.validate()
+
+
 def test_iter_choices(form):
     assert list(form.field.iter_choices()) == [("yes", "Yes", False), ("no", "No", False)]
+
+
+def test_iter_choices_with_selection():
+    form = RadioForm(data={"field": "yes"})
+    assert list(form.field.iter_choices()) == [("yes", "Yes", True), ("no", "No", False)]
+    form = RadioForm(data={"field": "no"})
+    assert list(form.field.iter_choices()) == [("yes", "Yes", False), ("no", "No", True)]

--- a/tests/forms/test_dm_radio_field.py
+++ b/tests/forms/test_dm_radio_field.py
@@ -47,3 +47,7 @@ def test_constructor_accepts_choices_parameter():
     form = RadioForm()
 
     assert form.field.choices
+
+
+def test_iter_choices(form):
+    assert list(form.field.iter_choices()) == [("yes", "Yes", False), ("no", "No", False)]


### PR DESCRIPTION
This commit adds the value property to selection button fields such as DMRadioField and DMBooleanField.

This means that the selection will persist if there is for instance a validation error.

It also improved backwards-compatibility with our codebase, which will make refactoring apps to use dmutils.forms features easier.

This code is needed to close Trello ticket [#77](https://trello.com/c/7QyecIBr/77-refactor-admin-frontend-to-use-new-dmutilsforms-features).