### PR TITLE
Refactor dmwidgets and add TextArea widget

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '42.7.0'
+__version__ = '42.8.0'

--- a/dmutils/forms/fields.py
+++ b/dmutils/forms/fields.py
@@ -157,8 +157,8 @@ class DMDateField(DMFieldMixin, wtforms.fields.Field):
         month = wtforms.fields.IntegerField("Month")
         year = wtforms.fields.IntegerField("Year")
 
-    def __init__(self, label=None, validators=None, hint=None, separator='-', **kwargs):
-        super().__init__(label=label, validators=validators, hint=hint, **kwargs)
+    def __init__(self, label=None, validators=None, hint=None, question_advice=None, separator='-', **kwargs):
+        super().__init__(label=label, validators=validators, hint=hint, question_advice=question_advice, **kwargs)
         self.form_field = wtforms.fields.FormField(self._DateForm, separator=separator, **kwargs)
 
     def _value(self):

--- a/dmutils/forms/mixins.py
+++ b/dmutils/forms/mixins.py
@@ -56,9 +56,10 @@ class DMFieldMixin:
     Derived classes which include this mixin should have a
     subclass of `wtforms.Field` in their base classes.
     '''
-    def __init__(self, label=None, validators=None, hint=None, **kwargs):
+    def __init__(self, label=None, validators=None, hint=None, question_advice=None, **kwargs):
         super().__init__(label=label, validators=validators, **kwargs)
         self.hint = hint or getattr(self.__class__, 'hint', None)
+        self.question_advice = question_advice or getattr(self.__class__, 'question_advice', None)
         self.type = getattr(self.__class__, 'type', self.type)
 
     @property

--- a/dmutils/forms/mixins.py
+++ b/dmutils/forms/mixins.py
@@ -58,8 +58,14 @@ class DMFieldMixin:
     '''
     def __init__(self, label=None, validators=None, hint=None, question_advice=None, **kwargs):
         super().__init__(label=label, validators=validators, **kwargs)
-        self.hint = hint or getattr(self.__class__, 'hint', None)
-        self.question_advice = question_advice or getattr(self.__class__, 'question_advice', None)
+        if hint:
+            self.hint = hint
+        if question_advice:
+            self.question_advice = question_advice
+
+        # wtforms.Field overwrites self.type on init
+        # if we want to specify it on a subclass
+        # this line will bring it back
         self.type = getattr(self.__class__, 'type', self.type)
 
     @property

--- a/dmutils/forms/mixins.py
+++ b/dmutils/forms/mixins.py
@@ -66,6 +66,10 @@ class DMFieldMixin:
     def question(self):
         return self.label.text
 
+    @question.setter
+    def question(self, value):
+        self.label.text = value
+
     @property
     def value(self):
         return self._value()

--- a/dmutils/forms/widgets.py
+++ b/dmutils/forms/widgets.py
@@ -1,7 +1,7 @@
 
 from flask import current_app
 
-__all__ = ["DMCheckboxInput", "DMDateInput", "DMRadioInput", "DMTextInput", "DMUnitInput"]
+__all__ = ["DMCheckboxInput", "DMDateInput", "DMRadioInput", "DMTextInput", "DMTextArea", "DMUnitInput"]
 
 
 class DMJinjaWidgetBase:
@@ -75,6 +75,16 @@ class DMRadioInput(DMSelectionButtonBase):
 
 class DMTextInput(DMJinjaWidgetBase):
     __template_file__ = "toolkit/forms/textbox.html"
+
+
+class DMTextArea(DMTextInput):
+    large = True
+
+    def __init__(self, max_length_in_words=None, **kwargs):
+        if max_length_in_words:
+            self.max_length_in_words = max_length_in_words
+
+        super().__init__(**kwargs)
 
 
 class DMUnitInput(DMTextInput):

--- a/dmutils/forms/widgets.py
+++ b/dmutils/forms/widgets.py
@@ -8,15 +8,25 @@ class DMJinjaWidgetBase:
 
     template_args = []
 
-    def __init__(self, hide_question=False):
+    def __init__(self, hide_question=False, **kwargs):
         # we include common template arguments here to avoid repetition
         self.template_args = ["error", "name", "hint", "question", "value"] + self.template_args
+
+        # kwargs can be used to add constants to the template_args
+        self.template_constants = kwargs
+
         if hide_question:
             self.template_args.remove("question")
 
         self.template = None
 
     def __call__(self, field, **kwargs):
+        # we use setdefault here and below so that keyword arguments
+        # provided to __call__ take precedence
+        if self.template_constants:
+            for k, v in self.template_constants.items():
+                kwargs.setdefault(k, v)
+
         # get the template variables from the field
         for attr in self.template_args:
             if hasattr(field, attr):
@@ -35,8 +45,11 @@ class DMSelectionButtonBase(DMJinjaWidgetBase):
     template_args = ["type", "inline", "options"]
     template_file = "toolkit/forms/selection-buttons.html"
 
+    def __init__(self, **kwargs):
+        kwargs.setdefault("type", self.type)
+        super().__init__(**kwargs)
+
     def __call__(self, field, **kwargs):
-        kwargs["type"] = self.type
         return super().__call__(field, **kwargs)
 
 
@@ -47,8 +60,8 @@ class DMCheckboxInput(DMSelectionButtonBase):
 class DMDateInput(DMJinjaWidgetBase):
     template_file = "toolkit/forms/date.html"
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.template_args.remove("value")
 
     def __call__(self, field, **kwargs):

--- a/dmutils/forms/widgets.py
+++ b/dmutils/forms/widgets.py
@@ -11,6 +11,7 @@ class DMJinjaWidgetBase:
     name = None
     hint = None
     question = None
+    question_advice = None
     value = None
 
     def __init__(self, hide_question=False, **kwargs):

--- a/tests/forms/test_dmfields.py
+++ b/tests/forms/test_dmfields.py
@@ -24,3 +24,11 @@ def test_field_has_hint_property(field_class):
 
     form = TestForm()
     assert form.field.hint == 'Hint text.'
+
+
+def test_field_has_question_advice_property(field_class):
+    class TestForm(wtforms.Form):
+        field = field_class(question_advice="Advice text.")
+
+    form = TestForm()
+    assert form.field.question_advice == "Advice text."

--- a/tests/forms/test_dmfields.py
+++ b/tests/forms/test_dmfields.py
@@ -3,12 +3,12 @@ import pytest
 
 import wtforms
 
-import dmutils.forms.fields as dm_fields
+import dmutils.forms.fields
 
 
-@pytest.fixture(params=dm_fields.__all__)
+@pytest.fixture(params=dmutils.forms.fields.__all__)
 def field_class(request):
-    return getattr(dm_fields, request.param)
+    return getattr(dmutils.forms.fields, request.param)
 
 
 def test_field_can_be_class_property(field_class):
@@ -26,9 +26,42 @@ def test_field_has_hint_property(field_class):
     assert form.field.hint == 'Hint text.'
 
 
+def test_field_class_can_have_default_hint():
+    class TestField(dmutils.forms.fields.DMFieldMixin, wtforms.Field):
+        hint = "Hint text."
+
+    class TestForm(wtforms.Form):
+        field = TestField()
+
+    form = TestForm()
+    assert form.field.hint == "Hint text."
+
+
 def test_field_has_question_advice_property(field_class):
     class TestForm(wtforms.Form):
         field = field_class(question_advice="Advice text.")
 
     form = TestForm()
     assert form.field.question_advice == "Advice text."
+
+
+def test_field_class_can_have_default_question_advice():
+    class TestField(dmutils.forms.fields.DMFieldMixin, wtforms.Field):
+        question_advice = "Advice text."
+
+    class TestForm(wtforms.Form):
+        field = TestField()
+
+    form = TestForm()
+    assert form.field.question_advice == "Advice text."
+
+
+def test_field_class_can_have_type():
+    class TestField(dmutils.forms.fields.DMFieldMixin, wtforms.Field):
+        type = "test_field"
+
+    class TestForm(wtforms.Form):
+        field = TestField()
+
+    form = TestForm()
+    assert form.field.type == "test_field"

--- a/tests/forms/test_dmwidgets.py
+++ b/tests/forms/test_dmwidgets.py
@@ -65,6 +65,39 @@ def test_arguments_can_be_added_to_template_context_from_widget_constructor(widg
     assert get_render_context(widget)["foo"] == "bar"
 
 
+class TestDMTextArea:
+    @pytest.fixture()
+    def widget_class(self):
+        return monkeypatch_render(dmutils.forms.widgets.DMTextArea)
+
+    def test_dm_text_area_sends_large_is_true_to_template(self, widget, field):
+        widget(field)
+        assert get_render_context(widget)["large"] is True
+
+    @pytest.mark.parametrize("max_length_in_words", (1, 45, 100))
+    def test_dm_text_area_can_send_max_length_in_words_to_template(self, widget_class, max_length_in_words, field):
+        widget = widget_class()
+        widget(field)
+        assert "max_length_in_words" not in get_render_context(widget)
+
+        widget = widget_class(max_length_in_words=max_length_in_words)
+        widget(field)
+        assert get_render_context(widget)["max_length_in_words"] == max_length_in_words
+
+    def test_dm_text_area_max_words_template_constant_is_instance_variable(self, widget_class):
+        widget1 = widget_class(max_length_in_words=mock.sentinel.max_length1)
+        widget2 = widget_class(max_length_in_words=mock.sentinel.max_length2)
+
+        widget1(mock.Mock())
+        widget2(mock.Mock())
+
+        assert (
+            get_render_context(widget1)["max_length_in_words"]
+            !=
+            get_render_context(widget2)["max_length_in_words"]
+        )
+
+
 class TestDMDateInput:
     @pytest.fixture()
     def widget_class(self):

--- a/tests/forms/test_dmwidgets.py
+++ b/tests/forms/test_dmwidgets.py
@@ -32,3 +32,10 @@ def test_template_render_args_are_populated_from_field(widget, field):
     for k in widget.template_args:
         assert k in dir(field)
         assert k in widget.template.render.call_args[1]
+
+
+def test_template_constants_are_passed_as_parameters_to_template_render(widget, field):
+    widget(field)
+    for k, v in widget.template_constants.items():
+        assert k in widget.template.render.call_args[1]
+        assert widget.template.render.call_args[1][k] == v

--- a/tests/forms/test_dmwidgets.py
+++ b/tests/forms/test_dmwidgets.py
@@ -1,0 +1,34 @@
+
+import mock
+import pytest
+
+import dmutils.forms.widgets as dm_widgets
+
+
+@pytest.fixture(params=dm_widgets.__all__)
+def widget_class(request):
+    return getattr(dm_widgets, request.param)
+
+
+@pytest.fixture
+def widget(widget_class):
+    widget = widget_class()
+    widget.template = mock.Mock()
+    return widget
+
+
+@pytest.fixture
+def field():
+    return mock.Mock()
+
+
+def test_calling_widget_calls_template_render(widget, field):
+    widget(field)
+    assert widget.template.render.called
+
+
+def test_template_render_args_are_populated_from_field(widget, field):
+    widget(field)
+    for k in widget.template_args:
+        assert k in dir(field)
+        assert k in widget.template.render.call_args[1]

--- a/tests/forms/test_dmwidgets.py
+++ b/tests/forms/test_dmwidgets.py
@@ -53,6 +53,12 @@ def test_template_context_includes_hint(widget, field):
     assert get_render_context(widget)["hint"] == "Hint text."
 
 
+def test_template_context_includes_question_advice(widget, field):
+    field.question_advice = "Advice text."
+    widget(field)
+    assert get_render_context(widget)["question_advice"] == "Advice text."
+
+
 def test_arguments_can_be_added_to_template_context_from_widget_constructor(widget_class, field):
     widget = widget_class(foo="bar")
     widget(field)


### PR DESCRIPTION
This PR has two main things:

## New widget
I've added a TextArea widget (needed for some apps including briefs-frontend)

## Refactored widgets
I've tried to make it easier to add new widgets based on DMJinjaWidgetBase by using a more declarative style; for instance, look at [DMSelectionButtonBase](https://github.com/alphagov/digitalmarketplace-utils/pull/444/files?utf8=%E2%9C%93&diff=unified#diff-e33286de9492b8dbcf36134ad0a6117cL34)

---

This PR also has some more attributes for forms and more tests for widgets thrown in for free