### PR TITLE
Remove unused dependencies from utils

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '43.0.0'
+__version__ = '43.1.0'

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
          'boto3==1.4.8',
          'contextlib2==0.4.0',
          'cryptography==2.3',
-         'inflection==0.3.1',
          'mailchimp3==2.0.11',
          'mandrill==1.0.57',
          'monotonic==0.3',
@@ -38,8 +37,6 @@ setup(
          'odfpy==1.3.6',
          'python-json-logger==0.1.4',
          'pytz==2015.4',
-         'pyyaml==3.11',
-         'six==1.11.0',
          'unicodecsv==0.14.1',
          'Werkzeug==0.14.1',
          'workdays==1.4'


### PR DESCRIPTION
Trello: https://trello.com/c/UEUfolNI/536-dependency-review-for-utils

Utils no longer uses:
- `inflection` (string pluralisation, not used in utils)
- `pyyaml` (yaml parsing, no longer used in utils)
- `six` (Python 2 support, no longer needed)

This shouldn't be a breaking change. All three are requirements for the content loader (with the same versions) so would still be pulled in by any apps needing them:
- Buyer FE and Briefs FE use `inflection`
- Some helper functions in the Search API and the Brief Responses FE still use `six` (though they should no longer need to - that's a separate ticket).