### PR TITLE
Expose helper functions for validating email addresses and getting multiple email addresses from a string

### DIFF
--- a/dmutils/email/helpers.py
+++ b/dmutils/email/helpers.py
@@ -5,6 +5,10 @@ import hashlib
 import re
 
 
+# List of characters that could be used to separate email addresses,
+# in decreasing precedence order.
+EMAIL_ADDRESS_SEPARATORS = [";", ",", "/"]
+
 # Largely copied from https://github.com/alphagov/notifications-utils/blob/\
 #   67889886ec1476136d12e7f32787a7dbd0574cc2/notifications_utils/recipients.py
 #
@@ -67,3 +71,36 @@ def validate_email_address(email_address):
         return False
 
     return True
+
+
+def get_email_addresses(string, separators=EMAIL_ADDRESS_SEPARATORS):
+    """
+    Returns a list of email addresses from a string.
+
+    It does not validate the email addresses.
+
+    @param separators   list of characters that could be
+                        used to separate email addresses
+
+    >>> from dmutils.email.helpers import email_addresses
+    >>> email_addresses("bob@blob.com ")
+    ['bob@blob.com']
+    >>> email_addresses("bob@blob.com; bob.blob@job.com")
+    ['bob@blob.com', 'bob.blob@job.com']
+    >>> email_addresses("bob@blob.com /  bob.blob@job.com")
+    ['bob@blob.com', 'bob.blob@job.com']
+    >>> email_addresses("bob@invalid;bob.blob@job.com")
+    ['bob@invalid', 'bob.blob@job.com']
+    >>> email_addresses("bob@blob;bob.blob@job.com;bob@blob..invalid")
+    ['bob@blob', 'bob.blob@job.com', 'bob@blob..invalid']
+    """
+
+    addresses = [string]
+    for sep in separators:
+        if sep in string:
+            addresses = string.split(sep)
+            break  # earlier separators take precedence
+
+    addresses = [s.strip() for s in addresses if s]
+
+    return addresses

--- a/dmutils/email/helpers.py
+++ b/dmutils/email/helpers.py
@@ -2,9 +2,68 @@
 """Email helpers."""
 import base64
 import hashlib
+import re
+
+
+# Largely copied from https://github.com/alphagov/notifications-utils/blob/\
+#   67889886ec1476136d12e7f32787a7dbd0574cc2/notifications_utils/recipients.py
+#
+# regexes for use in validate_email_address.
+# invalid local chars - whitespace, quotes and apostrophes, semicolons and colons, GBP sign
+# Note: Normal apostrophe eg `Firstname-o'surname@domain.com` is allowed.
+INVALID_LOCAL_CHARS = r"\s\",;:@£“”‘’"
+email_regex = re.compile(r'^[^{}]+@([^.@][^@]+)$'.format(INVALID_LOCAL_CHARS))
+hostname_part = re.compile(r'^(xn-|[a-z0-9]+)(-[a-z0-9]+)*$', re.IGNORECASE)
+tld_part = re.compile(r'^([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)$', re.IGNORECASE)
 
 
 def hash_string(string):
     """Hash a given string."""
     m = hashlib.sha256(str(string).encode('utf-8'))
     return base64.urlsafe_b64encode(m.digest()).decode('utf-8')
+
+
+def validate_email_address(email_address):
+    """Return True if `email_address` is valid, otherwise returns False"""
+
+    # Largely a straight copy from https://github.com/alphagov/notifications-utils/blob/\
+    #   67889886ec1476136d12e7f32787a7dbd0574cc2/notifications_utils/recipients.py#L439 onwards so that we have
+    # validity-parity with Notify and minimise nasty surprises once we attempt to send an email to this address via
+    # Notify and only find out it won't be accepted once it's too late to give the user a sane validation message
+
+    # almost exactly the same as by https://github.com/wtforms/wtforms/blob/master/wtforms/validators.py,
+    # with minor tweaks for SES compatibility - to avoid complications we are a lot stricter with the local part
+    # than neccessary - we don't allow any double quotes or semicolons to prevent SES Technical Failures
+    email_address = (email_address or "").strip()
+    match = re.match(email_regex, email_address)
+
+    # not an email
+    if not match:
+        return False
+
+    hostname = match.group(1)
+    # don't allow consecutive periods in domain names
+    if '..' in hostname:
+        return False
+
+    # idna = "Internationalized domain name" - this encode/decode cycle converts unicode into its accurate ascii
+    # representation as the web uses. '例え.テスト'.encode('idna') == b'xn--r8jz45g.xn--zckzah'
+    try:
+        hostname = hostname.encode('idna').decode('ascii')
+    except UnicodeError:
+        return False
+
+    parts = hostname.split('.')
+
+    if len(hostname) > 253 or len(parts) < 2:
+        return False
+
+    for part in parts:
+        if not part or len(part) > 63 or not hostname_part.match(part):
+            return False
+
+    # if the part after the last . is not a valid TLD then bail out
+    if not tld_part.match(parts[-1]):
+        return False
+
+    return True

--- a/tests/email/test_helpers.py
+++ b/tests/email/test_helpers.py
@@ -1,0 +1,30 @@
+
+import pytest
+
+from dmutils.email.helpers import get_email_addresses
+
+
+@pytest.mark.parametrize(
+    ("multiple_email_addresses", "expected"), (
+        ("grace.hopper@example.com",
+            ["grace.hopper@example.com"]),
+        ("sally_ride@space.example ",
+            ["sally_ride@space.example"]),
+        ("bob@blob.example / bob.blob@job.example",
+            ["bob@blob.example", "bob.blob@job.example"]),
+        ("annie.jump.cannon@example.email; mary.brück@email.example",
+            ["annie.jump.cannon@example.email", "mary.brück@email.example"]),
+        ("margrete.bose@physics.example,noether1882@erlangen.example,jocelyn.bell-burnell@lgm-1.example",
+            ["margrete.bose@physics.example", "noether1882@erlangen.example", "jocelyn.bell-burnell@lgm-1.example"]),
+        ("foobar / barfoo",
+            ["foobar", "barfoo"]),
+        ("bob@blob",
+            ["bob@blob"]),
+        ("bob@blob.com;bob.blob@job..com",
+            ["bob@blob.com", "bob.blob@job..com"]),
+        ("Please send emails to bob@blob.com",
+            ["Please send emails to bob@blob.com"]),
+    )
+)
+def test_get_email_addresses_returns_list_of_valid_email_addresses(multiple_email_addresses, expected):
+    assert get_email_addresses(multiple_email_addresses) == expected

--- a/tests/forms/test_validators.py
+++ b/tests/forms/test_validators.py
@@ -1,0 +1,54 @@
+
+import pytest
+import mock
+
+from wtforms.validators import ValidationError
+
+import dmutils.forms.validators
+
+
+@pytest.fixture
+def form():
+    return mock.Mock()
+
+
+@pytest.fixture
+def field():
+    return mock.Mock()
+
+
+@pytest.mark.parametrize(
+    "invalid_email_address", (
+        None,
+        "",
+        "foobar",
+        "bob@blob",
+        "cecilia.payne@sub-domain..domain.example",
+        "annie-jump-cannon@harvard-computers.example;henrietta-swan-leavitt@harvard-computers.example",
+        "Please send emails to b o b at b l o b dot example",
+    )
+)
+def test_email_validator_raises_validation_error_on_an_invalid_email_address(form, field, invalid_email_address):
+    validator = dmutils.forms.validators.EmailValidator()
+    field.data = invalid_email_address
+
+    with pytest.raises(ValidationError):
+        validator(form, field)
+
+
+@pytest.mark.parametrize(
+    "email_address", (
+        "bob@blob.com",
+        "test@example.com",
+        "user@user.marketplace.team",
+        "annie.j.easley@example.test",
+        "books@bücher.example",
+        "मीनाक्षी@email.example",
+        "我買@屋企.香港",
+    )
+)
+def test_email_validator_does_not_raise_on_a_valid_email_address(form, field, email_address):
+    validator = dmutils.forms.validators.EmailValidator()
+    field.data = email_address
+
+    validator(form, field)


### PR DESCRIPTION
A lot of our scripts send out emails to users based on addresses that they supply. These addresses have historically been collected from a form and stored in the database without any validation of the input. This means that we now have some failures where the user has tried to supply multiple addresses in one string (see [this ticket](https://trello.com/c/DHDgBuns)).

This PR tries to make it so that in future we can change our scripts so that a) they can handle strings that contain multiple email addresses; and b) they can try to validate the email addresses before they call Notify.

It does this by exposing the email validation algorithm that was recently added by @risicle as a helper function, and also by adding a new helper function that splits a string based on a set of characters to generate a list of possible email addresses.