### PR TITLE
Make the DMNotifyClient class a bit more ergonomic

### DIFF
--- a/dmutils/email/dm_mandrill.py
+++ b/dmutils/email/dm_mandrill.py
@@ -5,57 +5,72 @@ from flask._compat import string_types
 
 from mandrill import Mandrill
 from dmutils.email.exceptions import EmailError
-from dmutils.email.helpers import hash_string
 from dmutils.timing import logged_duration_for_external_request as log_external_request
 
 
-def send_email(to_email_addresses, email_body, api_key, subject, from_email, from_name, tags, reply_to=None,
-               metadata=None, logger=None):
-    logger = logger or current_app.logger
+class DMMandrillClient:
+    def __init__(self, api_key=None, *, logger=None):
+        if api_key is None:
+            api_key = current_app.config["DM_MANDRILL_API_KEY"]
 
-    if isinstance(to_email_addresses, string_types):
-        to_email_addresses = [to_email_addresses]
+        self.logger = logger or current_app.logger
+        self.client = Mandrill(api_key)
 
-    try:
-        mandrill_client = Mandrill(api_key)
+    def get_sent_emails(self, tags, date_from=None):
+        return self.client.messages.search(tags=tags, date_from=date_from, limit=1000)
 
-        message = {
-            'html': email_body,
-            'subject': subject,
-            'from_email': from_email,
-            'from_name': from_name,
-            'to': [{
-                'email': email_address,
-                'type': 'to'
-            } for email_address in to_email_addresses],
-            'important': False,
-            'track_opens': False,
-            'track_clicks': False,
-            'auto_text': True,
-            'tags': tags,
-            'metadata': metadata,
-            'headers': {'Reply-To': reply_to or from_email},
-            'preserve_recipients': False,
-            'recipient_metadata': [{
-                'rcpt': email_address
-            } for email_address in to_email_addresses]
-        }
+    def send_email(
+        self,
+        to_email_addresses,
+        from_email_address,
+        from_name,
+        email_body,
+        subject,
+        tags,
+        reply_to=None,
+        metadata=None,
+    ):
+        if isinstance(to_email_addresses, string_types):
+            to_email_addresses = [to_email_addresses]
 
-        with log_external_request(service='Mandrill', logger=logger):
-            result = mandrill_client.messages.send(message=message, async=True)
+        try:
+            message = {
+                'html': email_body,
+                'subject': subject,
+                'from_email': from_email_address,
+                'from_name': from_name,
+                'to': [{
+                    'email': email_address,
+                    'type': 'to'
+                } for email_address in to_email_addresses],
+                'important': False,
+                'track_opens': False,
+                'track_clicks': False,
+                'auto_text': True,
+                'tags': tags,
+                'metadata': metadata,
+                'headers': {'Reply-To': reply_to or from_email_address},
+                'preserve_recipients': False,
+                'recipient_metadata': [{
+                    'rcpt': email_address
+                } for email_address in to_email_addresses]
+            }
 
-    except Exception as e:
-        # Anything that Mandrill throws will be rethrown in a manner consistent with out other email backends.
-        # Note that this isn't just `mandrill.Error` exceptions, because the mandrill client also sometimes throws
-        # things like JSONDecodeError (sad face).
-        logger.error("Failed to send an email: {error}", extra={'error': e})
-        raise EmailError(e)
+            with log_external_request(service='Mandrill', logger=self.logger):
+                result = self.client.messages.send(message=message, async=True)
 
-    logger.info("Sent {tags} response: id={id}, email={email_hash}",
-                extra={'tags': tags, 'id': result[0]['_id'], 'email_hash': hash_string(result[0]['email'])})
+        except Exception as e:
+            # Anything that Mandrill throws will be rethrown in a manner consistent with out other email backends.
+            # Note that this isn't just `mandrill.Error` exceptions, because the mandrill client also sometimes throws
+            # things like JSONDecodeError (sad face).
+            self.logger.error(
+                "Error sending email: {error}",
+                extra={
+                    "client": self.client.__class__,
+                    "error": e,
+                    "tags": tags,
+                },
+            )
+            raise EmailError(e)
 
-
-def get_sent_emails(mandrill_api_key, tags, date_from=None):
-    mandrill_client = Mandrill(mandrill_api_key)
-
-    return mandrill_client.messages.search(tags=tags, date_from=date_from, limit=1000)
+        return result


### PR DESCRIPTION
Since we are customising the NotifyClient for our own purposes, we might 
as well make it fit our systems a bit better.

This commit makes two small changes to make using DMNotifyClient a bit 
less annoying; it automatically gets the API key from the current app 
config, and it looks up the template uuid for you if you want it to.

You don't have to use these features, but they might make your life 
better ;)