### PR TITLE
18 flask 1x upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 Records breaking changes from major version bumps
 
-
-## 44.0.0
+## 44.0.0
 
 PR [#455](https://github.com/alphagov/digitalmarketplace-utils/pull/455)
 
@@ -13,7 +12,23 @@ Apps should upgrade to `Flask==1.0.2` using the changelog here http://flask.poco
 the breaking changes in [v1.0](http://flask.pocoo.org/docs/1.0/changelog/#version-1-0) 
 
 
-## 43.0.0
+Updates to DMNotifyClient and addition of `DMMandrillClient`:
+
+`DMNotifyClient.__init__ `parameter logger is now keyword-only
+
+`DMNotifyClient.get_error_message` method has been deleted
+
+`DMNotifyClient.send_email` parameter email_address has been renamed to to_email_address
+
+`DMNotifyClient.get_reference` parameter email_adress has been renamed to to_email_address
+
+dm_mandrill now contains a single class `DMMandrillClient`
+
+`dm_mandrill.send_email` has been deleted. Its functionality has been moved to `DMMandrillClient.send_email`, however the function signature has changed.
+
+`dm_mandrill.get_sent_emails` has been deleted. Its functionality has been moved to `DMMandrillClient.get_sent_emails`, however the function signature has changed.
+
+## 43.0.0
 
 PR [#447](https://github.com/alphagov/digitalmarketplace-utils/pull/447)
 
@@ -30,7 +45,7 @@ initialization of FeatureFlags for the app.
 The dependency on Flask has been upgraded to Flask 0.12, so potentially apps are going to have to make changes
 in concordance with http://flask.pocoo.org/docs/0.12/changelog/
 
-## 42.0.0
+## 42.0.0
 
 PR [#400](https://github.com/alphagov/digitalmarketplace-utils/pull/400)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Records breaking changes from major version bumps
 
+
+## 44.0.0
+
+PR [#455](https://github.com/alphagov/digitalmarketplace-utils/pull/455)
+
+Upgrade flask to from 0.12.4 to 1.0.2. This has breaking changes for flask apps and therefore has breaking changes for users relying on init_app.
+
+Apps should upgrade to `Flask==1.0.2` using the changelog here http://flask.pocoo.org/docs/1.0/changelog/#version-1-0-2 taking care to note
+the breaking changes in [v1.0](http://flask.pocoo.org/docs/1.0/changelog/#version-1-0) 
+
+
 ## 43.0.0
 
 PR [#447](https://github.com/alphagov/digitalmarketplace-utils/pull/447)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '43.4.0'
+__version__ = '44.0.0'

--- a/dmutils/email/dm_mandrill.py
+++ b/dmutils/email/dm_mandrill.py
@@ -5,57 +5,72 @@ from flask._compat import string_types
 
 from mandrill import Mandrill
 from dmutils.email.exceptions import EmailError
-from dmutils.email.helpers import hash_string
 from dmutils.timing import logged_duration_for_external_request as log_external_request
 
 
-def send_email(to_email_addresses, email_body, api_key, subject, from_email, from_name, tags, reply_to=None,
-               metadata=None, logger=None):
-    logger = logger or current_app.logger
+class DMMandrillClient:
+    def __init__(self, api_key=None, *, logger=None):
+        if api_key is None:
+            api_key = current_app.config["DM_MANDRILL_API_KEY"]
 
-    if isinstance(to_email_addresses, string_types):
-        to_email_addresses = [to_email_addresses]
+        self.logger = logger or current_app.logger
+        self.client = Mandrill(api_key)
 
-    try:
-        mandrill_client = Mandrill(api_key)
+    def get_sent_emails(self, tags, date_from=None):
+        return self.client.messages.search(tags=tags, date_from=date_from, limit=1000)
 
-        message = {
-            'html': email_body,
-            'subject': subject,
-            'from_email': from_email,
-            'from_name': from_name,
-            'to': [{
-                'email': email_address,
-                'type': 'to'
-            } for email_address in to_email_addresses],
-            'important': False,
-            'track_opens': False,
-            'track_clicks': False,
-            'auto_text': True,
-            'tags': tags,
-            'metadata': metadata,
-            'headers': {'Reply-To': reply_to or from_email},
-            'preserve_recipients': False,
-            'recipient_metadata': [{
-                'rcpt': email_address
-            } for email_address in to_email_addresses]
-        }
+    def send_email(
+        self,
+        to_email_addresses,
+        from_email_address,
+        from_name,
+        email_body,
+        subject,
+        tags,
+        reply_to=None,
+        metadata=None,
+    ):
+        if isinstance(to_email_addresses, string_types):
+            to_email_addresses = [to_email_addresses]
 
-        with log_external_request(service='Mandrill', logger=logger):
-            result = mandrill_client.messages.send(message=message, async=True)
+        try:
+            message = {
+                'html': email_body,
+                'subject': subject,
+                'from_email': from_email_address,
+                'from_name': from_name,
+                'to': [{
+                    'email': email_address,
+                    'type': 'to'
+                } for email_address in to_email_addresses],
+                'important': False,
+                'track_opens': False,
+                'track_clicks': False,
+                'auto_text': True,
+                'tags': tags,
+                'metadata': metadata,
+                'headers': {'Reply-To': reply_to or from_email_address},
+                'preserve_recipients': False,
+                'recipient_metadata': [{
+                    'rcpt': email_address
+                } for email_address in to_email_addresses]
+            }
 
-    except Exception as e:
-        # Anything that Mandrill throws will be rethrown in a manner consistent with out other email backends.
-        # Note that this isn't just `mandrill.Error` exceptions, because the mandrill client also sometimes throws
-        # things like JSONDecodeError (sad face).
-        logger.error("Failed to send an email: {error}", extra={'error': e})
-        raise EmailError(e)
+            with log_external_request(service='Mandrill', logger=self.logger):
+                result = self.client.messages.send(message=message, async=True)
 
-    logger.info("Sent {tags} response: id={id}, email={email_hash}",
-                extra={'tags': tags, 'id': result[0]['_id'], 'email_hash': hash_string(result[0]['email'])})
+        except Exception as e:
+            # Anything that Mandrill throws will be rethrown in a manner consistent with out other email backends.
+            # Note that this isn't just `mandrill.Error` exceptions, because the mandrill client also sometimes throws
+            # things like JSONDecodeError (sad face).
+            self.logger.error(
+                "Error sending email: {error}",
+                extra={
+                    "client": self.client.__class__,
+                    "error": e,
+                    "tags": tags,
+                },
+            )
+            raise EmailError(e)
 
-
-def get_sent_emails(mandrill_api_key, tags, date_from=None):
-    mandrill_client = Mandrill(mandrill_api_key)
-
-    return mandrill_client.messages.search(tags=tags, date_from=date_from, limit=1000)
+        return result

--- a/dmutils/logging.py
+++ b/dmutils/logging.py
@@ -101,10 +101,9 @@ def init_app(app):
     if app.config['DM_APP_NAME'] != 'search-api':
         loggers.append(logging.getLogger('urllib3.util.retry'))
 
-    for logger in loggers:
-        logger.addHandler(handler)
-        logger.setLevel(loglevel)
-
+    for logger_ in loggers:
+        logger_.addHandler(handler)
+        logger_.setLevel(loglevel)
     app.logger.info('Logging configured')
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
          'Flask-Script==2.0.6',
          'Flask-WTF==0.14.2',
-         'Flask==0.12.4',
+         'Flask==1.0.2',
          'Flask-Login>=0.2.11',
          'boto3==1.7.83',
          'botocore<1.11.0',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import mock
+import os
 import pytest
 
 from flask import Flask
@@ -8,6 +9,20 @@ from logging import Logger, StreamHandler
 from boto.ec2.cloudwatch import CloudWatchConnection
 
 from dmutils.logging import init_app
+
+
+@pytest.fixture(scope='session', autouse=True)
+def log_to_null():
+    """Replace stdout logging with logging to dev/null in tests only.
+
+    A handler is set to stdout by default for dev envs. Turn this off for tests to make the output less noisy. Other
+    handlers are unaffected.
+
+    See digitalmarketplace-utils/dmutils/logging.py::get_handler
+    """
+    with open(os.devnull, 'w') as null:
+        with mock.patch('dmutils.logging.sys.stdout', null):
+            yield
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
-import tempfile
-
-import pytest
-from flask import Flask
 import mock
+import pytest
+
+from flask import Flask
+from io import StringIO
+from logging import Logger, StreamHandler
+
 from boto.ec2.cloudwatch import CloudWatchConnection
 
 from dmutils.logging import init_app
@@ -17,15 +19,26 @@ def app(request):
     return app
 
 
-# it's deceptively difficult to capture & inspect *actual* log output in pytest (no, capfd doesn't seem to work)
 @pytest.fixture
-def app_logtofile(request):
-    with tempfile.NamedTemporaryFile() as f:
-        app = Flask(__name__)
-        app.root_path = request.fspath.dirname
-        app.config['DM_LOG_PATH'] = f.name
-        init_app(app)
-        yield app
+def app_with_stream_logger(request):
+    """Force StreamHandler to use our StringIO object.
+
+    In the dmutils.logging.get_handler method we default to StreamHandler(sys.stdout), if we override sys.stdout to our
+    stream it is possible to check the contents of the stream for the correct log entries.
+    """
+    stream = StringIO()
+    with mock.patch('dmutils.logging.logging.StreamHandler', return_value=StreamHandler(stream)):
+        # Use the above app fixture method to return the app and return our stream
+        yield app(request), stream
+
+
+@pytest.fixture
+def app_with_mocked_logger(request):
+    """Patch `create_logger` to return a mock logger that is made accessible on `app.logger`
+    """
+    with mock.patch('flask.app.create_logger', return_value=mock.Mock(spec=Logger('flask.app'), handlers=[])):
+        # Use the above app fixture method to return the app
+        yield app(request)
 
 
 @pytest.yield_fixture

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -533,7 +533,6 @@ def test_logged_duration_real_logger(
                     if raise_exception is not None:
                         raise raise_exception("Boo")
 
-    stream.seek(0)
-    all_lines = tuple(json.loads(line) for line in stream.read().splitlines())
+    all_lines = tuple(json.loads(line) for line in stream.getvalue().splitlines())
 
     assert all_lines == (AnySupersetOf({"levelname": "INFO", "message": "Logging configured"}),) + expected_logs


### PR DESCRIPTION
http://flask.pocoo.org/docs/1.0/changelog/#version-1-0
https://trello.com/c/bBDir2Gp/18-flask-1x-upgrade

* Prevent overwriting of imported `logger` module in dmutils/logging
* New fixture to stream logs to StreamIO object (replaces `log_to_file` method)
* New fixture to mock `logger` attribute of `app`
* Changes to look for 'flask.app' new logger name
  * http://flask.pocoo.org/docs/1.0/changelog/#version-1-0
* Break out some parametrized tests to reduce complexity
* Use new fixtures where possible
* Add new `autouse` fixture to prevent stdout logging in tests