### PR TITLE
get_app_status: add additional_checks_internal for custom checks not considered a dependency

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '44.1.0'
+__version__ = '44.2.0'


### PR DESCRIPTION
`get_app_status`'s `additional_checks` argument is great, except it always assumes supplied check functions should be considered "dependencies", i.e. not included when `ignore_dependencies=True`. This isn't always what we want: in the antivirus-api's case, we should probably count the check of `clamd`'s status as part of the application.

So add a `additional_checks_internal` argument for this case while retaining compatibility.