### PR TITLE
[Bugfix] Fixes issue where the selection button widget type couldn't be customised for a DMBooleanField

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '44.2.0'
+__version__ = '44.2.1'

--- a/dmutils/forms/fields.py
+++ b/dmutils/forms/fields.py
@@ -44,9 +44,7 @@ __all__ = ['DMBooleanField', 'DMDecimalField', 'DMHiddenField', 'DMIntegerField'
 
 
 class DMBooleanField(DMFieldMixin, wtforms.fields.BooleanField):
-    widget = DMCheckboxInput(hide_question=True)
-
-    type = "checkbox"
+    widget = DMCheckboxInput(type="checkbox", hide_question=True)
 
     @property
     def options(self):

--- a/dmutils/forms/fields.py
+++ b/dmutils/forms/fields.py
@@ -44,7 +44,7 @@ __all__ = ['DMBooleanField', 'DMDecimalField', 'DMHiddenField', 'DMIntegerField'
 
 
 class DMBooleanField(DMFieldMixin, wtforms.fields.BooleanField):
-    widget = DMCheckboxInput(type="checkbox", hide_question=True)
+    widget = DMCheckboxInput(hide_question=True)
 
     @property
     def options(self):
@@ -81,8 +81,6 @@ class DMIntegerField(DMFieldMixin, wtforms.fields.IntegerField):
 
 class DMRadioField(DMSelectFieldMixin, DMFieldMixin, wtforms.fields.RadioField):
     widget = DMRadioInput()
-
-    type = "radio"
 
 
 class DMStringField(DMFieldMixin, wtforms.fields.StringField):

--- a/dmutils/forms/widgets.py
+++ b/dmutils/forms/widgets.py
@@ -17,23 +17,32 @@ class DMJinjaWidgetBase:
     def __init__(self, hide_question=False, **kwargs):
         self.__template__ = None
 
-        self.__context__ = {}
-        self.__context__.update({k: getattr(self, k) for k in dir(self) if not k.startswith("_")})
-        # kwargs can be used to add constants to the template context
-        self.__context__.update(kwargs)
+        self.__context__ = {k: getattr(self, k) for k in dir(self) if not k.startswith("_")}
+        self.__constructor_kwargs__ = kwargs
+
+        self.__dict__.update(kwargs)
 
         if hide_question:
             del self.__context__["question"]
 
     def __call__(self, field, **kwargs):
+
+        # get the template variables
+        # precedence (decreasing order)
+        # - kwargs to __call__
+        # - kwargs to constructor
+        # - field values
+        # - widget defaults
+
         context = {}
         context.update(self.__context__)
-        context.update(kwargs)
 
-        # get the template variables from the field
-        for attr in self.__context__:
+        for attr in context:
             if hasattr(field, attr):
                 context[attr] = getattr(field, attr)
+
+        context.update(self.__constructor_kwargs__)
+        context.update(kwargs)
 
         return self._render(context)
 

--- a/dmutils/forms/widgets.py
+++ b/dmutils/forms/widgets.py
@@ -38,6 +38,10 @@ class DMJinjaWidgetBase:
         context.update(self.__context__)
 
         for attr in context:
+            # we don't want the type from the field because
+            # this is just the class name of the field
+            if attr == "type":
+                continue
             if hasattr(field, attr):
                 context[attr] = getattr(field, attr)
 

--- a/tests/forms/test_dm_boolean_field.py
+++ b/tests/forms/test_dm_boolean_field.py
@@ -3,6 +3,7 @@ import pytest
 import wtforms
 
 from dmutils.forms.fields import DMBooleanField
+from dmutils.forms.widgets import DMSelectionButtonBase
 
 
 class BooleanForm(wtforms.Form):
@@ -20,3 +21,12 @@ def test_value_is_a_list(form):
 
 def test_value_is_empty_list_if_there_is_no_selection(form):
     assert form.field.value == []
+
+
+def test_can_be_used_with_a_different_kind_of_selection_button():
+    class BooleanForm(wtforms.Form):
+        field = DMBooleanField(widget=DMSelectionButtonBase(type="boolean"))
+
+    form = BooleanForm()
+
+    assert form.field.widget.type == "boolean"

--- a/tests/forms/test_dmwidgets.py
+++ b/tests/forms/test_dmwidgets.py
@@ -156,6 +156,43 @@ class TestDMBooleanField:
     def field_class(self):
         return dmutils.forms.fields.DMBooleanField
 
+    def test_default_type_is_checkbox(self, field_class):
+        class Form(wtforms.Form):
+            field = field_class()
+
+        form = Form()
+        form.field()
+
+        assert get_render_context(form.field.widget)["type"] == "checkbox"
+
+    def test_type_can_be_customised(self, widget_class, field_class):
+        class Form(wtforms.Form):
+            field = field_class(widget=widget_class(type="foo"))
+
+        form = Form()
+        form.field()
+
+        assert get_render_context(form.field.widget)["type"] == "foo"
+
+
+class TestDMRadioField:
+    @pytest.fixture
+    def widget_class(self):
+        return dmutils.forms.widgets.DMRadioInput
+
+    @pytest.fixture
+    def field_class(self):
+        return dmutils.forms.fields.DMRadioField
+
+    def test_default_type_is_radio(self, field_class):
+        class Form(wtforms.Form):
+            field = field_class()
+
+        form = Form()
+        form.field()
+
+        assert get_render_context(form.field.widget)["type"] == "radio"
+
     def test_type_can_be_customised(self, widget_class, field_class):
         class Form(wtforms.Form):
             field = field_class(widget=widget_class(type="foo"))

--- a/tests/forms/test_dmwidgets.py
+++ b/tests/forms/test_dmwidgets.py
@@ -11,25 +11,24 @@ import wtforms
 
 def get_render_context(widget):
     call = widget._render.call_args
-    return dict(*call[0], **call[1])
+    return dict(call[0][1], **call[1])
 
 
-def monkeypatch_render(cls):
-    def factory(*args, **kwargs):
-        instance = cls(*args, **kwargs)
-        instance._render = mock.Mock()
-        return instance
-    return factory
+@pytest.fixture(autouse=True)
+def render():
+    patch = mock.patch("dmutils.forms.widgets.DMJinjaWidgetBase._render", autospec=True)
+    yield patch.start()
+    patch.stop()
 
 
 @pytest.fixture(params=dmutils.forms.widgets.__all__)
-def widget_factory(request):
-    return monkeypatch_render(getattr(dmutils.forms.widgets, request.param))
+def widget_class(request):
+    return getattr(dmutils.forms.widgets, request.param)
 
 
 @pytest.fixture
-def widget(widget_factory):
-    return widget_factory()
+def widget(widget_class):
+    return widget_class()
 
 
 # We need this to limit what is accessed on our field mock
@@ -69,8 +68,8 @@ def test_template_context_includes_question_advice(widget, field):
     assert get_render_context(widget)["question_advice"] == "Advice text."
 
 
-def test_arguments_can_be_added_to_template_context_from_widget_constructor(widget_factory, field):
-    widget = widget_factory(foo="bar")
+def test_arguments_can_be_added_to_template_context_from_widget_constructor(widget_class, field):
+    widget = widget_class(foo="bar")
     widget(field)
     assert get_render_context(widget)["foo"] == "bar"
 
@@ -80,13 +79,13 @@ def test_template_context_argument_will_default_to_none_if_not_in_field(widget, 
     assert get_render_context(widget)["question_advice"] is None
 
 
-def test_arguments_to_widget_constructor_change_widget_attributes(widget_factory, field):
-    widget = widget_factory(foo="bar")
+def test_arguments_to_widget_constructor_change_widget_attributes(widget_class, field):
+    widget = widget_class(foo="bar")
     assert widget.foo == "bar"
 
 
-def test_arguments_to_widget_constructors_take_precedence_over_field_class_attributes(widget_factory, field):
-    widget = widget_factory(foo="bar")
+def test_arguments_to_widget_constructors_take_precedence_over_field_class_attributes(widget_class, field):
+    widget = widget_class(foo="bar")
     field.__class__.foo = "baz"
     widget(field)
     assert get_render_context(widget)["foo"] == "bar"
@@ -94,41 +93,40 @@ def test_arguments_to_widget_constructors_take_precedence_over_field_class_attri
 
 class TestDMTextArea:
     @pytest.fixture()
-    def widget_factory(self):
-        return monkeypatch_render(dmutils.forms.widgets.DMTextArea)
+    def widget_class(self):
+        return dmutils.forms.widgets.DMTextArea
 
     def test_dm_text_area_sends_large_is_true_to_template(self, widget, field):
         widget(field)
         assert get_render_context(widget)["large"] is True
 
     @pytest.mark.parametrize("max_length_in_words", (1, 45, 100))
-    def test_dm_text_area_can_send_max_length_in_words_to_template(self, widget_factory, max_length_in_words, field):
-        widget = widget_factory()
+    def test_dm_text_area_can_send_max_length_in_words_to_template(self, widget_class, max_length_in_words, field):
+        widget = widget_class()
         widget(field)
         assert "max_length_in_words" not in get_render_context(widget)
 
-        widget = widget_factory(max_length_in_words=max_length_in_words)
+        widget = widget_class(max_length_in_words=max_length_in_words)
         widget(field)
         assert get_render_context(widget)["max_length_in_words"] == max_length_in_words
 
-    def test_dm_text_area_max_words_template_constant_is_instance_variable(self, widget_factory):
-        widget1 = widget_factory(max_length_in_words=mock.sentinel.max_length1)
-        widget2 = widget_factory(max_length_in_words=mock.sentinel.max_length2)
+    def test_dm_text_area_max_words_template_constant_is_instance_variable(self, widget_class):
+        widget1 = widget_class(max_length_in_words=mock.sentinel.max_length1)
+        widget2 = widget_class(max_length_in_words=mock.sentinel.max_length2)
 
         widget1(mock.Mock())
-        widget2(mock.Mock())
+        max_length1 = get_render_context(widget1)["max_length_in_words"]
 
-        assert (
-            get_render_context(widget1)["max_length_in_words"]
-            !=
-            get_render_context(widget2)["max_length_in_words"]
-        )
+        widget2(mock.Mock())
+        max_length2 = get_render_context(widget2)["max_length_in_words"]
+
+        assert max_length1 != max_length2
 
 
 class TestDMDateInput:
     @pytest.fixture()
-    def widget_factory(self):
-        return monkeypatch_render(dmutils.forms.widgets.DMDateInput)
+    def widget_class(self):
+        return dmutils.forms.widgets.DMDateInput
 
     def test_dm_date_input_does_not_send_value_to_template(self, widget, field):
         widget(field)
@@ -141,8 +139,8 @@ class TestDMDateInput:
 
 class TestDMSelectionButtons:
     @pytest.fixture(params=["DMCheckboxInput", "DMRadioInput"])
-    def widget_factory(self, request):
-        return monkeypatch_render(getattr(dmutils.forms.widgets, request.param))
+    def widget_class(self, request):
+        return getattr(dmutils.forms.widgets, request.param)
 
     def test_dm_selection_buttons_send_type_to_render(self, widget, field):
         widget(field)
@@ -151,16 +149,16 @@ class TestDMSelectionButtons:
 
 class TestDMBooleanField:
     @pytest.fixture
-    def widget_factory(self):
-        return monkeypatch_render(dmutils.forms.widgets.DMSelectionButtonBase)
+    def widget_class(self):
+        return dmutils.forms.widgets.DMSelectionButtonBase
 
     @pytest.fixture
-    def field_factory(self):
+    def field_class(self):
         return dmutils.forms.fields.DMBooleanField
 
-    def test_type_can_be_customised(self, widget_factory, field_factory):
+    def test_type_can_be_customised(self, widget_class, field_class):
         class Form(wtforms.Form):
-            field = field_factory(widget=widget_factory(type="foo"))
+            field = field_class(widget=widget_class(type="foo"))
 
         form = Form()
         form.field()


### PR DESCRIPTION
Whilst refactoring forms for the supplier-frontend (PR to follow, I promise), I hit a bug where when I wanted to use a `DMBooleanField` with a slightly different widget I couldn't.

This PR fixes the order in which values are added to the template context to fix this bug; it also adds a few more tests so that the test suite captures more of the behaviour I want/need.