### PR TITLE
Upgrade Notify client

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '44.2.1'
+__version__ = '44.3.0'

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
          'mailchimp3==2.0.11',
          'mandrill==1.0.57',
          'monotonic==0.3',
-         'notifications-python-client==4.1.0',
+         'notifications-python-client==5.0.1',
          'odfpy==1.3.6',
          'python-json-logger==0.1.4',
          'pytz==2015.4',


### PR DESCRIPTION
Closes [lights-on ticket #136][ticket].

This commit it upgrades our version of `notifications-python-client` to v5.0.1, which for us has no breaking changes (see [the ticket][ticket] for more details).

[ticket]: https://trello.com/c/3Fodp3qJ