### PR TITLE
Set flask env config var

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '44.5.0'
+__version__ = '44.6.0'

--- a/dmutils/config.py
+++ b/dmutils/config.py
@@ -15,6 +15,13 @@ def init_app(app):
     app.config['DM_ENVIRONMENT'] = os.environ.get('DM_ENVIRONMENT',
                                                   'development')
 
+    # From Flask 1.0 onwards, ENV is set to either 'production' (default) or 'development'.
+    # If set as 'development' then debug mode will be enabled.
+    # If left as 'production' when running a local development server, it gives an unsettling warning message.
+    # See http://flask.pocoo.org/docs/1.0/config/#environment-and-debug-features
+    if app.config['DM_ENVIRONMENT'] == 'development':
+        app.config['ENV'] = 'development'
+
 
 def _convert_to_boolean_or_fail(key, value):
     result = convert_to_boolean(value)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -57,3 +57,20 @@ def test_init_app_fails_if_integer_field_is_not_inty(app, os_environ):
 
         with pytest.raises(ValueError):
             init_app(app)
+
+
+@pytest.mark.parametrize(
+    'dm_env, expected_flask_env',
+    [
+        ('development', 'development'),
+        ('preview', 'production'),
+        ('staging', 'production'),
+        ('production', 'production'),
+    ]
+)
+def test_init_app_sets_flask_env(dm_env, expected_flask_env, app, os_environ):
+    with app.app_context():
+        os_environ.update({'DM_ENVIRONMENT': dm_env})
+        init_app(app)
+
+        assert app.config['ENV'] == expected_flask_env


### PR DESCRIPTION
Trello: https://trello.com/c/yauaJQ4G/175-flaskenv-defaults-to-production-and-shows-a-harmless-but-worrying-debug-message-in-runserver

Addresses a harmless-but-worrying warning message introduced in Flask 1.0 (see See http://flask.pocoo.org/docs/1.0/config/#environment-and-debug-features). A new config var `ENV` defaults to production, and we weren't setting this properly.

Previously, when running an app locally, you'd get this warning:
```
12:55:43          api |  * Serving Flask app "app" (lazy loading)
12:55:43          api |  * Environment: production
12:55:43          api |    WARNING: Do not use the development server in a production environment.
12:55:43          api |    Use a production WSGI server instead.
12:55:43          api |  * Debug mode: on
```

Now it looks like this:
```
 * Serving Flask app "app" (lazy loading)
 * Environment: development
 * Debug mode: on
```

Having `ENV` set to production (value can be either `production` or `development`) should be fine for preview/staging (that's what they are using right now!). As far as I can work out, Flask is only using it for displaying the helpful message above, and toggling debug mode.