### PR TITLE
Try removing boto config fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "3.6"
 install:
-  - export BOTO_CONFIG=/dev/null
   - pip install -r requirements-dev.txt
 script:
   - ./scripts/run_tests.sh --cov=dmutils --cov-report=term-missing


### PR DESCRIPTION
Trello: https://trello.com/c/BK3NMYfV/583-review-whether-travis-workaround-is-still-required-after-migration-to-com

Let's see if we still get the GCE error.