### PR TITLE
480 overnight error adding email to mailchimp list

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '44.8.1'
+__version__ = '44.8.2'


### PR DESCRIPTION
If we get a 'User already subscribed' 400 error from mailchimp then return `True` from the `subscribe_new_email_to_list` method to avoid raising a 503 in the supplier frontend
https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/master/app/main/views/suppliers.py#L770

Traceback:

```
Traceback (most recent call last):
  File "/app/venv/lib/python3.6/site-packages/dmutils/timing.py", line 79, in logged_duration
    yield log_context
  File "/app/venv/lib/python3.6/site-packages/dmutils/email/dm_mailchimp.py", line 112, in subscribe_new_email_to_list
    "status_if_new": "subscribed"
  File "/app/venv/lib/python3.6/site-packages/mailchimp3/entities/listmembers.py", line 163, in create_or_update
    return self._mc_client._put(url=self._build_path(list_id, 'members', subscriber_hash), data=data)
  File "/app/venv/lib/python3.6/site-packages/mailchimp3/mailchimpclient.py", line 25, in wrapper
    return fn(self, *args, **kwargs)
  File "/app/venv/lib/python3.6/site-packages/mailchimp3/mailchimpclient.py", line 158, in _put
    r.raise_for_status()
  File "/app/venv/lib/python3.6/site-packages/requests/models.py", line 939, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://us5.api.mailchimp.com/3.0/lists/7534b3e89a/members/a3003c67999a823fd80398b3c2b0d4ee
```

Bring this in to supplier https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/939