### PR TITLE
"external" routes: add route for direct_award_service_page

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '44.8.3'
+__version__ = '44.9.0'

--- a/dmutils/external.py
+++ b/dmutils/external.py
@@ -26,6 +26,14 @@ def list_opportunities(framework_family):
     raise NotImplementedError()
 
 
+@external.route('/<framework_family>/services/<service_id>')
+def direct_award_service_page(framework_family, service_id):
+    if framework_family == 'suppliers':
+        # nginx would otherwise route this pattern to the Supplier FE
+        abort(404)
+    raise NotImplementedError()
+
+
 @external.route('/g-cloud/suppliers')
 def suppliers_list_by_prefix():
     raise NotImplementedError()

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -6,7 +6,8 @@ from dmutils.external import external
 @pytest.mark.parametrize(
     'url', [
         '/suppliers/opportunities',
-        '/suppliers/opportunities/1234'
+        '/suppliers/opportunities/1234',
+        '/suppliers/services/1234',
     ]
 )
 def test_external_routes_raise_404_if_suppliers_given_as_framework_family(app, url):
@@ -22,7 +23,8 @@ def test_external_routes_raise_404_if_suppliers_given_as_framework_family(app, u
         '/digital-outcomes-and-specialists/opportunities',
         '/digital-outcomes-and-specialists/opportunities/1234',
         '/foo/opportunities',
-        '/foo/opportunities/1234'
+        '/foo/opportunities/1234',
+        '/foo/services/1234',
     ]
 )
 def test_external_routes_raise_500_if_anything_else_given_as_framework_family(app, url):


### PR DESCRIPTION
https://trello.com/c/kjIZjvPz/224-external-route-for-public-g-cloud-service-page-frameworkfamily-services-serviceid