### PR TITLE
Pin MailChimp3 library to 2.0.11

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '44.8.2'
+__version__ = '44.8.3'

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -28,7 +28,7 @@ class DMMailChimpClient(object):
         logger,
         retries=0
     ):
-        self._client = MailChimp(mc_api=mailchimp_api_key, mc_user=mailchimp_username)
+        self._client = MailChimp(mc_user=mailchimp_username, mc_secret=mailchimp_api_key)
         self.logger = logger
         self.retries = retries
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
          'botocore<1.11.0',
          'contextlib2>=0.4.0',
          'cryptography<2.4,>=2.3',
-         'mailchimp3<4,>=3.0.5',
+         'mailchimp3<2.1.0,>=2.0.11',
          'mandrill>=1.0.57',
          'monotonic>=0.3',
          'notifications-python-client<6.0.0,>=5.0.1',


### PR DESCRIPTION
Pin MailChimp3 library to 2.0.11 (most commonly used across apps) after non semver'd breaking changes