### PR TITLE
Support Python 3.6 only

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '45.0.2'
+__version__ = '45.0.3'

--- a/setup.py
+++ b/setup.py
@@ -43,4 +43,5 @@ setup(
          'Werkzeug',
          'workdays>=1.4',
     ],
+    python_requires="==3.6.*",
 )


### PR DESCRIPTION
Add python_requires specification to setup.py that explicitly declares which versions of Python this library supports/is tested on.

Part of https://trello.com/c/wWFsv1SU/230-be-clear-in-our-libraries-what-versions-of-python-we-support