### PR TITLE
metrics: remove monotonic dependency in favour of time.perf_counter 

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '45.0.3'
+__version__ = '45.0.4'

--- a/dmutils/metrics.py
+++ b/dmutils/metrics.py
@@ -1,10 +1,10 @@
 import copy
 from datetime import datetime
+import time
 
 from boto.ec2.cloudwatch import connect_to_region
 from flask import current_app, _app_ctx_stack as stack
 from contextlib import ContextDecorator
-from monotonic import monotonic
 
 
 def flask_client():
@@ -75,10 +75,10 @@ class Timer(ContextDecorator):
         self.name = name
 
     def __enter__(self):
-        self.start = monotonic()
+        self.start = time.perf_counter()
 
     def __exit__(self, *exc):
-        elapsed = monotonic() - self.start
+        elapsed = time.perf_counter() - self.start
         self.client._put_metric(
             self.name,
             int(elapsed * 1000),

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
          'mailchimp3<2.1.0,>=2.0.11',
          'fleep<1.1,>=1.0.1',
          'mandrill>=1.0.57',
-         'monotonic>=0.3',
          'notifications-python-client<6.0.0,>=5.0.1',
          'odfpy>=1.3.6',
          'python-json-logger<0.2,>=0.1.4',


### PR DESCRIPTION
https://trello.com/c/2LfWhgkp/257-remove-use-of-monotonic-in-apiclient-and-utils

I chose `time.perf_counter`, a cousin of the new `time.monotonic` for the same reasons I did so when creating `logged_duration`. That is, I can't remember the exact difference right now, but we're basically using it for the same thing here as I was there.