### PR TITLE
Add Python version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Digital Marketplace utils
 
 [![Coverage Status](https://coveralls.io/repos/alphagov/digitalmarketplace-utils/badge.svg?branch=master&service=github)](https://coveralls.io/github/alphagov/digitalmarketplace-utils?branch=master)
 [![Requirements Status](https://requires.io/github/alphagov/digitalmarketplace-utils/requirements.svg?branch=master)](https://requires.io/github/alphagov/digitalmarketplace-utils/requirements/?branch=master)
+![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)
 
 ## What's in here?
 

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '45.0.4'
+__version__ = '45.0.6'


### PR DESCRIPTION
Adds a nifty visual indicator of what versions of Python we support

Part of https://trello.com/c/wWFsv1SU/230-be-clear-in-our-libraries-what-versions-of-python-we-support