### PR TITLE
Check for valid framework family before routing to Buyer FE

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '45.0.6'
+__version__ = '45.1.0'

--- a/dmutils/external.py
+++ b/dmutils/external.py
@@ -12,24 +12,24 @@ def index():
 
 @external.route('/<framework_family>/opportunities/<brief_id>')
 def get_brief_by_id(framework_family, brief_id):
-    if framework_family == 'suppliers':
-        # nginx would otherwise route this pattern to the Brief Responses FE
+    # The Buyer FE currently hardcodes this route to 'digital-outcomes-and-specialists'
+    if framework_family != 'digital-outcomes-and-specialists':
         abort(404)
     raise NotImplementedError()
 
 
 @external.route('/<framework_family>/opportunities')
 def list_opportunities(framework_family):
-    if framework_family == 'suppliers':
-        # nginx would otherwise route this pattern to the Brief Responses FE
+    # The Buyer FE currently hardcodes this route to 'digital-outcomes-and-specialists'
+    if framework_family != 'digital-outcomes-and-specialists':
         abort(404)
     raise NotImplementedError()
 
 
 @external.route('/<framework_family>/services/<service_id>')
 def direct_award_service_page(framework_family, service_id):
-    if framework_family == 'suppliers':
-        # nginx would otherwise route this pattern to the Supplier FE
+    # The Buyer FE currently hardcodes this route to 'g-cloud'
+    if framework_family != 'g-cloud':
         abort(404)
     raise NotImplementedError()
 

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -10,7 +10,7 @@ from dmutils.external import external
         '/suppliers/services/1234',
     ]
 )
-def test_external_routes_raise_404_if_suppliers_given_as_framework_family(app, url):
+def test_external_routes_raise_404_if_invalid_framework_family_given(app, url):
     app.register_blueprint(external)
     client = app.test_client()
     with app.app_context():
@@ -22,12 +22,11 @@ def test_external_routes_raise_404_if_suppliers_given_as_framework_family(app, u
     'url', [
         '/digital-outcomes-and-specialists/opportunities',
         '/digital-outcomes-and-specialists/opportunities/1234',
-        '/foo/opportunities',
-        '/foo/opportunities/1234',
-        '/foo/services/1234',
+        '/g-cloud/services/1234',
     ]
 )
-def test_external_routes_raise_500_if_anything_else_given_as_framework_family(app, url):
+def test_external_routes_raise_500_if_valid_framework_family_given(app, url):
+    # A valid framework should get routed to the Buyer FE
     app.register_blueprint(external)
     client = app.test_client()
     with app.app_context():


### PR DESCRIPTION
Trello: https://trello.com/c/2DHLpeo3/263-external-routes-raising-notimplementederror-when-they-should-404

We've been getting 500s due to malformed URLs with a duff `framework_family`. The Buyer FE is expecting either `g-cloud` or `digital-outcomes-and-specialists` for these URLs, and falls back to the 500 when it can't find them. 

Quick and dirty fix: hardcode a check for the framework family string in the external routes for now.