### PR TITLE
538 set sensible timeout on mailchimp client

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '45.1.0'
+__version__ = '45.1.1'

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -28,7 +28,7 @@ class DMMailChimpClient(object):
         logger,
         retries=0
     ):
-        self._client = MailChimp(mc_user=mailchimp_username, mc_secret=mailchimp_api_key)
+        self._client = MailChimp(mc_user=mailchimp_username, mc_secret=mailchimp_api_key, timeout=25)
         self.logger = logger
         self.retries = retries
 

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 """Tests for the Digital Marketplace MailChimp integration."""
 import logging
-import types
-from json.decoder import JSONDecodeError
-
 import mock
 import pytest
+import types
 
+from json.decoder import JSONDecodeError
 from requests import RequestException
 from requests.exceptions import HTTPError
 
 from dmutils.email.dm_mailchimp import DMMailChimpClient
+
 from helpers import assert_external_service_log_entry, PatchExternalServiceLogConditionMixin
 
 

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -7,7 +7,7 @@ import types
 
 from json.decoder import JSONDecodeError
 from requests import RequestException
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, ConnectTimeout
 
 from dmutils.email.dm_mailchimp import DMMailChimpClient
 
@@ -261,6 +261,22 @@ class TestMailchimp(PatchExternalServiceLogConditionMixin):
                 mock.call('list_id', count=100, offset=0),
                 mock.call('list_id', count=100, offset=100),
             ]
+
+    @mock.patch('dmutils.email.dm_mailchimp.MailChimp', autospec=True)
+    def test_timeout_default_is_passed_to_client(self, mailchimp_client):
+        DMMailChimpClient('username', DUMMY_MAILCHIMP_API_KEY, logging.getLogger('mailchimp'))
+        args, kwargs = mailchimp_client.call_args
+
+        assert kwargs['timeout'] == 25
+
+    def test_timeout_exception_is_not_propagated_for_create_or_update(self):
+        dm_mailchimp_client = DMMailChimpClient('username', DUMMY_MAILCHIMP_API_KEY, logging.getLogger('mailchimp'))
+        with mock.patch.object(
+                dm_mailchimp_client._client.lists.members, 'create_or_update', autospec=True) as create_or_update:
+            create_or_update.side_effect = ConnectTimeout()
+
+            assert dm_mailchimp_client.subscribe_new_email_to_list('a_list_id', 'example@example.com') is False
+            assert create_or_update.called is True
 
     def test_default_timeout_retry_performs_no_retries(self):
         dm_mailchimp_client = DMMailChimpClient('username', DUMMY_MAILCHIMP_API_KEY, logging.getLogger('mailchimp'))


### PR DESCRIPTION
Add sensible timeout to Mailchimp client  …
We should time out before 30 seconds.
Our hosting provder (paas) has a timeout of 30 secs for a request.
If we hang connecting the MailChimp (ie if mailchimp is down) PaaS severs the connection displaying an ugly 504 page.