### PR TITLE
Update mailchimp error handling for new version

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '45.3.0'
+__version__ = '45.3.1'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ hypothesis<4.0.0,>=3.6.1
 mock
 moto==1.3.5
 pytest
-pytest-cov
+pytest-cov==2.6.0
 testfixtures<7.0.0,>=6.0.2
 
 git+https://github.com/alphagov/digitalmarketplace-test-utils.git@1.4.0#egg=digitalmarketplace-test-utils==1.4.0


### PR DESCRIPTION
`mailchimp3` has changes the errors returned in it's client. This PR updates the `DMMailChimpClient` to gracefully handle these errors.