### PR TITLE
repoutils.freeze_requirements: upgrade pip to latest version in newly created venv

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,7 +23,7 @@ in (with args; {
 
     hardeningDisable = pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [ "format" ];
 
-    VIRTUALENV_ROOT = "venv${pythonPackages.python.pythonVersion}";
+    VIRTUALENV_ROOT = (toString (./.)) + "/venv${pythonPackages.python.pythonVersion}";
     VIRTUAL_ENV_DISABLE_PROMPT = "1";
     SOURCE_DATE_EPOCH = "315532800";
 
@@ -37,7 +37,8 @@ in (with args; {
         ${pythonPackages.python}/bin/python -m venv $VIRTUALENV_ROOT
       fi
       source $VIRTUALENV_ROOT/bin/activate
-      make requirements${pkgs.stdenv.lib.optionalString forDev "-dev"}
+      pip install --upgrade pip==18.0  # some packages are sensitive to "old" pips
+      make -C ${toString (./.)} requirements${pkgs.stdenv.lib.optionalString forDev "-dev"}
     '';
   }).overrideAttrs (if builtins.pathExists localOverridesPath then (import localOverridesPath args) else (x: x));
 })

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '45.4.0'
+__version__ = '45.5.0'

--- a/dmutils/repoutils/freeze_requirements.py
+++ b/dmutils/repoutils/freeze_requirements.py
@@ -60,6 +60,14 @@ if __name__ == '__main__':
     logger.info(f'Creating virtualenv: {virtualenv_name}')
     venv.main(args=(virtualenv_name,))
 
+    logger.info(f'Upgrading pip version in virtualenv: {virtualenv_name}')
+    install_cmd = subprocess.run(
+        [f'{virtualenv_name}/bin/pip', 'install', '--upgrade', 'pip'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True
+    )
+
     logger.info(f'Installing requirements from {target} in virtualenv: {virtualenv_name}')
     install_cmd = subprocess.run(
         [f'{virtualenv_name}/bin/pip', 'install', '-r', target],


### PR DESCRIPTION
This makes me feel extremely dirty, but at least it's consistently inconsistent between different peoples different machines. Increasing numbers of packages with their sub-dependencies are sensitive to pip
versions, so freezes can occasionally fail if the system pip is used as it is often quite old.