### PR TITLE
Add `sub_country_codes` filter

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '46.0.0'
+__version__ = '46.1.0'

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -1,4 +1,6 @@
 from __future__ import unicode_literals
+
+import govuk_country_register
 import re
 from jinja2 import evalcontextfilter, Markup, escape
 
@@ -96,3 +98,25 @@ def preserve_line_breaks(eval_ctx, value):
         result = Markup(result)
 
     return result
+
+
+def sub_country_codes(text):
+    """Replace country codes with country common name
+
+    :param text:    text containing country codes in the form 'country:AA'
+                    where AA is a two-letter ISO 3166-2 alpha-2 country code
+    :return:        text containing country names, or the country code if not found
+    """
+
+    def replace_match_with_country_name(match):
+        country_code = match["country_code"]
+        try:
+            return govuk_country_register.to_country(country_code)
+        except KeyError:
+            return country_code
+
+    return re.sub(
+        r"country:(?P<country_code>[A-Z][A-Z])",
+        replace_match_with_country_name,
+        text
+    )

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -73,6 +73,7 @@ def init_app(
     application.add_template_filter(filters.nbsp)
     application.add_template_filter(filters.smartjoin)
     application.add_template_filter(filters.preserve_line_breaks)
+    application.add_template_filter(filters.sub_country_codes)
     # Make select formats available in templates.
     application.add_template_filter(formats.dateformat)
     application.add_template_filter(formats.datetimeformat)

--- a/dmutils/jinja2_environment.py
+++ b/dmutils/jinja2_environment.py
@@ -1,6 +1,6 @@
 from jinja2.sandbox import SandboxedEnvironment
 
-from .filters import format_links, nbsp, smartjoin
+from .filters import format_links, nbsp, smartjoin, sub_country_codes
 from .formats import dateformat, datetimeformat, datetodatetimeformat, shortdateformat
 
 
@@ -11,7 +11,8 @@ CUSTOM_FILTERS = {
     'dateformat': dateformat,
     'datetimeformat': datetimeformat,
     'shortdateformat': shortdateformat,
-    'datetodatetimeformat': datetodatetimeformat
+    'datetodatetimeformat': datetodatetimeformat,
+    'sub_country_codes': sub_country_codes,
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
          'botocore<1.11.0',
          'contextlib2>=0.4.0',
          'cryptography<2.4,>=2.3',
+         'govuk-country-register==0.2.2',
          'mailchimp3==3.0.6',
          'fleep<1.1,>=1.0.1',
          'notifications-python-client<6.0.0,>=5.0.1',

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -6,7 +6,7 @@ import pytest
 
 from flask import Markup
 
-from dmutils.filters import capitalize_first, format_links, nbsp, smartjoin, preserve_line_breaks
+from dmutils.filters import capitalize_first, format_links, nbsp, smartjoin, preserve_line_breaks, sub_country_codes
 
 
 def test_smartjoin_for_more_than_one_item():
@@ -148,3 +148,25 @@ def test_preserve_line_breaks(_autoescape):
     assert preserve_line_breaks(eval_ctx_mock, '\n') == '\n'
     assert preserve_line_breaks(eval_ctx_mock, 'You’ll be eating 🍕') == 'You’ll be eating 🍕'
     assert preserve_line_breaks(eval_ctx_mock, '\r\n\r\n  \r\n\r\n  \t\v \r\n\r\n') == '<br><br>'
+
+
+def test_sub_country_codes():
+    assert sub_country_codes("") == ""
+    assert sub_country_codes("This text contains no country codes") == "This text contains no country codes"
+    assert sub_country_codes("country:GB") == "United Kingdom"
+    assert sub_country_codes("The country:GB consists of four nations") == "The United Kingdom consists of four nations"
+    assert sub_country_codes("The UK consists of four nations") == "The UK consists of four nations"
+    assert sub_country_codes("country:XY is not a valid country code") == "XY is not a valid country code"
+    assert sub_country_codes("country:XY") == "XY"
+
+    assert sub_country_codes(
+        """
+        There are three Latin American countries that straddle the equator:
+        country:BR, country:EC, and country:CO.
+        """
+    ) == (
+        """
+        There are three Latin American countries that straddle the equator:
+        Brazil, Ecuador, and Colombia.
+        """
+    )


### PR DESCRIPTION
Being able to convert country codes to country names is a functionality that currently exists in multiple places in our codebase; this PR adds a function that can be used for this purpose generally.

The implementation relies on a new Python library [`govuk-country-register`], which is maintained by myself (@lfdebrux). The reason for doing this rather than simply adding our existing code to dmutils was twofold:

- firstly, there were a number of implementations used, some of which called the register API using requests, others which relied on an existing nodeJS library to provide the data, therefore it made sense to start with a clean slate implementation;

- secondly, having the register data in a separate library allows us to use the implementation in places where dmutils are not already present, or pin different apps to a specific version of the register data.

[`govuk-country-register`]: https://pypi.org/project/govuk-country-register