### PR TITLE
get_app_status: log check failures

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '46.1.1'
+__version__ = '46.1.2'

--- a/dmutils/status.py
+++ b/dmutils/status.py
@@ -95,6 +95,10 @@ def get_app_status(
         _perform_additional_checks(additional_checks_internal, response_data, error_messages)
 
     if error_messages:
+        current_app.logger.error(
+            "Request completed with error_messages = {error_messages}",
+            extra={"error_messages": error_messages},
+        )
         response_data['status'] = 'error'
         response_data['message'] = error_messages
 


### PR DESCRIPTION
See https://trello.com/c/CqTPp8E0/

I added this in two parts. Firstly, the sensible log message output just before the view returns - put here because it's not _just_ the "additional checks" we want to report the results of.

But Then I _also_ added a `logged_duration` wrapper around the call to each additional check, with the idea that it would give us better detail about the timing and order of these failures. It may aid in untangling things during a storm.

I've done it as two separate commits, so I can easily drop the latter. Do we think we want the latter or is it too much?