### PR TITLE
Declaration document upload

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '46.1.2'
+__version__ = '46.2.0'

--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -87,7 +87,7 @@ def upload_document(uploader, upload_type, documents_url, service, field, file_c
         service['frameworkSlug'],
         upload_type,
         service['supplierId'],
-        service['id'],
+        service.get('id'),
         field,
         file_contents.filename
     )
@@ -105,6 +105,17 @@ def upload_document(uploader, upload_type, documents_url, service, field, file_c
     )
 
     return full_url
+
+
+def upload_declaration_documents(
+    uploader, upload_type, documents_url, request_files, section, framework_slug, supplier_id, public=True
+):
+    # Provide a pseudo 'service' without a Service ID, to construct the filename
+    return upload_service_documents(
+        uploader, upload_type, documents_url,
+        {"frameworkSlug": framework_slug, "supplierId": supplier_id},
+        request_files, section, public=public
+    )
 
 
 def upload_service_documents(uploader, upload_type, documents_url, service, request_files, section, public=True):
@@ -232,13 +243,25 @@ def generate_file_name(framework_slug, upload_type, supplier_id, service_id, fie
         'termsAndConditionsDocumentURL': 'terms-and-conditions',
         'sfiaRateDocumentURL': 'sfia-rate-card',
         'pricingDocumentURL': 'pricing-document',
+        'modernSlaveryStatement': 'modern-slavery-statement',
+        'modernSlaveryStatementOptional': 'modern-slavery-statement',
     }
 
-    return '{}/{}/{}/{}-{}-{}{}'.format(
+    if service_id:
+        return '{}/{}/{}/{}-{}-{}{}'.format(
+            framework_slug,
+            upload_type,
+            supplier_id,
+            service_id,
+            ID_TO_FILE_NAME_SUFFIX[field],
+            suffix,
+            get_extension(filename)
+        )
+
+    return '{}/{}/{}/{}-{}{}'.format(
         framework_slug,
         upload_type,
         supplier_id,
-        service_id,
         ID_TO_FILE_NAME_SUFFIX[field],
         suffix,
         get_extension(filename)


### PR DESCRIPTION
Trello: https://trello.com/c/daSH619N/390-allow-non-service-specific-document-uploads-during-supplier-applications

Allows documents without a service ID to be uploaded to a supplier's S3 bucket (e.g. documents uploaded at the declaration stage) via a new function `upload_declaration_documents`. This calls the existing `upload_service_documents` function, but passes through a 'service' object built from additional params `frameworkSlug` and `supplierID`, in order to create the upload URL.

Also adds in the mappings for the two `modernSlaveryStatement` questions (only one of which will be answered by the supplier, they should upload to the same path).

This should be backwards-compatible so no breaking changes.