### PR TITLE
decode_password_reset_token: fail for inactive users 

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '46.2.2'
+__version__ = '46.3.0'

--- a/dmutils/email/tokens.py
+++ b/dmutils/email/tokens.py
@@ -113,6 +113,10 @@ def decode_password_reset_token(token, data_api_client):
         DATETIME_FORMAT
     )
 
+    if not user["users"]["active"]:
+        current_app.logger.info("Error changing password: target user is not active.")
+        return {'error': 'user_inactive'}
+
     # Check if the token was created before the last password change
     # (allow 1 second leeway for reset tokens generated for the 'Your password was changed' email link)
     if token_timestamp + timedelta(seconds=1) < user_last_changed_password_at:

--- a/tests/email/test_tokens.py
+++ b/tests/email/test_tokens.py
@@ -164,6 +164,18 @@ class TestDecodePasswordReset:
                 else:
                     assert decode_password_reset_token(token, data_api_client) == {'error': 'token_invalid'}
 
+    def test_decode_password_reset_token_user_inactive(
+        self, email_app, data_api_client, password_reset_token
+    ):
+        with freeze_time('2016-01-01T12:00:00.30Z'):
+            token = generate_token(password_reset_token, "Key", 'PassSalt')
+
+        data_api_client.get_user.return_value["users"]["active"] = False
+
+        with freeze_time('2016-01-01T13:00:00.30Z'):
+            with email_app.app_context():
+                assert decode_password_reset_token(token, data_api_client) == {'error': 'user_inactive'}
+
 
 class TestDecodeInvitationToken:
 


### PR DESCRIPTION
https://trello.com/c/ARkdAn0z

Though in the above ticket we're making it so that password reset tokens aren't even generated for inactive users, there's always the possibility that a user has been made inactive _since_ they generated the token, so we should at least handle that gracefully.