### PR TITLE
Add time formatter

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '47.0.0'
+__version__ = '47.1.0'

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -78,6 +78,7 @@ def init_app(
     application.add_template_filter(formats.dateformat)
     application.add_template_filter(formats.datetimeformat)
     application.add_template_filter(formats.datetodatetimeformat)
+    application.add_template_filter(formats.displaytimeformat)
     application.add_template_filter(formats.shortdateformat)
     application.add_template_filter(formats.timeformat)
     application.add_template_filter(formats.utcdatetimeformat)

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -10,6 +10,7 @@ DISPLAY_SHORT_DATE_FORMAT = '%-d %B'
 DISPLAY_NO_DAY_DATE_FORMAT = '%-d %B %Y'
 DISPLAY_DATE_FORMAT = '%A %-d %B %Y'
 DISPLAY_TIME_FORMAT = '%H:%M:%S'
+DISPLAY_TIME_TZ_FORMAT = '%-I:%M%p %Z'
 DISPLAY_DATETIME_FORMAT = '%A %-d %B %Y at %I:%M%p %Z'
 DISPLAY_SHORTTIME_LONGDATE_FORMAT = '%-I%p %Z, %A %-d %B %Y'
 
@@ -23,6 +24,17 @@ def timeformat(value, default_value=None):
     Currently (Jan 2018) only used in admin app tables.
     """
     return _format_date(value, default_value, DISPLAY_TIME_FORMAT, localize=False)
+
+
+def displaytimeformat(value, default_value=None):
+    """
+    Example value: datetime.strptime("2018-07-25 08:15:00", "%Y-%m-%d %H:%M:%S")
+    Example output: '9:15am BST'
+
+    "timeformat_with_tz" is used for events which are less than a few hours away.
+    Currently (Mar 2019) only used in timeout warnings to users.
+    """
+    return _format_date(value, default_value, DISPLAY_TIME_TZ_FORMAT, localize=True)
 
 
 def shortdateformat(value, default_value=None):

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -2,6 +2,7 @@
 from dmutils.formats import (
     dateformat,
     datetimeformat,
+    displaytimeformat,
     iso_datetime_format,
     datetodatetimeformat,
     monthyearformat,
@@ -103,6 +104,24 @@ def test_monthyearformat(dt, default_value, formatted_date):
 ))
 def test_datetimeformat(dt, formatted_datetime):
     assert datetimeformat(dt) == formatted_datetime
+
+
+@pytest.mark.parametrize("dt, formatted_time", (
+    (datetime(2012, 11, 10, 9, 8, 7, 6), "9:08am GMT"),
+    ("2012-11-10T09:08:07.0Z", "9:08am GMT"),
+    (datetime(2012, 8, 10, 9, 8, 7, 6), "10:08am BST"),
+    ("2012-08-10T09:08:07.0Z", "10:08am BST"),
+    (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "10:08am BST"),
+    (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), "10:08am BST"),
+    (datetime(2012, 8, 1, 22, 59, 7, 6, tzinfo=pytz.utc), "11:59pm BST"),
+    # Daylight savings edge case
+    (datetime(2012, 3, 25, 0, 59, 7, 6, tzinfo=pytz.utc), "12:59am GMT"),
+    (datetime(2012, 3, 25, 1, 59, 7, 6, tzinfo=pytz.utc), "2:59am BST"),
+    # Fall back to default if no valid date supplied
+    (None, None),
+))
+def test_displaytimeformat(dt, formatted_time):
+    assert displaytimeformat(dt) == formatted_time
 
 
 @pytest.mark.parametrize("dt, formatted_datetime", (


### PR DESCRIPTION
For the timeout warnings ([ticket]) we want to be able to display to the user a nicely formatted time (without date).

[ticket]: https://trello.com/c/92nGYty4/394-timeout-warning-accessibility-guidelines