### PR TITLE
Handle users who want to resubscribe to Mailchimp lists

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '47.2.0'
+__version__ = '47.3.0'

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -142,6 +142,16 @@ class DMMailChimpClient(object):
                     extra={"error": str(e), "mailchimp_response": response}
                 )
                 return True
+            elif 'The contact must re-subscribe to get back on the list.' in response.get('detail', ''):
+                # User has previously unsubscribed and must confirm their resubscription via email
+                self.logger.warning(
+                    f"Expected error: Mailchimp cannot automatically subscribe user ({hashed_email}) to list "
+                    "({list_id}) as the user has been permanently deleted and must manually re-subscribe. "
+                    "A confirmation email will be sent.",
+                    extra={"error": str(e), "mailchimp_response": response}
+                )
+                return self.resubscribe_email_to_list(list_id, email_address)
+
             # Otherwise this was an unexpected error and should be logged as such
             self.logger.error(
                 f"Mailchimp failed to add user ({hashed_email}) to list ({list_id})",


### PR DESCRIPTION
Trello: https://trello.com/c/pzAoSoTC/434-mailchimp-resubscribe-for-users-who-have-unsubscribed

Users who try to sign up when they've already unsubscribed trigger a 503 error - not a great experience. 

Solution based on Ben's idea in the ticket: 
- new `DMMailChimpClient` method `resubscribe_email_to_list` which sends a confirmation email to the user first (i.e. no error message needs to be shown on the frontend)
- catch this type of error in the `subscribe_new_email_to_list` method, log a warning and try the resubscribe, and don't raise the error.