### PR TITLE
Handle Mailchimp deleted user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Records breaking changes from major version bumps
 
+## 48.0.0
+
+PR [#504](https://github.com/alphagov/digitalmarketplace-utils/pull/509)
+
+`DMMailChimpClient.subscribe_new_email_to_list` now returns an error payload instead of a boolean.
+
+Example responses:
+
+```
+{"status": "success", "status_code": 200, "error_type": None}
+{"status": "error", "status_code": 400, "error_type": "invalid_email"}
+{"status": "error", "status_code": 400, "error_type": "already_subscribed"}
+{"status": "error", "status_code": 400, "error_type": "deleted_user"}
+{"status": "error", "status_code": 500, "error_type": "unexpected_error"}
+```
+
 ## 47.0.0
 
 PR [#504](https://github.com/alphagov/digitalmarketplace-utils/pull/504)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '47.2.0'
+__version__ = '48.0.0'


### PR DESCRIPTION
Attempt 2 of https://github.com/alphagov/digitalmarketplace-utils/pull/507 (now attempt 3?)

Trello: https://trello.com/c/pzAoSoTC/434-mailchimp-resubscribe-for-users-who-have-unsubscribed

We can't resubscribe deleted users, but we can tell the frontend what's happened so it can display an appropriate error message.

Introduces a breaking change to format the error/success response in a sane way (i.e. not `True`, `False`, `<anything else>`). 