### PR TITLE
435-spike-figure-out-why-werkzeug-0150-is-breaking-everything

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '48.0.1'
+__version__ = '48.0.2'

--- a/dmutils/proxy_fix.py
+++ b/dmutils/proxy_fix.py
@@ -1,9 +1,9 @@
-from werkzeug.contrib.fixers import ProxyFix
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 
 class CustomProxyFix(object):
     def __init__(self, app, forwarded_proto):
-        self.app = ProxyFix(app)
+        self.app = ProxyFix(app, x_for=1, x_proto=1, x_host=1)
         self.forwarded_proto = forwarded_proto
 
     def __call__(self, environ, start_response):

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
          'python-json-logger<0.2,>=0.1.4',
          'pytz',
          'unicodecsv>=0.14.1',
-         'Werkzeug>=0.14.1,<0.15.0',
+         'Werkzeug>=0.15.1,<0.16.0',
          'workdays>=1.4',
     ],
     python_requires="==3.6.*",


### PR DESCRIPTION
https://trello.com/c/DvUSNTbL/435-spike-figure-out-why-werkzeug-0150-is-breaking-everything


New ProxyFix class is requires kwargs to have an effect.

https://github.com/pallets/werkzeug/blob/0.14.1/werkzeug/contrib/fixers.py#L97
vs
https://github.com/pallets/werkzeug/blob/master/src/werkzeug/middleware/proxy_fix.py#L46 

It won't set the HTTP_X_FORWARDED_PROTO unless you pass in a value for `x_proto` when you instantiate it.

Do this.