### PR TITLE
Mailchimp subscribe: include response info for happy path

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '48.0.0'
+__version__ = '48.0.1'

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -119,7 +119,7 @@ class DMMailChimpClient(object):
         hashed_email = self.get_email_hash(email_address)
         try:
             with log_external_request(service='Mailchimp'):
-                self._client.lists.members.create_or_update(
+                resp = self._client.lists.members.create_or_update(
                     list_id,
                     hashed_email,
                     {
@@ -127,7 +127,8 @@ class DMMailChimpClient(object):
                         "status_if_new": "subscribed"
                     }
                 )
-                return {"status": "success", "error_type": None, "status_code": 200}
+                resp.update({"status": "success", "error_type": None, "status_code": 200})
+                return resp
         except (RequestException, MailChimpError) as e:
             # Some errors we don't care about but do want to log. Find and log them here.
             response = get_response_from_exception(e)

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -156,7 +156,7 @@ class TestMailchimp(PatchExternalServiceLogConditionMixin):
             with assert_external_service_log_entry():
                 res = dm_mailchimp_client.subscribe_new_email_to_list('list_id', 'example@example.com')
 
-            assert res == {"status": "success", 'error_type': None, 'status_code': 200}
+            assert res == {"status": "success", 'error_type': None, 'status_code': 200, "response": "data"}
             create_or_update.assert_called_once_with(
                 'list_id',
                 "foo",


### PR DESCRIPTION
Trello: https://trello.com/c/pzAoSoTC/434-mailchimp-resubscribe-for-users-who-have-unsubscribed

The supplier FE uses some of the info returned by Mailchimp when creating the audit event for the mailing list subscription (see https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/master/app/main/views/suppliers.py#L697). 