### PR TITLE
Mailchimp invalid fix

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '48.0.2'
+__version__ = '48.0.3'

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -159,6 +159,14 @@ class DMMailChimpClient(object):
                     extra={"error": str(e), "mailchimp_response": response}
                 )
                 return {"status": "error", "error_type": "deleted_user", "status_code": 400}
+            elif response.get('status') == 400:
+                # Some other validation error
+                self.logger.warning(
+                    f"Expected error: Mailchimp failed to add user ({hashed_email}) to list ({list_id}). "
+                    "API error: The email address was invalid.",
+                    extra={"error": str(e), "mailchimp_response": response}
+                )
+                return {"status": "error", "error_type": "invalid_email", "status_code": 400}
 
             # Otherwise this was an unexpected error and should be logged as such
             self.logger.error(

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -137,7 +137,7 @@ class DMMailChimpClient(object):
                 # requested mailchimp to never add them to mailchimp lists. In this case, we resort to allowing a
                 # failed API call (but log) as a user of this method would unlikely be able to do anything as we have
                 # no control over this behaviour.
-                self.logger.error(
+                self.logger.warning(
                     f"Expected error: Mailchimp failed to add user ({hashed_email}) to list ({list_id}). "
                     "API error: The email address looks fake or invalid, please enter a real email address.",
                     extra={"error": str(e), "mailchimp_response": response}

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -186,7 +186,7 @@ class TestMailchimp(PatchExternalServiceLogConditionMixin):
             assert log_catcher.records[1].levelname == 'ERROR'
 
     @mock.patch("dmutils.email.dm_mailchimp.DMMailChimpClient.get_email_hash", return_value="foo")
-    def test_log_mailchimp_error_error_message_if_error_subscribing_email_to_list(self, get_email_hash):
+    def test_log_mailchimp_error_unexpected_error_payload_if_error_subscribing_email_to_list(self, get_email_hash):
         dm_mailchimp_client = DMMailChimpClient('username', DUMMY_MAILCHIMP_API_KEY, logging.getLogger('mailchimp'))
         with mock.patch.object(
                 dm_mailchimp_client._client.lists.members, 'create_or_update', autospec=True) as create_or_update:
@@ -202,7 +202,7 @@ class TestMailchimp(PatchExternalServiceLogConditionMixin):
             assert log_catcher.records[1].levelname == 'ERROR'
 
     @mock.patch("dmutils.email.dm_mailchimp.DMMailChimpClient.get_email_hash", return_value="foo")
-    def test_create_or_update_returns_true_for_expected_request_exception(self, get_email_hash):
+    def test_create_or_update_returns_error_payload_for_expected_request_exception(self, get_email_hash):
         dm_mailchimp_client = DMMailChimpClient('username', DUMMY_MAILCHIMP_API_KEY, logging.getLogger('mailchimp'))
         with mock.patch.object(
                 dm_mailchimp_client._client.lists.members, 'create_or_update', autospec=True) as create_or_update:
@@ -222,7 +222,7 @@ class TestMailchimp(PatchExternalServiceLogConditionMixin):
             assert log_catcher.records[1].levelname == 'ERROR'
 
     @mock.patch("dmutils.email.dm_mailchimp.DMMailChimpClient.get_email_hash", return_value="foo")
-    def test_create_or_update_returns_true_for_expected_mailchimp_error(self, get_email_hash):
+    def test_create_or_update_returns_error_payload_for_expected_mailchimp_error(self, get_email_hash):
         dm_mailchimp_client = DMMailChimpClient('username', DUMMY_MAILCHIMP_API_KEY, logging.getLogger('mailchimp'))
         with mock.patch.object(
                 dm_mailchimp_client._client.lists.members, 'create_or_update', autospec=True) as create_or_update:
@@ -249,7 +249,7 @@ class TestMailchimp(PatchExternalServiceLogConditionMixin):
             assert log_catcher.records[1].levelname == 'ERROR'
 
     @mock.patch("dmutils.email.dm_mailchimp.DMMailChimpClient.get_email_hash", return_value="foo")
-    def test_returns_true_if_expected_already_subscribed_email_error(self, get_email_hash):
+    def test_returns_error_payload_if_expected_already_subscribed_email_error(self, get_email_hash):
         dm_mailchimp_client = DMMailChimpClient('username', DUMMY_MAILCHIMP_API_KEY, logging.getLogger('mailchimp'))
 
         with mock.patch.object(
@@ -278,7 +278,7 @@ class TestMailchimp(PatchExternalServiceLogConditionMixin):
             assert log_catcher.records[1].levelname == 'WARNING'
 
     @mock.patch("dmutils.email.dm_mailchimp.DMMailChimpClient.get_email_hash", return_value="foo")
-    def test_returns_error_string_if_user_previously_unsubscribed_error(self, get_email_hash):
+    def test_returns_error_payload_if_user_previously_unsubscribed_error(self, get_email_hash):
         dm_mailchimp_client = DMMailChimpClient('username', DUMMY_MAILCHIMP_API_KEY, logging.getLogger('mailchimp'))
 
         with mock.patch.object(

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -219,7 +219,7 @@ class TestMailchimp(PatchExternalServiceLogConditionMixin):
                 "API error: The email address looks fake or invalid, please enter a real email address."
             )
             assert log_catcher.records[1].error == "error sending"
-            assert log_catcher.records[1].levelname == 'ERROR'
+            assert log_catcher.records[1].levelname == 'WARNING'
 
     @mock.patch("dmutils.email.dm_mailchimp.DMMailChimpClient.get_email_hash", return_value="foo")
     def test_create_or_update_returns_error_payload_for_expected_mailchimp_error(self, get_email_hash):
@@ -230,7 +230,7 @@ class TestMailchimp(PatchExternalServiceLogConditionMixin):
                 {
                     "detail": "foo looks fake or invalid, please enter a real email address.",
                     'request': 'failed',
-                    'status': 500
+                    'status': 400
                 }
             )
 
@@ -244,9 +244,9 @@ class TestMailchimp(PatchExternalServiceLogConditionMixin):
             )
             assert log_catcher.records[1].error == (
                 "{'detail': 'foo looks fake or invalid, please enter a real email address.', "
-                "'request': 'failed', 'status': 500}"
+                "'request': 'failed', 'status': 400}"
             )
-            assert log_catcher.records[1].levelname == 'ERROR'
+            assert log_catcher.records[1].levelname == 'WARNING'
 
     @mock.patch("dmutils.email.dm_mailchimp.DMMailChimpClient.get_email_hash", return_value="foo")
     def test_returns_error_payload_if_expected_already_subscribed_email_error(self, get_email_hash):


### PR DESCRIPTION
Fix for the changes in Mailchimp's error response for invalid emails. The method now catches generic Mailchimp 400s (i.e. the user has made a mistake, not Mailchimp).

Previous response message: `email address looks fake or invalid`
Now: `Please provide a valid email address`

See recent log message example:
```
{'type': 'http://developer.mailchimp.com/documentation/mailchimp/guides/error-glossary/', 'title': 'Invalid Resource', 'status': 400, 'detail': 'Please provide a valid email address.', 'instance': '<instance-id-redacted>'}
```

Also 
- renamed some tests that were still referring to the old return values for errors
- changed the expected error case to log level `WARNING` rather than `ERROR`