### PR TITLE
app error handlers: add logging calls as last-ditch attempt to output exception information that might otherwise be lost

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '48.1.0'
+__version__ = '48.2.0'

--- a/dmutils/errors/api.py
+++ b/dmutils/errors/api.py
@@ -12,6 +12,18 @@ class ValidationError(ValueError):
 
 def json_error_handler(e):
     try:
+        should_log = False
+        should_log = int((hasattr(e, "status_code") and e.status_code) or (hasattr(e, "code") and e.code)) >= 500
+    except Exception:
+        should_log = True
+
+    if should_log:
+        # this is a last ditch effort at outputting a traceback hopefully explaining why we're returning a 5xx.
+        # unfortunately flask can't always be trusted to do this on its own. this ends up being a suitable place to
+        # do it because these handlers are called by flask while a view-generated exception is still being serviced.
+        current_app.logger.warning("Generating error response", exc_info=True, extra={"e": e})
+
+    try:
         # initially we'll try and assume this is an HTTPException of some sort.  for the most part, the default
         # HTTPExceptions render themselves in the desired way if returned as a response. the only change we want to
         # make is to enclose the error description in json.

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -52,74 +52,158 @@ def test_unauthorised_redirects_to_login(app):
         assert response.location == '/user/login?next=%2F'
 
 
-@pytest.mark.parametrize('exception, status_code, expected_template', [
-    (BadRequest, 400, 'errors/400.html'),
-    (NotFound, 404, 'errors/404.html'),
-    (Gone, 410, 'errors/410.html'),
-    (InternalServerError, 500, 'errors/500.html'),
-    (ServiceUnavailable, 503, 'errors/500.html'),
-    (mock.Mock(code=None), 500, 'errors/500.html'),
+@pytest.mark.parametrize('exception,expected_status_code,expected_template,expect_log_call', [
+    (BadRequest, 400, 'errors/400.html', False),
+    (NotFound, 404, 'errors/404.html', False),
+    (Gone, 410, 'errors/410.html', False),
+    (InternalServerError, 500, 'errors/500.html', True),
+    (ServiceUnavailable, 503, 'errors/500.html', True),
+    (mock.Mock(code=None), 500, 'errors/500.html', True),
 ])
 @mock.patch('dmutils.errors.frontend.render_template')
-def test_render_error_page_with_exception(render_template, exception, status_code, expected_template, app):
-    with app.test_request_context('/'):
-        assert render_error_page(exception()) == (render_template.return_value, status_code)
+def test_render_error_page_with_exception(
+    render_template,
+    exception,
+    expected_status_code,
+    expected_template,
+    expect_log_call,
+    app_with_mocked_logger,
+):
+    with app_with_mocked_logger.test_request_context('/'):
+        exc_instance = exception()
+        assert render_error_page(exc_instance) == (render_template.return_value, expected_status_code)
         assert render_template.call_args_list == [
             mock.call(expected_template, error_message=None)
         ]
+        assert app_with_mocked_logger.logger.warning.mock_calls == ([
+            mock.call(
+                'Rendering error page',
+                exc_info=True,
+                extra={
+                    'e': exc_instance,
+                    'status_code': None,
+                    'error_message': None,
+                },
+            )
+        ] if expect_log_call else [])
 
 
-@pytest.mark.parametrize('status_code, expected_template', [
-    (400, 'errors/400.html'),
-    (404, 'errors/404.html'),
-    (410, 'errors/410.html'),
-    (500, 'errors/500.html'),
-    (503, 'errors/500.html'),
+@pytest.mark.parametrize('status_code,expected_template,expect_log_call', [
+    (400, 'errors/400.html', False,),
+    (404, 'errors/404.html', False,),
+    (410, 'errors/410.html', False,),
+    (500, 'errors/500.html', True,),
+    (503, 'errors/500.html', True,),
 ])
 @mock.patch('dmutils.errors.frontend.render_template')
-def test_render_error_page_with_status_code(render_template, status_code, expected_template, app):
-    with app.test_request_context('/'):
+def test_render_error_page_with_status_code(
+    render_template,
+    status_code,
+    expected_template,
+    expect_log_call,
+    app_with_mocked_logger,
+):
+    with app_with_mocked_logger.test_request_context('/'):
         assert render_error_page(status_code=status_code) == (render_template.return_value, status_code)
         assert render_template.call_args_list == [mock.call(expected_template, error_message=None)]
+        assert app_with_mocked_logger.logger.warning.mock_calls == ([
+            mock.call(
+                'Rendering error page',
+                exc_info=True,
+                extra={
+                    'e': None,
+                    'status_code': status_code,
+                    'error_message': None,
+                },
+            )
+        ] if expect_log_call else [])
 
 
 @mock.patch('dmutils.errors.frontend.render_template')
-def test_render_error_page_with_custom_http_exception(render_template, app):
+def test_render_error_page_with_custom_http_exception(render_template, app_with_mocked_logger):
     class CustomHTTPError(Exception):
         def __init__(self):
             self.status_code = 500
 
-    with app.test_request_context('/'):
-        assert render_error_page(CustomHTTPError()) == (render_template.return_value, 500)
+    with app_with_mocked_logger.test_request_context('/'):
+        exc_instance = CustomHTTPError()
+        assert render_error_page(exc_instance) == (render_template.return_value, 500)
         assert render_template.call_args_list == [mock.call('errors/500.html', error_message=None)]
-
-
-@mock.patch('dmutils.errors.frontend.render_template')
-def test_render_error_page_for_unknown_status_code_defaults_to_500(render_template, app):
-    with app.test_request_context('/'):
-        assert render_error_page(ImATeapot()) == (render_template.return_value, 500)
-        assert render_template.call_args_list == [mock.call('errors/500.html', error_message=None)]
-
-
-@mock.patch('dmutils.errors.frontend.render_template')
-def test_render_error_page_falls_back_to_toolkit_templates(render_template, app):
-    render_template.side_effect = [TemplateNotFound('Oh dear'), "successful rendering"]
-    with app.test_request_context('/'):
-        assert render_error_page(ImATeapot()) == ("successful rendering", 500)
-        assert render_template.call_args_list == [
-            mock.call('errors/500.html', error_message=None),
-            mock.call('toolkit/errors/500.html', error_message=None)
+        assert app_with_mocked_logger.logger.warning.mock_calls == [
+            mock.call(
+                'Rendering error page',
+                exc_info=True,
+                extra={
+                    'e': exc_instance,
+                    'status_code': None,
+                    'error_message': None,
+                },
+            )
         ]
 
 
 @mock.patch('dmutils.errors.frontend.render_template')
-def test_render_error_page_passes_error_message_as_context(render_template, app):
+def test_render_error_page_for_unknown_status_code_defaults_to_500(render_template, app_with_mocked_logger):
+    with app_with_mocked_logger.test_request_context('/'):
+        exc_instance = ImATeapot()
+        assert render_error_page(exc_instance) == (render_template.return_value, 500)
+        assert render_template.call_args_list == [mock.call('errors/500.html', error_message=None)]
+        assert app_with_mocked_logger.logger.warning.mock_calls == [
+            mock.call(
+                'Rendering error page',
+                exc_info=True,
+                extra={
+                    'e': exc_instance,
+                    'status_code': None,
+                    'error_message': None,
+                },
+            )
+        ]
+
+
+@mock.patch('dmutils.errors.frontend.render_template')
+def test_render_error_page_falls_back_to_toolkit_templates(render_template, app_with_mocked_logger):
     render_template.side_effect = [TemplateNotFound('Oh dear'), "successful rendering"]
-    with app.test_request_context('/'):
-        assert render_error_page(ImATeapot(), error_message="Hole in Teapot") == ("successful rendering", 500)
+    with app_with_mocked_logger.test_request_context('/'):
+        exc_instance = ImATeapot()
+        assert render_error_page(exc_instance) == ("successful rendering", 500)
+        assert render_template.call_args_list == [
+            mock.call('errors/500.html', error_message=None),
+            mock.call('toolkit/errors/500.html', error_message=None)
+        ]
+        assert app_with_mocked_logger.logger.warning.mock_calls == [
+            mock.call(
+                'Rendering error page',
+                exc_info=True,
+                extra={
+                    'e': exc_instance,
+                    'status_code': None,
+                    'error_message': None,
+                },
+            )
+        ]
+
+
+@mock.patch('dmutils.errors.frontend.render_template')
+def test_render_error_page_passes_error_message_as_context(render_template, app_with_mocked_logger):
+    render_template.side_effect = [TemplateNotFound('Oh dear'), "successful rendering"]
+    with app_with_mocked_logger.test_request_context('/'):
+        exc_instance = ImATeapot()
+        assert render_error_page(exc_instance, error_message="Hole in Teapot") == ("successful rendering", 500)
         assert render_template.call_args_list == [
             mock.call('errors/500.html', error_message="Hole in Teapot"),
             mock.call('toolkit/errors/500.html', error_message="Hole in Teapot")
+        ]
+        assert app_with_mocked_logger.logger.warning.mock_calls == [
+            mock.call(
+                'Rendering error page',
+                exc_info=True,
+                extra={
+                    'e': exc_instance,
+                    'status_code': None,
+                    'error_message': "Hole in Teapot",
+                },
+            )
         ]
 
 


### PR DESCRIPTION
https://trello.com/c/d6aDkDDf

I'm going to turn my ideas about refactoring the error handler init and writing extended tests as a result into a separate ticket.