### PR TITLE
s3: add get_full_signed_url method

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '48.3.1'
+__version__ = '48.4.0'


### PR DESCRIPTION
This doesn't have any tests yet as I'm just floating it for general approval. If we're going to let admins delete comms files we really have to allow them to download them to see what they're about to delete. So this implies we need some kind of clone of https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/eca2133f5a9cd3df95ec41e539d930e1816cdf2b/app/main/views/frameworks.py#L701

So I'm just seeking to combine common code and it feels less silly to just add this method straight to the `S3` class instead of moving a copy of https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/eca2133f5a9cd3df95ec41e539d930e1816cdf2b/app/main/helpers/services.py#L50 to utils.