### PR TITLE
add SafePurePathConverter to allow us to easily extract "safe" components out of url paths

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,6 +13,7 @@ in (with args; {
     shortName = "dm-utils";
     buildInputs = [
       pythonPackages.python
+      pkgs.glibcLocales
       pkgs.libffi
       pkgs.openssl
       pkgs.git

--- a/default.nix
+++ b/default.nix
@@ -7,12 +7,24 @@ let
     forDev = true;
     localOverridesPath = ./local.nix;
   } // argsOuter;
+  sitePrioNonNix = args.pkgs.writeTextFile {
+    name = "site-prio-non-nix";
+    destination = "/${args.pythonPackages.python.sitePackages}/sitecustomize.py";
+    text = ''
+      import sys
+      first_nix_i = next((i for i, p in enumerate(sys.path) if p.startswith("/nix/")), 1)
+      # after the first nix-provided path in sys.path (presumably the python stdlib itself), re-sort all non-nix
+      # paths to be before the nix paths. this is helped by python's sort being a stable-sort
+      sys.path[first_nix_i+1:] = sorted(sys.path[first_nix_i+1:], key=lambda p: p.startswith("/nix/"))
+    '';
+  };
 in (with args; {
   digitalMarketplaceUtilsEnv = (pkgs.stdenv.mkDerivation rec {
     name = "digitalmarketplace-utils-frontend-env";
     shortName = "dm-utils";
     buildInputs = [
       pythonPackages.python
+      sitePrioNonNix
       pkgs.glibcLocales
       pkgs.libffi
       pkgs.openssl

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '48.3.1'
+__version__ = '48.4.0'

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -4,6 +4,7 @@ from types import MappingProxyType
 
 from dmutils import config, logging, proxy_fix, request_id, formats, filters
 from dmutils.errors import api as api_errors, frontend as fe_errors
+from dmutils.urls import SafePurePathConverter
 from flask_script import Manager, Server
 from flask_wtf.csrf import CSRFError
 from werkzeug.exceptions import default_exceptions
@@ -61,6 +62,9 @@ def init_app(
         login_manager.init_app(application)
     if search_api_client:
         search_api_client.init_app(application)
+
+    # allow us to use <safepurepath:...> components in route patterns
+    application.url_map.converters["safepurepath"] = SafePurePathConverter
 
     @application.after_request
     def add_header(response):

--- a/dmutils/urls.py
+++ b/dmutils/urls.py
@@ -1,0 +1,28 @@
+from pathlib import PurePath
+import re
+
+from werkzeug.routing import BaseConverter, ValidationError
+
+
+class SafePurePathConverter(BaseConverter):
+    """
+        Like the default :class:`PathConverter`, but it converts
+        the output to a :class:`pathlib.PurePath` and ensures it
+        contains no path components consisting only of dots.
+    """
+
+    regex = "[^/].*?"
+    weight = 200
+
+    _disallowed_path_part_re = re.compile(r"\.+$")
+
+    def to_python(self, value):
+        pth = PurePath(value)
+        if not pth.parts:
+            raise ValidationError("All path parts squashed out")
+
+        for part in pth.parts:
+            if self._disallowed_path_part_re.match(part):
+                raise ValidationError(f"Disallowed path part {part!r}")
+
+        return pth

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,0 +1,87 @@
+from pathlib import PurePath
+
+from flask import url_for
+import pytest
+
+from dmutils.urls import SafePurePathConverter
+
+
+@pytest.mark.parametrize("route_pattern,request_path", tuple(
+    ("/beside/<safepurepath:some_path>/shakespeare", request_path) for request_path in (
+        "/beside/../shakespeare",
+        "/beside/../saxon/shakespeare",
+        "/beside/saxon/../shakespeare",
+        "/beside/saxon/../hamlet/shakespeare",
+        "/beside/saxon/.../hamlet/shakespeare",
+        "/beside/shakespeare",
+        "/beside//shakespeare",
+        "/beside/./shakespeare",
+    )
+) + tuple(
+    ("/beside/shakespeare/<safepurepath:some_path>", request_path) for request_path in (
+        "/beside/shakespeare/hamlet/../saxon.pdf",
+        "/beside/shakespeare/../hamlet/bards",
+        "/beside/shakespeare/saxon/hamlet/../bards.png",
+        "/beside/shakespeare//hamlet/saxon.pdf",
+    )
+))
+def test_safepurepath_undesirable_urls(app, route_pattern, request_path):
+    app.url_map.converters["safepurepath"] = SafePurePathConverter
+
+    @app.route(route_pattern)
+    def some_view(some_path):
+        assert False, f"View body not expected to be executed: {some_path!r}"
+
+    with app.app_context():
+        response = app.test_client().get(request_path)
+        assert response.status_code == 404
+
+
+@pytest.mark.parametrize("route_pattern,request_path,expected_arg", tuple(
+    ("/beside/<safepurepath:some_path>/shakespeare", request_path, expected_arg) for request_path, expected_arg in (
+        ("/beside/..saxon/shakespeare", PurePath('..saxon'),),
+        ("/beside/saxon/hamlet123/shakespeare", PurePath('saxon/hamlet123'),),
+        ("/beside/saxon/./shakespeare", PurePath('saxon'),),  # note empty part squashed out
+        ("/beside/..saxon../hamlet//shakespeare", PurePath('..saxon../hamlet'),),
+        ("/beside/hamlet-123/.saxon/shakespeare", PurePath('hamlet-123/.saxon'),),
+        ("/beside/shakespeare/shakespeare", PurePath('shakespeare'),),
+    )
+) + tuple(
+    ("/beside/shakespeare/<safepurepath:some_path>", request_path, expected_arg) for request_path, expected_arg in (
+        ("/beside/shakespeare/hamlet//saxon.pdf", PurePath('hamlet/saxon.pdf'),),
+        ("/beside/shakespeare/..hamlet/bards", PurePath('..hamlet/bards'),),
+        ("/beside/shakespeare/hamlet/bard/", PurePath('hamlet/bard'),),
+        ("/beside/shakespeare/saxon_/.ham/let/bards...png", PurePath('saxon_/.ham/let/bards...png'),),
+    )
+))
+def test_safepurepath_acceptable_urls(app, route_pattern, request_path, expected_arg):
+    app.url_map.converters["safepurepath"] = SafePurePathConverter
+
+    @app.route(route_pattern)
+    def some_view(some_path):
+        assert some_path == expected_arg
+        return "Success", 201
+
+    with app.app_context():
+        response = app.test_client().get(request_path)
+        assert response.status_code == 201
+
+
+@pytest.mark.parametrize("arg_value,expected_url", (
+    ("hamlet/saxon", "http://eglington/beside/hamlet/saxon/shakespeare",),
+    (PurePath("hamlet/saxon"), "http://eglington/beside/hamlet/saxon/shakespeare",),
+    # in reality, requesting the following would 404
+    (PurePath("."), "http://eglington/beside/./shakespeare",),
+    (PurePath("../.."), "http://eglington/beside/../../shakespeare",),
+    ("../../", "http://eglington/beside/../..//shakespeare",),
+))
+def test_safepurepath_url_reversing(app, arg_value, expected_url):
+    app.config["SERVER_NAME"] = "eglington"
+    app.url_map.converters["safepurepath"] = SafePurePathConverter
+
+    @app.route("/beside/<safepurepath:some_path>/shakespeare")
+    def some_view(some_path):
+        pass
+
+    with app.app_context():
+        assert url_for("some_view", some_path=arg_value) == expected_url


### PR DESCRIPTION
Spurred by https://trello.com/c/jZVhvJRA

Over fears of double-dots making their way into `<path:...>` route components and causing unexpected access violations, the real way of dealing with this problem is to give us a slightly more powerful version of `<path:...>` - one that will fail to match paths containing only-dot components. It will also return `pathlib.PurePath` instances to reflect the normalized nature of this path that has been passed through and encourage use of proper path-handling tools.