### PR TITLE
documents: remove asserts in favour of explicit checks

### DIFF
--- a/dmutils/documents.py
+++ b/dmutils/documents.py
@@ -81,7 +81,8 @@ def upload_document(uploader, upload_type, documents_url, service, field, file_c
              failed
 
     """
-    assert upload_type in ['documents', 'submissions']
+    if upload_type not in ('documents', 'submissions',):
+        raise ValueError(f"Unexpected upload_type {upload_type!r}")
 
     file_path = generate_file_name(
         service['frameworkSlug'],
@@ -119,7 +120,8 @@ def upload_declaration_documents(
 
 
 def upload_service_documents(uploader, upload_type, documents_url, service, request_files, section, public=True):
-    assert upload_type in ['documents', 'submissions']
+    if upload_type not in ('documents', 'submissions',):
+        raise ValueError(f"Unexpected upload_type {upload_type!r}")
 
     files = {field: request_files[field] for field in section.get_question_ids(type="upload")
              if field in request_files}

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -246,7 +246,7 @@ class TestUploadDocument:
 
     def test_document_upload_with_invalid_upload_type(self):
         uploader = mock.Mock()
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             assert upload_document(
                 uploader,
                 'invalid',


### PR DESCRIPTION
Just a quick one I noticed.

`assert`s are meant as debugging hints, not value enforcement - they should *not* be relied upon in live code. The python runtime is is hypothetically free to omit them.