### PR TITLE
request ids: ensure generated request/trace/span ids are zero-padded 

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '48.4.0'
+__version__ = '48.4.1'

--- a/dmutils/request_id.py
+++ b/dmutils/request_id.py
@@ -75,10 +75,12 @@ class RequestIdRequestMixin(object):
             return None
 
     def _get_new_trace_id(self):
-        return hex(self._traceid_random.randrange(1 << 128))[2:]
+        bitlen = 128
+        return hex(self._traceid_random.randrange(1 << bitlen))[2:].rjust(bitlen // 4, "0")
 
     def _get_new_span_id(self):
-        return hex(self._spanid_random.randrange(1 << 64))[2:]
+        bitlen = 64
+        return hex(self._spanid_random.randrange(1 << bitlen))[2:].rjust(bitlen // 4, "0")
 
     def get_onwards_request_headers(self):
         """


### PR DESCRIPTION
https://trello.com/c/N4RQMMbr

Including a test.

Bit of an oops that I missed this originally - ah well...