### PR TITLE
Add "cookie probe" system to allow us to properly detect disabled cookies

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '48.4.1'
+__version__ = '48.5.0'

--- a/dmutils/cookie_probe.py
+++ b/dmutils/cookie_probe.py
@@ -1,0 +1,29 @@
+from datetime import timedelta
+
+
+
+DEFAULT_DM_COOKIE_PROBE_COOKIE_NAME = "dm_cookie_probe"
+DEFAULT_DM_COOKIE_PROBE_COOKIE_VALUE = "yum"
+DEFAULT_DM_COOKIE_PROBE_COOKIE_MAX_AGE = timedelta(days=365).total_seconds()
+DEFAULT_DM_COOKIE_PROBE_EXPECT_PRESENT = False
+
+
+def init_app(app):
+    """
+        Unconditionally sets a long-lived cookie on all responses from `app`, which we will
+        easily be able to check for when trying to determine whether cookies are working for a
+        particular client at all.
+    """
+    app.config.setdefault("DM_COOKIE_PROBE_COOKIE_NAME", DEFAULT_DM_COOKIE_PROBE_COOKIE_NAME)
+    app.config.setdefault("DM_COOKIE_PROBE_COOKIE_VALUE", DEFAULT_DM_COOKIE_PROBE_COOKIE_VALUE)
+    app.config.setdefault("DM_COOKIE_PROBE_COOKIE_MAX_AGE", DEFAULT_DM_COOKIE_PROBE_COOKIE_MAX_AGE)
+    app.config.setdefault("DM_COOKIE_PROBE_COOKIE_EXPECT_PRESENT", DEFAULT_DM_COOKIE_PROBE_EXPECT_PRESENT)
+
+    @app.after_request
+    def set_probe_cookie(response):
+        response.set_cookie(
+            app.config["DM_COOKIE_PROBE_COOKIE_NAME"],
+            app.config["DM_COOKIE_PROBE_COOKIE_VALUE"],
+            max_age=app.config["DM_COOKIE_PROBE_COOKIE_MAX_AGE"],
+        )
+        return response

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 import os
 from types import MappingProxyType
 
-from dmutils import config, logging, proxy_fix, request_id, formats, filters
+from dmutils import config, logging, proxy_fix, request_id, formats, filters, cookie_probe
 from dmutils.errors import api as api_errors, frontend as fe_errors
 from dmutils.urls import SafePurePathConverter
 from flask_script import Manager, Server
@@ -51,6 +51,7 @@ def init_app(
     logging.init_app(application)
     proxy_fix.init_app(application)
     request_id.init_app(application)
+    cookie_probe.init_app(application)
 
     if bootstrap:
         bootstrap.init_app(application)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,13 +7,13 @@ from logging import Logger, StreamHandler
 
 from boto.ec2.cloudwatch import CloudWatchConnection
 
-from dmutils.logging import init_app
+from dmutils.logging import init_app as logging_init_app
 
 
 def create_app(request):
     app = Flask(__name__)
     app.root_path = request.fspath.dirname
-    init_app(app)
+    logging_init_app(app)
     app.config['SECRET_KEY'] = 'secret_key'
     return app
 

--- a/tests/test_cookie_probe.py
+++ b/tests/test_cookie_probe.py
@@ -1,0 +1,24 @@
+from werkzeug.http import parse_cookie
+
+from dmutils import cookie_probe
+
+
+def test_cookie_probe_cookie_present(app):
+    cookie_probe.init_app(app)
+
+    @app.route('/')
+    def error_route():
+        return "<html>Success</html>"
+
+    client = app.test_client()
+    assert not client.cookie_jar  # i.e. empty
+
+    response = client.get('/')
+
+    assert response.status_code == 200
+    assert any(
+        name == app.config["DM_COOKIE_PROBE_COOKIE_NAME"] and value == app.config["DM_COOKIE_PROBE_COOKIE_VALUE"]
+        for name, value in (
+            tuple(parse_cookie(raw).items())[0] for raw in response.headers.getlist("Set-Cookie")
+        )
+    )


### PR DESCRIPTION
https://trello.com/c/HsZ9mj7o

Called this "cookie probe" instead of "test cookie" because we already overload the term "test" enough.

This consists of two parts: a piece of middleware to set a long-lived "probe" cookie on every response and a check for this which ends up being in the `csrf_handler` for reasons explained in the comments.

The latter check needs to be enabled using the config setting `DM_COOKIE_PROBE_EXPECT_PRESENT`, but only *after* we've rolled out the cookie-setting half to all frontends, so we can reliably expect the cookie to be present.