### PR TITLE
add DMGzipMiddleware, a thin wrapper around Flask_gzip adding header-controllability & instrumentation

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '48.5.0'
+__version__ = '48.6.0'

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
          'Flask-Script>=2.0.6',
          'Flask-WTF>=0.14.2',
          'Flask<1.1,>=1.0.2',
+         'Flask-gzip>=0.2',
          'Flask-Login>=0.2.11',
          'boto3<2,>=1.7.83',
          'contextlib2>=0.4.0',

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -1,0 +1,55 @@
+from dmutils.flask import DMGzipMiddleware
+
+
+class TestDMGzipMiddleware:
+    def test_with_compression_safe_header(self, app):
+        DMGzipMiddleware(app, compress_by_default=False)
+
+        @app.route('/')
+        def some_route():
+            return "!" * 9000, 200, {"X-Compression-Safe": "1"}
+
+        response = app.test_client().get('/', headers={"Accept-Encoding": "gzip"})
+        assert response.status_code == 200
+        assert response.headers["Content-Encoding"] == "gzip"
+        assert len(response.get_data()) < 9000
+        assert "X-Compression-Safe" not in response.headers
+
+    def test_with_compression_unsafe_header(self, app):
+        DMGzipMiddleware(app, compress_by_default=False)
+
+        @app.route('/')
+        def some_route():
+            return "!" * 9000, 200, {"X-Compression-Safe": "0"}
+
+        response = app.test_client().get('/', headers={"Accept-Encoding": "gzip"})
+        assert response.status_code == 200
+        assert response.headers.get("Content-Encoding") != "gzip"
+        assert len(response.get_data()) == 9000
+        assert "X-Compression-Safe" not in response.headers
+
+    def test_with_compression_default_false(self, app):
+        DMGzipMiddleware(app)
+
+        @app.route('/')
+        def some_route():
+            return "!" * 9000, 200
+
+        response = app.test_client().get('/', headers={"Accept-Encoding": "gzip"})
+        assert response.status_code == 200
+        assert response.headers.get("Content-Encoding") != "gzip"
+        assert len(response.get_data()) == 9000
+        assert "X-Compression-Safe" not in response.headers
+
+    def test_with_compression_default_true(self, app):
+        DMGzipMiddleware(app, compress_by_default=True)
+
+        @app.route('/')
+        def some_route():
+            return "!" * 9000, 200
+
+        response = app.test_client().get('/', headers={"Accept-Encoding": "gzip"})
+        assert response.status_code == 200
+        assert response.headers["Content-Encoding"] == "gzip"
+        assert len(response.get_data()) < 9000
+        assert "X-Compression-Safe" not in response.headers


### PR DESCRIPTION
https://trello.com/c/Kd4qas51

This should make us (me) more comfortable about rolling out compression to other apps.

Bumped the default min size to 8k to ensure it really is only used when needed.