### PR TITLE
DMGzipMiddleware: emit warning when middleware receives an unknown X-Compression-Safe value

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '48.6.0'
+__version__ = '48.6.1'


### PR DESCRIPTION
@lfdebrux had a point in https://github.com/alphagov/digitalmarketplace-utils/pull/537 that the choice of `0`, `1` as `X-Compression-Safe`'s values may seem funny to some - I still think it's the best choice but in case anyone misses the plot let's at least have a warning so developers know when an attempted use isn't having the effect they expect it to.