### PR TITLE
Allow individual app views to set their own X-Frame-Options header

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '48.6.1'
+__version__ = '48.7.0'

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -69,7 +69,10 @@ def init_app(
 
     @application.after_request
     def add_header(response):
-        response.headers['X-Frame-Options'] = 'DENY'
+        # Block sites from rendering our views inside <iframe>, <embed>, etc by default.
+        # Individual views may set their own value (e.g. 'SAMEORIGIN')
+        if not response.headers.get('X-Frame-Options'):
+            response.headers.setdefault('X-Frame-Options', 'DENY')
         return response
 
     # Make filters accessible in templates.

--- a/tests/test_flask_init.py
+++ b/tests/test_flask_init.py
@@ -1,4 +1,7 @@
-from dmutils.flask_init import pluralize
+from flask import Flask
+
+from dmutils.flask_init import pluralize, init_app
+import mock
 import pytest
 
 
@@ -9,3 +12,78 @@ import pytest
 ])
 def test_pluralize(count, singular, plural, output):
     assert pluralize(count, singular, plural) == output
+
+
+class TestFlaskInit:
+
+    def setup(self):
+        self.application = Flask("mytestapp")
+
+    def test_init_app_sets_digitalmarketplace_env_config(self):
+        init_app(self.application, {})
+        assert self.application.config['DM_ENVIRONMENT'] == 'development'
+        assert self.application.config['ENV'] == 'development'
+
+    def test_init_app_sets_logging_config(self):
+        init_app(self.application, {})
+        assert self.application.config['DM_LOG_LEVEL'] == 'INFO'
+        assert self.application.config['DM_APP_NAME'] == 'none'
+
+    def test_init_app_sets_request_id_config(self):
+        init_app(self.application, {})
+        assert self.application.config['DM_TRACE_ID_HEADERS'] == ('DM-Request-ID', "X-B3-TraceId")
+        assert self.application.config['DM_SPAN_ID_HEADERS'] == ('X-B3-SpanId', )
+        assert self.application.config['DM_PARENT_SPAN_ID_HEADERS'] == ('X-B3-ParentSpanId', )
+        assert self.application.config['DM_IS_SAMPLED_HEADERS'] == ('X-B3-Sampled', )
+        assert self.application.config['DM_DEBUG_FLAG_HEADERS'] == ('X-B3-Flags', )
+        assert self.application.config['DM_REQUEST_ID_HEADER'] == 'DM-Request-ID'
+
+    def test_init_app_sets_cookie_probe_config(self):
+        init_app(self.application, {})
+        assert self.application.config['DM_COOKIE_PROBE_COOKIE_EXPECT_PRESENT'] is False
+        assert self.application.config['DM_COOKIE_PROBE_COOKIE_MAX_AGE'] == 31536000.0
+        assert self.application.config['DM_COOKIE_PROBE_COOKIE_NAME'] == 'dm_cookie_probe'
+        assert self.application.config['DM_COOKIE_PROBE_COOKIE_VALUE'] == 'yum'
+
+    def test_init_app_registers_custom_template_filters(self):
+        init_app(self.application, {})
+        expected_filters = [
+            'capitalize_first',
+            'format_links',
+            'nbsp',
+            'smartjoin',
+            'preserve_line_breaks',
+            'sub_country_codes',
+            'dateformat',
+            'datetimeformat',
+            'datetodatetimeformat',
+            'displaytimeformat',
+            'shortdateformat',
+            'timeformat',
+            'utcdatetimeformat',
+            'utctoshorttimelongdateformat'
+        ]
+        for filter in expected_filters:
+            assert filter in self.application.jinja_env.filters
+
+    def test_init_app_calls_optional_inits(self):
+        bootstrap_mock = mock.Mock()
+        data_api_client_mock = mock.Mock()
+        db_mock = mock.Mock()
+        login_manager_mock = mock.Mock()
+        search_api_client_mock = mock.Mock()
+        init_app(
+            self.application,
+            {},
+            bootstrap=bootstrap_mock,
+            data_api_client=data_api_client_mock,
+            db=db_mock,
+            login_manager=login_manager_mock,
+            search_api_client=search_api_client_mock
+        )
+
+        assert bootstrap_mock.init_app.call_args_list == [mock.call(self.application)]
+        assert data_api_client_mock.init_app.call_args_list == [mock.call(self.application)]
+        assert db_mock.init_app.call_args_list == [mock.call(self.application)]
+        assert login_manager_mock.init_app.call_args_list == [mock.call(self.application)]
+        assert search_api_client_mock.init_app.call_args_list == [mock.call(self.application)]


### PR DESCRIPTION
https://trello.com/c/lvSNZWCR/64-3-create-single-tab-buyer-preview-page-on-briefs-fe

For the DOS preview work, we need to allow an individual view to set the `X-Frame-Options` header to `SAMEORIGIN`, so we can place the result in an `<iframe>`. Currently the `flask_init.init_app` sets this header to `DENY` after every request, overriding any custom header value set by the app view.

This change looks for any existing `X-Frame-Options` header, and sets to `DENY` if the view itself has not provided a value. This should avoid a breaking change to other app views.

If people feel strongly I can do an extra check to only allow `SAMEORIGIN` as an acceptable custom header value, however we may also need `ALLOW-FROM` to support the feature IE Edge (see [browser compatibility table](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options), and I didn't want to overcomplicate this change.

I've also started some basic unit tests for `init_app` as I always have to double check what it's actually doing when I work on it - mostly setting config, adding template filters, registering error handlers etc. We test (some of) this behaviour in (some of) the apps we pull `dmutils` into, and I intend to test the `X-Frame-Options` change in the Briefs FE, so these tests don't have to be super-extensive yet.