### PR TITLE
Change the default port for the search api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Records breaking changes from major version bumps
 
+## 49.0.0
+
+PR [#540](https://github.com/alphagov/digitalmarketplace-scripts/pull/540)
+
+Change the default search api port for development environments.
+
 ## 48.0.0
 
 PR [#504](https://github.com/alphagov/digitalmarketplace-utils/pull/509)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '48.8.0'
+__version__ = '49.0.0'

--- a/dmutils/env_helpers.py
+++ b/dmutils/env_helpers.py
@@ -18,7 +18,7 @@ def get_api_endpoint_from_stage(stage, app='api'):
 
     dev_ports = {
         "api": os.getenv("DM_API_PORT", 5000),
-        "search-api": os.getenv("DM_SEARCH_API_PORT", 5001),
+        "search-api": os.getenv("DM_SEARCH_API_PORT", 5009),
         "antivirus-api": os.getenv("DM_ANTIVIRUS_API_PORT", 5008),
     }
 

--- a/dmutils/env_helpers.py
+++ b/dmutils/env_helpers.py
@@ -1,3 +1,6 @@
+import os
+
+
 def get_api_endpoint_from_stage(stage, app='api'):
     """Return the full URL of given API or Search API environment.
 
@@ -14,9 +17,9 @@ def get_api_endpoint_from_stage(stage, app='api'):
     }
 
     dev_ports = {
-        'api': 5000,
-        'search-api': 5001,
-        'antivirus-api': 5008,
+        "api": os.getenv("DM_API_PORT", 5000),
+        "search-api": os.getenv("DM_SEARCH_API_PORT", 5001),
+        "antivirus-api": os.getenv("DM_ANTIVIRUS_API_PORT", 5008),
     }
 
     if stage in ['local', 'dev', 'development']:

--- a/tests/test_env_helpers.py
+++ b/tests/test_env_helpers.py
@@ -29,7 +29,7 @@ class TestGetAPIEndpointFromStage:
     @pytest.mark.parametrize("stage", ["local", "dev", "development"])
     def test_get_search_api_endpoint_for_dev_environments(self, stage):
         with patch.dict("os.environ", {}):
-            assert get_api_endpoint_from_stage(stage, app="search-api") == "http://localhost:5001"
+            assert get_api_endpoint_from_stage(stage, app="search-api") == "http://localhost:5009"
 
         with patch.dict("os.environ", {"DM_SEARCH_API_PORT": "9001"}):
             assert get_api_endpoint_from_stage(stage, app="search-api") == "http://localhost:9001"

--- a/tests/test_env_helpers.py
+++ b/tests/test_env_helpers.py
@@ -1,12 +1,19 @@
+from unittest.mock import patch
+
 import pytest
+
 from dmutils.env_helpers import get_api_endpoint_from_stage, get_assets_endpoint_from_stage, get_web_url_from_stage
 
 
 class TestGetAPIEndpointFromStage:
 
-    @pytest.mark.parametrize('stage', ['local', 'dev', 'development'])
+    @pytest.mark.parametrize("stage", ["local", "dev", "development"])
     def test_get_api_endpoint_for_dev_environments(self, stage):
-        assert get_api_endpoint_from_stage(stage) == 'http://localhost:5000'
+        with patch.dict("os.environ", {}):
+            assert get_api_endpoint_from_stage(stage) == "http://localhost:5000"
+
+        with patch.dict("os.environ", {"DM_API_PORT": "9000"}):
+            assert get_api_endpoint_from_stage(stage) == "http://localhost:9000"
 
     @pytest.mark.parametrize(
         'stage, expected_result',
@@ -19,9 +26,13 @@ class TestGetAPIEndpointFromStage:
     def test_get_api_endpoint_for_non_dev_environments(self, stage, expected_result):
         assert get_api_endpoint_from_stage(stage) == expected_result
 
-    @pytest.mark.parametrize('stage', ['local', 'dev', 'development'])
+    @pytest.mark.parametrize("stage", ["local", "dev", "development"])
     def test_get_search_api_endpoint_for_dev_environments(self, stage):
-        assert get_api_endpoint_from_stage(stage, app='search-api') == 'http://localhost:5001'
+        with patch.dict("os.environ", {}):
+            assert get_api_endpoint_from_stage(stage, app="search-api") == "http://localhost:5001"
+
+        with patch.dict("os.environ", {"DM_SEARCH_API_PORT": "9001"}):
+            assert get_api_endpoint_from_stage(stage, app="search-api") == "http://localhost:9001"
 
     @pytest.mark.parametrize(
         'stage, expected_result',


### PR DESCRIPTION
2nd line ticket: https://trello.com/c/cwjzIU8U/1212-stop-search-api-from-using-port-5001

See the PR on the search api that adds `DM_SEARCH_API_PORT` for more details: https://github.com/alphagov/digitalmarketplace-search-api/pull/241