### PR TITLE
Add shared footer URLs to external routes

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '48.7.0'
+__version__ = '48.8.0'

--- a/dmutils/external.py
+++ b/dmutils/external.py
@@ -44,6 +44,21 @@ def help():
     raise NotImplementedError()
 
 
+@external.route('/terms-and-conditions')
+def terms_and_conditions():
+    raise NotImplementedError()
+
+
+@external.route('/privacy-notice')
+def privacy_notice():
+    raise NotImplementedError()
+
+
+@external.route('/cookies')
+def cookies():
+    raise NotImplementedError()
+
+
 # Supplier frontend
 
 @external.route('/suppliers')


### PR DESCRIPTION
https://trello.com/c/OYUBf016/71-add-footer-component-to-digital-marketplace-govuk-frontend-decision-on-urls-for-footer

Our footer template currently has a mixture of hardcoded and dynamic links. This PR adds the three hardcoded URLs to the `dmutils.external` blueprint, to make them available across all the FE apps. (See the [Buyer FE](https://github.com/alphagov/digitalmarketplace-buyer-frontend/blob/master/app/__init__.py#L105) for an example of where we use these external routes.)