### PR TITLE
bump werkzeug restriction to >=0.16,<0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Records breaking changes from major version bumps
 
+## 50.0.0
+
+PR [#542](https://github.com/alphagov/digitalmarketplace-scripts/pull/542)
+
+Bumping the werkzeug version restriction. Test & deploy with extra care.
+
 ## 49.0.0
 
 PR [#540](https://github.com/alphagov/digitalmarketplace-scripts/pull/540)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '49.0.0'
+__version__ = '50.0.0'

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
          'python-json-logger<0.2,>=0.1.4',
          'pytz',
          'unicodecsv>=0.14.1',
-         'Werkzeug>=0.15.1,<0.16.0',
+         'Werkzeug>=0.16,<0.17',
          'workdays>=1.4',
     ],
     python_requires="==3.6.*",


### PR DESCRIPTION
https://trello.com/c/dz3EnMnh

What do people think of me adding this `python-dateutil` restriction here? It's demanded by `botocore 1.13.15`, but of course _could_ be mandated in-app instead...?