### PR TITLE
Add support for GOV.UK Frontend error components

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '50.0.1'
+__version__ = '50.1.0'

--- a/dmutils/forms/helpers.py
+++ b/dmutils/forms/helpers.py
@@ -19,13 +19,71 @@ def remove_csrf_token(data):
 
 
 def get_errors_from_wtform(form):
-    """Converts errors from a Flask-WTForm into the same format we generate from content-loader forms. This allows us
-    to treat errors from both content-loader forms and wtforms the same way inside templates.
+    """Converts Flask-WTForm errors into formats suitable for use in Digital Marketplace templates.
+
+    Returns a dictionary with the following keys, supporting three types of error display:
+
+    1) digitalmarketplace-frontend-toolkit template toolkit/forms/validation.html:
+      `input_name`, `question`, `message`
+
+    2) govuk-frontend macro govukErrorSummary:
+      `text`, `href`
+
+    3) govuk-frontend errorMessage:
+      `errorMessage`
+
+    This allows us to treat errors from both content-loader forms and wtforms the same way inside templates,
+    and provides backwards-compatible support for the migration to using govuk-frontend components.
+
+    Example usage:
+
+        # app.py
+        class Form(FlaskForm):
+            input = DMTextInput()
+
+        @flask.route("/")
+        def view():
+            form = Form()
+            errors = get_errors_from_wtform()
+            return render(
+                "template.html",
+                errors=errors,
+            )
+
+        # template.html  (govuk-frontend)
+        {{ govukErrorSummary({
+            "errorList": errors.values()
+        }) }}
+
+        {{ govukTextInput({
+            "errorMessage": errors.input.errorMessage,
+        }) }}
+
+        # template.html (DM frontend toolkit uses 'errors' by default)
+        {% include 'toolkit/forms/validation.html' %}
+
     :param form: A Flask-WTForm
-    :return: A dict with three keys: `input_name`, `question`, and `message` suitable for passing into templates.
+    :return: A dict with error information in a form suitable for Digital Marketplace templates
     """
     return OrderedDict(
-        (key, {'input_name': key, 'question': form[key].label.text, 'message': form[key].errors[0]})
+        # TODO: remove legacy code (items for frontend toolkit validation banners, 'input-' prefix)
+        (
+            key,
+            {
+                # parameters for digitalmarketplace-frontend-toolkit template toolkit/forms/validation.html
+                "input_name": key, "question": form[key].label.text, "message": form[key].errors[0],
+
+                # parameters for govuk-frontend macro govukErrorSummary
+                "text": form[key].errors[0], "href": f"#input-{key}",
+
+                # parameters for govuk-frontend errorMessage parameter
+                "errorMessage": (
+                    {"text": form[key].errors[0]}
+                    if form[key].errors[0]
+                    else {}
+                )
+            }
+        )
         for key in
         form.errors.keys()
     )


### PR DESCRIPTION
Ticket: https://trello.com/c/jy1qTEQN/132-replace-validation-banner-with-govuk-frontend-error-summary-component-in-user-frontend

We want to be able to use the GOV.UK Frontend error summary component in our frontend apps.

This commit adds the expected parameters for the `govukErrorSummary` component to the output of `get_errors_from_wtform`, so that you can create an error summary for a WTForms form using

    # view.py
    errors = get_errors_from_wtform(form)

    # template.html
    {{ govukErrorSummary({
      "errorList": errors.values()
    }) }}

    {{ govukTextInput({
      "errorMessage": errors.input.message
    }) }}

This change should be backwards compatible.

---

Note that the GOV.UK Frontend versions use the error message to populate the error summary, which is different to the frontend toolkit style; see https://github.com/alphagov/digitalmarketplace-user-frontend/pull/190 for an example of these changes in use.