### PR TITLE
Remove upper restriction on Python versions

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '50.0.0'
+__version__ = '50.0.1'

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,5 @@ setup(
          'Werkzeug>=0.16,<0.17',
          'workdays>=1.4',
     ],
-    python_requires="==3.6.*",
+    python_requires="~=3.6",
 )


### PR DESCRIPTION
https://trello.com/c/GsDBHBo7/135-switch-on-python-37-and-38-travis-checks-to-check-potential-dependency-problems-before-upgrade

The `~=` syntax denotes we don't fully support higher versions yet:

https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires