### PR TITLE
Add 'noopener noreferrer' to external links opening in a new tab

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '50.2.0'
+__version__ = '50.2.1'

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -32,7 +32,7 @@ def format_links(text, open_links_in_new_tab=None):
     matched_urls = [type(text)(substr) for substr in url_match.findall(text)]
     if matched_urls:
         if open_links_in_new_tab:
-            link = '<a href="{0}" class="break-link" rel="external" target="_blank">{0}</a>'
+            link = '<a href="{0}" class="break-link" rel="external noreferrer noopener" target="_blank">{0}</a>'
         else:
             link = '<a href="{0}" class="break-link" rel="external">{0}</a>'
         plaintext_link = '<span class="break-link">{0}</span>'

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -70,7 +70,7 @@ class TestFormatLinks:
 
     def test_format_links_open_links_in_new_tab(self):
         link = 'http://www.example.com'
-        link_new_tab = '<a href="http://www.example.com" class="break-link" rel="external" target="_blank">http://www.example.com</a>'  # noqa
+        link_new_tab = '<a href="http://www.example.com" class="break-link" rel="external noreferrer noopener" target="_blank">http://www.example.com</a>'  # noqa
         assert format_links(link, open_links_in_new_tab=True) == link_new_tab
 
     def test_multiple_urls(self):


### PR DESCRIPTION
https://trello.com/c/WSCRVNH8/149-allow-buyers-to-preview-external-links-on-their-brief

For links opening in a new tab, we want to ensure users aren't vulnerable to `window.opener` Javascript attacks (see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#Security_and_privacy).

(Thanks @lfdebrux for spotting this!)