### PR TITLE
Add helpers for turning content loader errors into govuk errors

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -36,6 +36,7 @@ in (with args; {
 
     hardeningDisable = pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [ "format" ];
 
+    GIT_SSL_CAINFO="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
     VIRTUALENV_ROOT = (toString (./.)) + "/venv${pythonPackages.python.pythonVersion}";
     VIRTUAL_ENV_DISABLE_PROMPT = "1";
     SOURCE_DATE_EPOCH = "315532800";

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '50.2.1'
+__version__ = '50.3.0'

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '50.3.0'
+__version__ = '50.4.0'

--- a/dmutils/forms/errors.py
+++ b/dmutils/forms/errors.py
@@ -83,3 +83,74 @@ def govuk_errors(errors: typing.Mapping[str, ErrorMapping]) -> typing_OrderedDic
     return OrderedDict(
         (key, {**error, **govuk_error(error)}) for key, error in errors.items()
     )
+
+
+def get_errors_from_wtform(form):
+    """Converts Flask-WTForm errors into formats suitable for use in Digital Marketplace templates.
+
+    Returns a dictionary with the following keys, supporting three types of error display:
+
+    1) digitalmarketplace-frontend-toolkit template toolkit/forms/validation.html:
+      `input_name`, `question`, `message`
+
+    2) govuk-frontend macro govukErrorSummary:
+      `text`, `href`
+
+    3) govuk-frontend errorMessage:
+      `errorMessage`
+
+    This allows us to treat errors from both content-loader forms and wtforms the same way inside templates,
+    and provides backwards-compatible support for the migration to using govuk-frontend components.
+
+    Example usage:
+
+        # app.py
+        class Form(FlaskForm):
+            input = DMTextInput()
+
+        @flask.route("/")
+        def view():
+            form = Form()
+            errors = get_errors_from_wtform()
+            return render(
+                "template.html",
+                errors=errors,
+            )
+
+        # template.html  (govuk-frontend)
+        {{ govukErrorSummary({
+            "errorList": errors.values()
+        }) }}
+
+        {{ govukTextInput({
+            "errorMessage": errors.input.errorMessage,
+        }) }}
+
+        # template.html (DM frontend toolkit uses 'errors' by default)
+        {% include 'toolkit/forms/validation.html' %}
+
+    :param form: A Flask-WTForm
+    :return: A dict with error information in a form suitable for Digital Marketplace templates
+    """
+    return OrderedDict(
+        # TODO: remove legacy code (items for frontend toolkit validation banners, 'input-' prefix)
+        (
+            key,
+            {
+                # parameters for digitalmarketplace-frontend-toolkit template toolkit/forms/validation.html
+                "input_name": key, "question": form[key].label.text, "message": form[key].errors[0],
+
+                # parameters for govuk-frontend macro govukErrorSummary
+                "text": form[key].errors[0], "href": f"#input-{key}",
+
+                # parameters for govuk-frontend errorMessage parameter
+                "errorMessage": (
+                    {"text": form[key].errors[0]}
+                    if form[key].errors[0]
+                    else {}
+                )
+            }
+        )
+        for key in
+        form.errors.keys()
+    )

--- a/dmutils/forms/errors.py
+++ b/dmutils/forms/errors.py
@@ -1,0 +1,78 @@
+from collections import OrderedDict
+
+
+def govuk_error(error):
+    if error:
+        text = error.get("message", error.get("question", ""))
+        return {
+            "text": text,
+            "href": f"#input-{error['input_name']}",
+            "errorMessage": {"text": text},
+        }
+    else:
+        return {}
+
+
+def govuk_errors(errors):
+    """Converts digitalmarketplace-frontend-toolkit style errors into a format
+    suitable for use with either digitalmarketplace-frontend-toolkit
+    templates/macros or govuk-frontend macros.
+
+    Returns a dictionary with the following keys, supporting three types of
+    error display:
+
+    1) digitalmarketplace-frontend-toolkit template toolkit/forms/validation.html:
+      `input_name`, `question`, `message`
+
+    2) govuk-frontend macro govukErrorSummary:
+      `text`, `href`
+
+    3) govuk-frontend errorMessage:
+      `errorMessage`
+
+    This allows us to treat errors from both content-loader forms and wtforms
+    the same way inside templates,
+    and provides backwards-compatible support for the migration to using
+    govuk-frontend components.
+
+    Example usage:
+
+        # app.py
+
+        @flask.route("/", methods=["GET", "POST"])
+        def view():
+            section = content_loader.get_section()
+            try:
+                data_api_client.update_something()
+            except HTTPError as e:
+                errors = govuk_errors(
+                    section.get_error_messages(e.message)
+                )
+
+            return render(
+                "template.html",
+                question=section,
+                errors=errors,
+            )
+
+        # template.html  (govuk-frontend)
+        {{ govukErrorSummary({
+            "errorList": errors.values()
+        }) }}
+
+        {{ govukTextInput({
+            "errorMessage": errors.input.errorMessage,
+        }) }}
+
+        # template.html (DM frontend toolkit uses 'errors' by default)
+        {% include 'toolkit/forms/validation.html' %}
+
+        {{ forms[question.type](question, service_data, errors) }}
+
+    :param errors: A digitalmarketplace-frontend-toolkit error dictionary
+    :return: A dict with error information in a form suitable for
+             Digital Marketplace templates
+    """
+    return OrderedDict(
+        (key, {**error, **govuk_error(error)}) for key, error in errors.items()
+    )

--- a/dmutils/forms/errors.py
+++ b/dmutils/forms/errors.py
@@ -1,7 +1,14 @@
 from collections import OrderedDict
+import typing
 
 
-def govuk_error(error):
+# TODO use TypedDict once we're on python 3.8 to allow us to be more specific about this mapping's contents
+ErrorMapping = typing.Mapping[str, typing.Any]
+# use typing.OrderedDict if available (python 3.7+)
+typing_OrderedDict = getattr(typing, "OrderedDict", typing.Mapping)
+
+
+def govuk_error(error: ErrorMapping) -> ErrorMapping:
     if error:
         text = error.get("message", error.get("question", ""))
         return {
@@ -13,7 +20,7 @@ def govuk_error(error):
         return {}
 
 
-def govuk_errors(errors):
+def govuk_errors(errors: typing.Mapping[str, ErrorMapping]) -> typing_OrderedDict[str, ErrorMapping]:
     """Converts digitalmarketplace-frontend-toolkit style errors into a format
     suitable for use with either digitalmarketplace-frontend-toolkit
     templates/macros or govuk-frontend macros.

--- a/dmutils/forms/helpers.py
+++ b/dmutils/forms/helpers.py
@@ -1,5 +1,6 @@
 
-from collections import OrderedDict
+# allow importing from dmutils.forms.helpers for backwards compatibility
+from .errors import get_errors_from_wtform  # noqa: F401
 
 
 def remove_csrf_token(data):
@@ -16,74 +17,3 @@ def remove_csrf_token(data):
         del cleaned_data['csrf_token']
 
     return cleaned_data
-
-
-def get_errors_from_wtform(form):
-    """Converts Flask-WTForm errors into formats suitable for use in Digital Marketplace templates.
-
-    Returns a dictionary with the following keys, supporting three types of error display:
-
-    1) digitalmarketplace-frontend-toolkit template toolkit/forms/validation.html:
-      `input_name`, `question`, `message`
-
-    2) govuk-frontend macro govukErrorSummary:
-      `text`, `href`
-
-    3) govuk-frontend errorMessage:
-      `errorMessage`
-
-    This allows us to treat errors from both content-loader forms and wtforms the same way inside templates,
-    and provides backwards-compatible support for the migration to using govuk-frontend components.
-
-    Example usage:
-
-        # app.py
-        class Form(FlaskForm):
-            input = DMTextInput()
-
-        @flask.route("/")
-        def view():
-            form = Form()
-            errors = get_errors_from_wtform()
-            return render(
-                "template.html",
-                errors=errors,
-            )
-
-        # template.html  (govuk-frontend)
-        {{ govukErrorSummary({
-            "errorList": errors.values()
-        }) }}
-
-        {{ govukTextInput({
-            "errorMessage": errors.input.errorMessage,
-        }) }}
-
-        # template.html (DM frontend toolkit uses 'errors' by default)
-        {% include 'toolkit/forms/validation.html' %}
-
-    :param form: A Flask-WTForm
-    :return: A dict with error information in a form suitable for Digital Marketplace templates
-    """
-    return OrderedDict(
-        # TODO: remove legacy code (items for frontend toolkit validation banners, 'input-' prefix)
-        (
-            key,
-            {
-                # parameters for digitalmarketplace-frontend-toolkit template toolkit/forms/validation.html
-                "input_name": key, "question": form[key].label.text, "message": form[key].errors[0],
-
-                # parameters for govuk-frontend macro govukErrorSummary
-                "text": form[key].errors[0], "href": f"#input-{key}",
-
-                # parameters for govuk-frontend errorMessage parameter
-                "errorMessage": (
-                    {"text": form[key].errors[0]}
-                    if form[key].errors[0]
-                    else {}
-                )
-            }
-        )
-        for key in
-        form.errors.keys()
-    )

--- a/tests/forms/test_errors.py
+++ b/tests/forms/test_errors.py
@@ -1,0 +1,46 @@
+from collections import OrderedDict
+
+import pytest
+
+from dmutils.forms.errors import govuk_errors
+
+
+@pytest.mark.parametrize("dm_errors,expected_output", (
+    ({}, OrderedDict()),
+    (
+        OrderedDict((
+            ("haddock", {
+                "input_name": "haddock",
+                "question": "What was that, Joe?",
+                "message": "Too numerous to be enumerated",
+            },),
+            ("pollock", {},),
+            ("flounder", {
+                "input_name": "flounder",
+                "question": "Anything strange or wonderful, Joe?",
+                "roach": "halibut",
+            },),
+        )),
+        OrderedDict((
+            ("haddock", {
+                "input_name": "haddock",
+                "question": "What was that, Joe?",
+                "message": "Too numerous to be enumerated",
+                "text": "Too numerous to be enumerated",
+                "href": "#input-haddock",
+                "errorMessage": {"text": "Too numerous to be enumerated"},
+            },),
+            ("pollock", {},),
+            ("flounder", {
+                "input_name": "flounder",
+                "question": "Anything strange or wonderful, Joe?",
+                "roach": "halibut",
+                "text": "Anything strange or wonderful, Joe?",
+                "href": "#input-flounder",
+                "errorMessage": {"text": "Anything strange or wonderful, Joe?"},
+            },),
+        )),
+    ),
+))
+def test_govuk_errors(dm_errors, expected_output):
+    assert govuk_errors(dm_errors) == expected_output


### PR DESCRIPTION
Ticket: https://trello.com/c/xdGjiDqF/160-2-replace-validation-banner-with-govuk-frontend-error-summary-component-in-admin-frontend

---

## Outstanding:

- Tests
- Is this the right place for the module?