### PR TITLE
timing tests: remove testing of timing.exceeds_slow_external_call_threshold

### DIFF
--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -139,7 +139,6 @@ _parameter_combinations = tuple(product(
         timing.logged_duration.default_condition,
         _duration_real_gt_075,
         _default_and_no_exception,
-        timing.exceeds_slow_external_call_threshold,
         timing.request_is_sampled
     ),
     (  # raise_exception values
@@ -169,8 +168,6 @@ def _expect_log(
         (condition is timing.logged_duration.default_condition and (is_sampled or sleep_time > 0.5))
         or (condition is _duration_real_gt_075 and sleep_time >= 0.08)
         or (condition is _default_and_no_exception and is_sampled and raise_exception is None)
-        or (condition is timing.exceeds_slow_external_call_threshold
-            and sleep_time >= timing.SLOW_EXTERNAL_CALL_THRESHOLD)
         or (condition is timing.request_is_sampled and is_sampled)
         or (condition in (True, None,))
     )


### PR DESCRIPTION
It's technically no more interesting than other time threshold cases we already test and this reduces the strength of the dimensional explosion of the parametrization, speeding up the test run, which is welcome.