### PR TITLE
168-spike-check-a-newly-deployed-app-can-connect-to-its-paas-backing-service-timebox-1d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 Records breaking changes from major version bumps
 
+## 51.0.0
+
+Signature change to:
+
+`dmutils/status.py::get_app_status`
+
+```
+get_app_status(
+     search_api_client=None,
+     ignore_dependencies=False,
+     additional_checks=None,
+-    additional_checks_internal=None,
++    additional_checks_extended=None,
+ ):
+```
+
+Additional checks will now always be called regardless of the value of
+`ignore_dependencies`.
+
+New argument `additional_checks_extended` whose checks will only be
+called when `ignore_dependencies=False`.
+
 ## 50.0.0
 
 PR [#542](https://github.com/alphagov/digitalmarketplace-scripts/pull/542)

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '50.4.0'
+__version__ = '51.0.0'


### PR DESCRIPTION
See changelog, change dmutils/status.py::get_app_status to always run additional_checks

https://trello.com/c/B2GfZgfO/192-cause-additionalchecks-to-always-be-run-regardless-of-ignore-dependencies-on-status-endpoint