### PR TITLE
Add 'become a supplier' external route

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test-flake8: virtualenv
 	${VIRTUALENV_ROOT}/bin/flake8 .
 
 .PHONY: test-python
-test-python: virtualenv
+test-python: virtualenv requirements-dev
 	${VIRTUALENV_ROOT}/bin/py.test ${PYTEST_ARGS}
 
 .PHONY: show-environment

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '51.2.0'
+__version__ = '51.3.0'

--- a/dmutils/external.py
+++ b/dmutils/external.py
@@ -71,6 +71,12 @@ def supplier_dashboard():
     raise NotImplementedError()
 
 
+@external.route('/suppliers/supply')
+def become_a_supplier():
+    raise NotImplementedError()
+
+
+# Brief Responses frontend
 @external.route('/suppliers/opportunities/<brief_id>/responses/start')
 def start_brief_response(brief_id):
     raise NotImplementedError()


### PR DESCRIPTION
https://trello.com/c/N85yhHQX/278-add-suppliers-supply-to-external-routes-in-dmutils

This Supplier FE URL is used in the Buyer FE, where it's currently hardcoded.

Also adds in a step to install dev dependencies before running `make test`, as it wasn't doing so. I think the only reason we didn't have it there already was to get round the `freeze-requirements` issue, which we're phasing out.