### PR TITLE
Update cookie settings page external route

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '51.3.0'
+__version__ = '51.3.1'

--- a/dmutils/external.py
+++ b/dmutils/external.py
@@ -4,7 +4,6 @@ external = Blueprint('external', __name__)
 
 
 # Buyer frontend
-
 @external.route('/')
 def index():
     raise NotImplementedError()
@@ -58,8 +57,8 @@ def privacy_notice():
 def cookies():
     raise NotImplementedError()
 
-# Supplier frontend
 
+# Supplier frontend
 @external.route('/suppliers')
 def supplier_dashboard():
     raise NotImplementedError()
@@ -87,14 +86,12 @@ def opportunities_dashboard(framework_slug):
 
 
 # Admin frontend
-
 @external.route('/admin')
 def admin_dashboard():
     raise NotImplementedError()
 
 
 # User frontend
-
 @external.route('/user/create/<encoded_token>')
 def create_user(encoded_token):
     raise NotImplementedError()
@@ -124,8 +121,8 @@ def change_password():
 def cookie_settings():
     raise NotImplementedError()
 
-# Briefs frontend
 
+# Briefs frontend
 @external.route('/buyers')
 def buyer_dashboard():
     raise NotImplementedError()

--- a/dmutils/external.py
+++ b/dmutils/external.py
@@ -58,12 +58,6 @@ def privacy_notice():
 def cookies():
     raise NotImplementedError()
 
-
-@external.route('/cookie-settings')
-def cookie_settings():
-    raise NotImplementedError()
-
-
 # Supplier frontend
 
 @external.route('/suppliers')
@@ -125,6 +119,10 @@ def user_research_consent():
 def change_password():
     raise NotImplementedError()
 
+
+@external.route('/user/cookie-settings')
+def cookie_settings():
+    raise NotImplementedError()
 
 # Briefs frontend
 


### PR DESCRIPTION
https://trello.com/c/hGlNERQ6/294-3-cookie-settings-page-incl-analytics-roll-out

The cookie settings page is now in the User FE app (see https://github.com/alphagov/digitalmarketplace-user-frontend/pull/214), so we need to change the external route for it (and include the `/user/..` prefix).

