### PR TITLE
email tokens: rename *_SALT config variables to *_TOKEN_NS

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '51.3.1'
+__version__ = '51.4.0'

--- a/dmutils/email/tokens.py
+++ b/dmutils/email/tokens.py
@@ -1,6 +1,8 @@
 import base64
 import json
 import struct
+from warnings import warn
+
 
 from datetime import datetime, timedelta
 
@@ -100,7 +102,11 @@ def decode_password_reset_token(token, data_api_client):
         decoded, token_timestamp = decode_token(
             token,
             current_app.config["SHARED_EMAIL_KEY"],
-            current_app.config["RESET_PASSWORD_SALT"],
+            (
+                current_app.config.get('RESET_PASSWORD_TOKEN_NS')
+                or warn("RESET_PASSWORD_SALT has been renamed RESET_PASSWORD_TOKEN_NS", DeprecationWarning)
+                or current_app.config['RESET_PASSWORD_SALT']
+            ),
             ONE_DAY_IN_SECONDS,
         )
     except fernet.InvalidToken as e:
@@ -138,8 +144,12 @@ def decode_invitation_token(encoded_token):
         token, _ = decode_token(
             encoded_token,
             current_app.config['SHARED_EMAIL_KEY'],
-            current_app.config['INVITE_EMAIL_SALT'],
-            SEVEN_DAYS_IN_SECONDS
+            (
+                current_app.config.get('INVITE_EMAIL_TOKEN_NS')
+                or warn("INVITE_EMAIL_SALT has been renamed INVITE_EMAIL_TOKEN_NS", DeprecationWarning)
+                or current_app.config['INVITE_EMAIL_SALT']
+            ),
+            SEVEN_DAYS_IN_SECONDS,
         )
         return token
 
@@ -148,8 +158,12 @@ def decode_invitation_token(encoded_token):
             token, _ = decode_token(
                 encoded_token,
                 current_app.config['SHARED_EMAIL_KEY'],
-                current_app.config['INVITE_EMAIL_SALT'],
-                None
+                (
+                    current_app.config.get('INVITE_EMAIL_TOKEN_NS')
+                    or warn("INVITE_EMAIL_SALT has been renamed INVITE_EMAIL_TOKEN_NS", DeprecationWarning)
+                    or current_app.config['INVITE_EMAIL_SALT']
+                ),
+                None,
             )
 
             current_app.logger.info("Invitation reset attempt with expired token. error {error}",

--- a/dmutils/email/user_account_email.py
+++ b/dmutils/email/user_account_email.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 from flask import current_app, session, abort, url_for
 from . import DMNotifyClient, generate_token, EmailError
 from .helpers import hash_string
@@ -15,7 +17,11 @@ def send_user_account_email(role, email_address, template_name_or_id, extra_toke
     token = generate_token(
         token_data,
         current_app.config['SHARED_EMAIL_KEY'],
-        current_app.config['INVITE_EMAIL_SALT']
+        (
+            current_app.config.get('INVITE_EMAIL_TOKEN_NS')
+            or warn("INVITE_EMAIL_SALT has been renamed INVITE_EMAIL_TOKEN_NS", DeprecationWarning)
+            or current_app.config['INVITE_EMAIL_SALT']
+        ),
     )
 
     link_url = url_for('external.create_user', encoded_token=token, _external=True)


### PR DESCRIPTION
https://trello.com/c/AVadfnPO

These are not really salts, and calling them so is likely to confuse and raise alarm bells as they are not used in the secure manner a salt would need to be.

Continue to fall back to `*_SALT` with a `DeprecationWarning` for the time being to enable backward compatibility. We should probably remove this compatibility on the next major bump, but I'm not going to do an omnibump for this.