### PR TITLE
Update install requires

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.egg-info/
 *.pyc
 .cache
+.mypy_cache
 .pytest_cache
 venv*
 .hypothesis

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '51.4.0'
+__version__ = '51.5.0'

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
          'Flask-Script>=2.0.6',
          'Flask-WTF>=0.14.2',
-         'Flask<1.1,>=1.0.2',
+         'Flask<1.1.0,>=1.0.2',
          'Flask-gzip>=0.2',
          'Flask-Login>=0.2.11',
          'boto3<2,>=1.7.83',
@@ -41,7 +41,7 @@ setup(
          'python-json-logger<0.2,>=0.1.4',
          'pytz',
          'unicodecsv>=0.14.1',
-         'Werkzeug>=0.16,<0.17',
+         'Werkzeug>=0.16,<1.1.0',
          'workdays>=1.4',
     ],
     python_requires="~=3.6",

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -22,7 +22,6 @@ from dmutils.urls import SafePurePathConverter
         "/beside/shakespeare/hamlet/../saxon.pdf",
         "/beside/shakespeare/../hamlet/bards",
         "/beside/shakespeare/saxon/hamlet/../bards.png",
-        "/beside/shakespeare//hamlet/saxon.pdf",
     )
 ))
 def test_safepurepath_undesirable_urls(app, route_pattern, request_path):
@@ -33,7 +32,7 @@ def test_safepurepath_undesirable_urls(app, route_pattern, request_path):
         assert False, f"View body not expected to be executed: {some_path!r}"
 
     with app.app_context():
-        response = app.test_client().get(request_path)
+        response = app.test_client().get(request_path, follow_redirects=True)
         assert response.status_code == 404
 
 
@@ -63,7 +62,7 @@ def test_safepurepath_acceptable_urls(app, route_pattern, request_path, expected
         return "Success", 201
 
     with app.app_context():
-        response = app.test_client().get(request_path)
+        response = app.test_client().get(request_path, follow_redirects=True)
         assert response.status_code == 201
 
 


### PR DESCRIPTION
- Update Flask<1.1 to Flask<1.2.0
- Update Werkzeug<0.17 to Werkzeug<1.1

This install requires were causing pip to complain about conflicts with 
apps that were already using these versions in the requirements files.

Hopefully using pip-tools will mean these constraints will be properly 
respected in future :)