### PR TITLE
1504-make-loggeddurationforexternalrequestalways-log-on-error

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '51.5.0'
+__version__ = '51.5.1'

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -80,7 +80,9 @@ def assert_external_service_log_entry(service=r'\w+', description='.+', successf
 
 class PatchExternalServiceLogConditionMixin:
     def setup(self):
-        self.log_condition_patch = mock.patch('dmutils.timing.request_context_and_any_of_slow_call_or_sampled_request')
+        self.log_condition_patch = mock.patch(
+            'dmutils.timing.request_context_and_any_of_slow_call_or_sampled_request_or_exception_in_stack'
+        )
         self.log_condition = self.log_condition_patch.start()
         self.log_condition.return_value = True
 


### PR DESCRIPTION
https://trello.com/c/pOVlqacc/1504-make-loggeddurationforexternalrequestalways-log-on-error

* Make logged_duration_for_external_request always log on exception
* Only add content type is it is not none
* Bugfix version bump to 51.5.1
