### PR TITLE
formats: split out get_localized_datetime() function from _format_date()

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '51.5.1'
+__version__ = '51.6.0'


### PR DESCRIPTION
To support https://trello.com/c/RBJb5rfV

All these date processing functions are nice and all, but none of them currently allow you to recover a `datetime` object from an iso timestamp as commonly returned from the api.

`get_localized_datetime` returns a timezone-localized `datetime` object given an iso timestamp or another `datetime`.