### PR TITLE
Change break-link class name

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '52.0.0'
+__version__ = '52.1.0'

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -32,10 +32,10 @@ def format_links(text, open_links_in_new_tab=None):
     matched_urls = [type(text)(substr) for substr in url_match.findall(text)]
     if matched_urls:
         if open_links_in_new_tab:
-            link = '<a href="{0}" class="break-link" rel="external noreferrer noopener" target="_blank">{0}</a>'
+            link = '<a href="{0}" class="app-break-link" rel="external noreferrer noopener" target="_blank">{0}</a>'
         else:
-            link = '<a href="{0}" class="break-link" rel="external">{0}</a>'
-        plaintext_link = '<span class="break-link">{0}</span>'
+            link = '<a href="{0}" class="app-break-link" rel="external">{0}</a>'
+        plaintext_link = '<span class="app-break-link">{0}</span>'
         text_array = [type(text)(substr) for substr in url_match.split(text)]
         formatted_text_array = []
         for partial_text in text_array:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -31,32 +31,32 @@ class TestSmartJoin:
 class TestFormatLinks:
     def test_format_link(self):
         link = 'http://www.example.com'
-        formatted_link = '<a href="http://www.example.com" class="break-link" rel="external">http://www.example.com</a>'
+        formatted_link = '<a href="http://www.example.com" class="app-break-link" rel="external">http://www.example.com</a>' # noqa
         assert format_links(link) == formatted_link
 
     def test_format_link_without_protocol(self):
         link = 'www.example.com'
-        formatted_link = '<span class="break-link">www.example.com</span>'
+        formatted_link = '<span class="app-break-link">www.example.com</span>'
         assert format_links(link) == formatted_link
 
     def test_format_link_with_text(self):
         text = 'This is the Greek Γ Δ Ε Ζ Η Θ Ι Κ Λ link: http://www.exΔmple.com'
-        formatted_text = 'This is the Greek Γ Δ Ε Ζ Η Θ Ι Κ Λ link: <a href="http://www.exΔmple.com" class="break-link" rel="external">http://www.exΔmple.com</a>'  # noqa
+        formatted_text = 'This is the Greek Γ Δ Ε Ζ Η Θ Ι Κ Λ link: <a href="http://www.exΔmple.com" class="app-break-link" rel="external">http://www.exΔmple.com</a>'  # noqa
         assert format_links(text) == formatted_text
 
     def test_format_link_handles_markup_objects_with_protocol(self):
         text = Markup('<td class="summary-item-field">\n\n<span>Hurray - http://www.example.com is great</span></td>')
-        formatted_text = Markup('<td class="summary-item-field">\n\n<span>Hurray - <a href="http://www.example.com" class="break-link" rel="external">http://www.example.com</a> is great</span></td>')  # noqa
+        formatted_text = Markup('<td class="summary-item-field">\n\n<span>Hurray - <a href="http://www.example.com" class="app-break-link" rel="external">http://www.example.com</a> is great</span></td>')  # noqa
         assert format_links(text) == formatted_text
 
     def test_format_link_handles_markup_objects_without_protocol(self):
         text = Markup('<td class="summary-item-field">\n\n<span>Hurray - www.example.com is great</span></td>')
-        formatted_text = Markup('<td class="summary-item-field">\n\n<span>Hurray - <span class="break-link">www.example.com</span> is great</span></td>')  # noqa
+        formatted_text = Markup('<td class="summary-item-field">\n\n<span>Hurray - <span class="app-break-link">www.example.com</span> is great</span></td>')  # noqa
         assert format_links(text) == formatted_text
 
     def test_format_link_and_text_escapes_extra_html(self):
         text = 'This is the <strong>link</strong>: http://www.example.com'
-        formatted_text = 'This is the &lt;strong&gt;link&lt;/strong&gt;: <a href="http://www.example.com" class="break-link" rel="external">http://www.example.com</a>'  # noqa
+        formatted_text = 'This is the &lt;strong&gt;link&lt;/strong&gt;: <a href="http://www.example.com" class="app-break-link" rel="external">http://www.example.com</a>'  # noqa
         assert format_links(text) == formatted_text
 
     def test_format_link_does_not_die_horribly(self):
@@ -64,20 +64,20 @@ class TestFormatLinks:
                'https://something&lt;span&gt;what&lt;/span&gt;something.com'
         formatted_text = 'This is the URL that made a previous regex die horribly' \
                          '<a href="https://something&amp;lt;span&amp;gt;what&amp;lt;/span&amp;gt;something.com" ' \
-                         'class="break-link" rel="external">https://something&amp;lt;span&amp;gt;what&amp;lt;/span'\
+                         'class="app-break-link" rel="external">https://something&amp;lt;span&amp;gt;what&amp;lt;/span'\
                          '&amp;gt;something.com</a>'
         assert format_links(text) == formatted_text
 
     def test_format_links_open_links_in_new_tab(self):
         link = 'http://www.example.com'
-        link_new_tab = '<a href="http://www.example.com" class="break-link" rel="external noreferrer noopener" target="_blank">http://www.example.com</a>'  # noqa
+        link_new_tab = '<a href="http://www.example.com" class="app-break-link" rel="external noreferrer noopener" target="_blank">http://www.example.com</a>'  # noqa
         assert format_links(link, open_links_in_new_tab=True) == link_new_tab
 
     def test_multiple_urls(self):
         text = 'This is the first link http://www.example.com and this is the second http://secondexample.com.'  # noqa
-        formatted_text = 'This is the first link <a href="http://www.example.com" class="break-link" '\
+        formatted_text = 'This is the first link <a href="http://www.example.com" class="app-break-link" '\
             'rel="external">http://www.example.com</a> and this is the second '\
-            '<a href="http://secondexample.com" class="break-link" rel="external">http://secondexample.com</a>.'
+            '<a href="http://secondexample.com" class="app-break-link" rel="external">http://secondexample.com</a>.'
         assert format_links(text) == formatted_text
 
     def test_no_links_no_change(self):


### PR DESCRIPTION
https://trello.com/c/bcU2s0Zs/33-2-links-in-summary-tables-eg-dos-opportunities-dont-wrap-in-safari-or-chrome

Changing the class name `break-link` to `app-break-link`.