### PR TITLE
Add ability to override href for govuk_error object

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '52.3.0'
+__version__ = '52.4.0'

--- a/dmutils/forms/errors.py
+++ b/dmutils/forms/errors.py
@@ -144,7 +144,7 @@ def get_errors_from_wtform(form):
                 "input_name": key, "question": form[key].label.text, "message": form[key].errors[0],
 
                 # parameters for govuk-frontend macro govukErrorSummary
-                "text": form[key].errors[0], "href": f"#{form[key].id}",
+                "text": form[key].errors[0], "href": f"#{getattr(form[key], 'href', form[key].id)}",
 
                 # parameters for govuk-frontend errorMessage parameter
                 "errorMessage": (

--- a/dmutils/forms/errors.py
+++ b/dmutils/forms/errors.py
@@ -13,7 +13,7 @@ def govuk_error(error: ErrorMapping) -> ErrorMapping:
         text = error.get("message", error.get("question", ""))
         return {
             "text": text,
-            "href": f"#input-{error['input_name']}",
+            "href": error.get("href") or f"#input-{error['input_name']}",
             "errorMessage": {"text": text},
         }
     else:
@@ -102,6 +102,9 @@ def get_errors_from_wtform(form):
     This allows us to treat errors from both content-loader forms and wtforms the same way inside templates,
     and provides backwards-compatible support for the migration to using govuk-frontend components.
 
+    The `href` for the govuk-frontend error summary is derived from the `id` of the form field; if you need to
+    override the `href` for some reason you can do this by passing the correct `id` to the field constructor.
+
     Example usage:
 
         # app.py
@@ -111,7 +114,7 @@ def get_errors_from_wtform(form):
         @flask.route("/")
         def view():
             form = Form()
-            errors = get_errors_from_wtform()
+            errors = get_errors_from_wtform(form)
             return render(
                 "template.html",
                 errors=errors,
@@ -133,7 +136,7 @@ def get_errors_from_wtform(form):
     :return: A dict with error information in a form suitable for Digital Marketplace templates
     """
     return OrderedDict(
-        # TODO: remove legacy code (items for frontend toolkit validation banners, 'input-' prefix)
+        # TODO: remove legacy code (items for frontend toolkit validation banners)
         (
             key,
             {
@@ -141,7 +144,7 @@ def get_errors_from_wtform(form):
                 "input_name": key, "question": form[key].label.text, "message": form[key].errors[0],
 
                 # parameters for govuk-frontend macro govukErrorSummary
-                "text": form[key].errors[0], "href": f"#input-{key}",
+                "text": form[key].errors[0], "href": f"#{form[key].id}",
 
                 # parameters for govuk-frontend errorMessage parameter
                 "errorMessage": (

--- a/dmutils/forms/fields.py
+++ b/dmutils/forms/fields.py
@@ -46,6 +46,12 @@ __all__ = ['DMBooleanField', 'DMDecimalField', 'DMHiddenField', 'DMIntegerField'
 class DMBooleanField(DMFieldMixin, wtforms.fields.BooleanField):
     widget = DMCheckboxInput(hide_question=True)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # digitalmarketplace-frontend-toolkit suffixes the id with `-1`
+        if "id" not in kwargs:
+            self.id = self.id + "-1"
+
     @property
     def options(self):
         return [{"label": self.label.text, "value": self.data}]

--- a/dmutils/forms/fields.py
+++ b/dmutils/forms/fields.py
@@ -50,7 +50,7 @@ class DMBooleanField(DMFieldMixin, wtforms.fields.BooleanField):
         super().__init__(*args, **kwargs)
         # digitalmarketplace-frontend-toolkit suffixes the id with `-1`
         if "id" not in kwargs:
-            self.id = self.id + "-1"
+            self.href = self.href + "-1"
 
     @property
     def options(self):

--- a/dmutils/forms/mixins.py
+++ b/dmutils/forms/mixins.py
@@ -56,11 +56,13 @@ class DMFieldMixin:
     Derived classes which include this mixin should have a
     subclass of `wtforms.Field` in their base classes.
     '''
-    def __init__(self, label=None, validators=None, hint=None, question_advice=None, _id_prefix="input-", **kwargs):
+    def __init__(self, label=None, validators=None, hint=None, question_advice=None, **kwargs):
         super().__init__(label=label, validators=validators, **kwargs)
 
-        if "id" not in kwargs:
-            self.id = _id_prefix + self.id
+        if "id" in kwargs:
+            self.href = kwargs["id"]
+        else:
+            self.href = "input-" + self.id
 
         if hint:
             self.hint = hint
@@ -109,7 +111,8 @@ class DMSelectFieldMixin:
     def __init__(self, label=None, validators=None, coerce=text_type, options=None, **kwargs):
         super().__init__(label, validators=validators, coerce=coerce, **kwargs)
         if "id" not in kwargs:
-            self.id = self.id + "-1"
+            # This should be the id for the first option
+            self.href = self.href + "-1"
         if options:
             self.options = copy(options)
 

--- a/dmutils/forms/mixins.py
+++ b/dmutils/forms/mixins.py
@@ -56,8 +56,12 @@ class DMFieldMixin:
     Derived classes which include this mixin should have a
     subclass of `wtforms.Field` in their base classes.
     '''
-    def __init__(self, label=None, validators=None, hint=None, question_advice=None, **kwargs):
+    def __init__(self, label=None, validators=None, hint=None, question_advice=None, _id_prefix="input-", **kwargs):
         super().__init__(label=label, validators=validators, **kwargs)
+
+        if not "id" in kwargs:
+            self.id = _id_prefix + self.id
+
         if hint:
             self.hint = hint
         if question_advice:

--- a/dmutils/forms/mixins.py
+++ b/dmutils/forms/mixins.py
@@ -59,7 +59,7 @@ class DMFieldMixin:
     def __init__(self, label=None, validators=None, hint=None, question_advice=None, _id_prefix="input-", **kwargs):
         super().__init__(label=label, validators=validators, **kwargs)
 
-        if not "id" in kwargs:
+        if "id" not in kwargs:
             self.id = _id_prefix + self.id
 
         if hint:
@@ -108,6 +108,8 @@ class DMSelectFieldMixin:
     '''
     def __init__(self, label=None, validators=None, coerce=text_type, options=None, **kwargs):
         super().__init__(label, validators=validators, coerce=coerce, **kwargs)
+        if "id" not in kwargs:
+            self.id = self.id + "-1"
         if options:
             self.options = copy(options)
 

--- a/tests/forms/test_dmfields.py
+++ b/tests/forms/test_dmfields.py
@@ -73,13 +73,37 @@ def test_field_id_is_prefixed_with_input_prefix(field_class):
 
     form = TestForm()
 
-    assert form.field.id == "input-field"
+    assert form.field.id.startswith("input-")
 
 
 def test_field_id_is_not_prefixed_with_input_prefix_if_specified(field_class):
     class TestForm(wtforms.Form):
-        field = field_class(id="input-field")
+        field = field_class(id="field")
 
     form = TestForm()
 
-    assert form.field.id == "input-field"
+    assert form.field.id == "field"
+
+
+@pytest.mark.parametrize("field_class", (
+    dmutils.forms.fields.DMRadioField, dmutils.forms.fields.DMBooleanField
+))
+def test_selection_field_id_is_suffixed_with_number(field_class):
+    class TestForm(wtforms.Form):
+        field = field_class()
+
+    form = TestForm()
+
+    assert form.field.id == "input-field-1"
+
+
+@pytest.mark.parametrize("field_class", (
+    dmutils.forms.fields.DMRadioField, dmutils.forms.fields.DMBooleanField
+))
+def test_selection_field_id_is_not_suffixed_with_number_if_id_is_specified(field_class):
+    class TestForm(wtforms.Form):
+        field = field_class(id="field")
+
+    form = TestForm()
+
+    assert form.field.id == "field"

--- a/tests/forms/test_dmfields.py
+++ b/tests/forms/test_dmfields.py
@@ -67,43 +67,43 @@ def test_field_class_can_have_type():
     assert form.field.type == "test_field"
 
 
-def test_field_id_is_prefixed_with_input_prefix(field_class):
+def test_field_href_is_prefixed_with_input_prefix(field_class):
     class TestForm(wtforms.Form):
         field = field_class()
 
     form = TestForm()
 
-    assert form.field.id.startswith("input-")
+    assert form.field.href.startswith("input-")
 
 
-def test_field_id_is_not_prefixed_with_input_prefix_if_specified(field_class):
+def test_field_href_is_not_prefixed_with_input_prefix_if_specified(field_class):
     class TestForm(wtforms.Form):
         field = field_class(id="field")
 
     form = TestForm()
 
-    assert form.field.id == "field"
+    assert form.field.href == "field"
 
 
 @pytest.mark.parametrize("field_class", (
     dmutils.forms.fields.DMRadioField, dmutils.forms.fields.DMBooleanField
 ))
-def test_selection_field_id_is_suffixed_with_number(field_class):
+def test_selection_field_href_is_suffixed_with_number(field_class):
     class TestForm(wtforms.Form):
         field = field_class()
 
     form = TestForm()
 
-    assert form.field.id == "input-field-1"
+    assert form.field.href == "input-field-1"
 
 
 @pytest.mark.parametrize("field_class", (
     dmutils.forms.fields.DMRadioField, dmutils.forms.fields.DMBooleanField
 ))
-def test_selection_field_id_is_not_suffixed_with_number_if_id_is_specified(field_class):
+def test_selection_field_href_is_not_suffixed_with_number_if_id_is_specified(field_class):
     class TestForm(wtforms.Form):
         field = field_class(id="field")
 
     form = TestForm()
 
-    assert form.field.id == "field"
+    assert form.field.href == "field"

--- a/tests/forms/test_dmfields.py
+++ b/tests/forms/test_dmfields.py
@@ -65,3 +65,21 @@ def test_field_class_can_have_type():
 
     form = TestForm()
     assert form.field.type == "test_field"
+
+
+def test_field_id_is_prefixed_with_input_prefix(field_class):
+    class TestForm(wtforms.Form):
+        field = field_class()
+
+    form = TestForm()
+
+    assert form.field.id == "input-field"
+
+
+def test_field_id_is_not_prefixed_with_input_prefix_if_specified(field_class):
+    class TestForm(wtforms.Form):
+        field = field_class(id="input-field")
+
+    form = TestForm()
+
+    assert form.field.id == "input-field"

--- a/tests/forms/test_dmwidgets.py
+++ b/tests/forms/test_dmwidgets.py
@@ -56,6 +56,13 @@ def test_template_context_is_populated_from_field(widget):
         assert k in get_render_context(widget)
 
 
+def test_template_context_does_not_include_id(widget, field):
+    """The id is managed by the template rather than by WTForms"""
+    field.id = "foobar"
+    widget(field)
+    assert "id" not in get_render_context(widget)
+
+
 def test_template_context_includes_hint(widget, field):
     field.hint = "Hint text."
     widget(field)

--- a/tests/forms/test_errors.py
+++ b/tests/forms/test_errors.py
@@ -1,8 +1,10 @@
 from collections import OrderedDict
 
 import pytest
+import wtforms
 
-from dmutils.forms.errors import govuk_errors
+import dmutils.forms.fields as fields
+from dmutils.forms.errors import get_errors_from_wtform, govuk_errors
 
 
 @pytest.mark.parametrize("dm_errors,expected_output", (
@@ -44,3 +46,57 @@ from dmutils.forms.errors import govuk_errors
 ))
 def test_govuk_errors(dm_errors, expected_output):
     assert govuk_errors(dm_errors) == expected_output
+
+
+class RadiosForm(wtforms.Form):
+    radios = fields.DMRadioField(
+        choices=[("Yes", "yes"), ("No", "no")],
+        validators=[wtforms.validators.InputRequired()],
+    )
+
+
+class BooleanForm(wtforms.Form):
+    boolean = fields.DMBooleanField(
+        validators=[wtforms.validators.DataRequired()]
+    )
+
+
+class TextInputForm(wtforms.Form):
+    text_input = fields.DMStringField(
+        validators=[wtforms.validators.Length(max=5)]
+    )
+
+
+@pytest.mark.parametrize("form_class, data, expected_error", [
+    (RadiosForm, {}, {"radios": {
+        "href": "#input-radios-1",
+        "text": "This field is required.",
+        "errorMessage": {"text": "This field is required."},
+
+        "input_name": "radios",
+        "question": "Radios",
+        "message": "This field is required.",
+    }}),
+    (BooleanForm, {"boolean": ""}, {"boolean": {
+        "href": "#input-boolean-1",
+        "text": "This field is required.",
+        "errorMessage": {"text": "This field is required."},
+
+        "input_name": "boolean",
+        "question": "Boolean",
+        "message": "This field is required.",
+    }}),
+    (TextInputForm, {"text_input": "Hello World"}, {"text_input": {
+        "href": "#input-text_input",
+        "text": "Field cannot be longer than 5 characters.",
+        "errorMessage": {"text": "Field cannot be longer than 5 characters."},
+
+        "input_name": "text_input",
+        "question": "Text Input",
+        "message": "Field cannot be longer than 5 characters.",
+    }}),
+])
+def test_get_errors_from_wtform(form_class, data, expected_error):
+    form = form_class(data=data)
+    form.validate()
+    assert get_errors_from_wtform(form) == expected_error


### PR DESCRIPTION
We want to be able to use the dmutils.forms.errors helpers everywhere we are using forms in our frontend apps. Sometimes our forms can be a little... weird. Having the ability to override the field input href is useful, especially for things like fields inside selection buttons.

This PR does this by allowing a developer to either a) specify the href for the error message in the error object passed to `govuk_errors` or b) setting the `id` of the form field in a WTForms form.

This PR also adds some logic to cover the default cases better, reducing the situations where we do need to override the href. Specifically it:

- adds prefix `input-` to id for WTForms fields
- adds suffix `-1` to id for WTForms selection button fields

See the commit messages for more details.

---

This PR is needed to make sure that error summaries work as expected in the following tickets:

https://trello.com/c/u5CoMrCP/19-1-replace-validation-banner-with-govuk-frontend-error-summary-component-in-the-buyer-frontend

https://trello.com/c/qUAR9Nm4/20-1-replace-validation-banner-with-govuk-frontend-error-summary-component-in-the-briefs-frontend