### PR TITLE
Look up email references directly in Notify API

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '52.6.0'
+__version__ = '52.7.0'

--- a/dmutils/email/dm_notify.py
+++ b/dmutils/email/dm_notify.py
@@ -75,8 +75,13 @@ class DMNotifyClient:
         if self._sent_references_cache is not None:
             self._sent_references_cache.update([reference])
 
-    def has_been_sent(self, reference):
-        """Checks for a matching reference in our list of delivered references."""
+    def has_been_sent(self, reference, use_recent_cache=True):
+        """
+        Checks for a matching reference in our list of recently delivered references (last 250 emails).
+        If use_recent_cache is set to False, we do a fresh lookup of the reference in the Notify API.
+        """
+        if not use_recent_cache:
+            return len(self.client.get_all_notifications(reference=reference)['notifications']) > 0
         return reference in self.get_delivered_references()
 
     @staticmethod

--- a/dmutils/email/dm_notify.py
+++ b/dmutils/email/dm_notify.py
@@ -131,7 +131,8 @@ class DMNotifyClient:
         personalisation=None,
         allow_resend=True,
         reference=None,
-        reply_to_address_id=None
+        reply_to_address_id=None,
+        use_recent_cache=True
     ):
         """
         Method to send an email using the Notify api.
@@ -142,12 +143,14 @@ class DMNotifyClient:
         :param personalisation: The template variables, dict
         :param allow_resend: if False instantiate the delivered reference cache and ensure we are not sending duplicates
         :param reply_to_address_id: String id of reply-to email address. Must be set up in Notify config before use
+        :param use_recent_cache: Use the client's cache of recently sent references. If set to False, any
+                                 has_been_sent() calls will check the reference in the Notify API directly
         :return: response from the api. For more information see https://github.com/alphagov/notifications-python-client
         """
         template_id = self.templates.get(template_name_or_id, template_name_or_id)
         reference = reference or self.get_reference(to_email_address, template_id, personalisation)
 
-        if not allow_resend and self.has_been_sent(reference):
+        if not allow_resend and self.has_been_sent(reference, use_recent_cache=use_recent_cache):
             self.logger.info(
                 "Email with reference '{reference}' has already been sent",
                 extra=dict(

--- a/tests/email/test_dm_notify.py
+++ b/tests/email/test_dm_notify.py
@@ -216,7 +216,7 @@ class TestDMNotifyClient(PatchExternalServiceLogConditionMixin):
                 email_reply_to_id=None
             )
 
-    def test_personalisation_passed(self, dm_notify_client, notify_send_email):
+    def test_send_email_personalisation_passed_to_client(self, dm_notify_client, notify_send_email):
         """Assert the expected existence of personalisation."""
         personalisation = {u'f\u00a3oo': u'bar\u00a3'}
         with mock.patch(self.client_class_str + '.' + 'send_email_notification') as email_mock:
@@ -236,7 +236,7 @@ class TestDMNotifyClient(PatchExternalServiceLogConditionMixin):
                 email_reply_to_id=None
             )
 
-    def test_personalisation_appears_in_reference(self, dm_notify_client, notify_send_email):
+    def test_send_email_includes_personalisation_in_reference(self, dm_notify_client, notify_send_email):
         """Assert personalisation is added to the auto generated reference."""
         personalisation = {u'f\u00a3oo': u'bar\u00a3'}
         with mock.patch(self.client_class_str + '.' + 'send_email_notification') as email_mock:
@@ -256,7 +256,7 @@ class TestDMNotifyClient(PatchExternalServiceLogConditionMixin):
                 email_reply_to_id=None
             )
 
-    def test_cache_not_instantiated_with_allow_resend(self, dm_notify_client):
+    def test_send_email_does_not_instantiate_cache_with_allow_resend(self, dm_notify_client):
         """The cache shouldn't be touched until we pass `allow_resend=False` to `send_email`."""
         with mock.patch(self.client_class_str + '.' + 'send_email_notification'):
             assert dm_notify_client._sent_references_cache is None
@@ -265,7 +265,7 @@ class TestDMNotifyClient(PatchExternalServiceLogConditionMixin):
 
             assert dm_notify_client._sent_references_cache is None
 
-    def test_cache_instantiated_without_allow_resend(
+    def test_send_email_instantiates_cache_if_allow_resend_is_false(
             self,
             dm_notify_client,
             notify_send_email,
@@ -289,7 +289,9 @@ class TestDMNotifyClient(PatchExternalServiceLogConditionMixin):
                     dm_notify_client.get_reference(self.email_address, self.template_id, None)
                 )
 
-    def test_cache_always_populated_after_first_send_without_allow_resend(self, dm_notify_client, notify_send_email):
+    def test_send_email_populates_cache_after_first_send_without_allow_resend(
+        self, dm_notify_client, notify_send_email
+    ):
         """Until `allow_resend` is set to False for the first time the cache shouldn't be populated, after, it should.
 
         After the first instance of `allow_resend=False` every reference should be added to the cache.
@@ -322,7 +324,7 @@ class TestDMNotifyClient(PatchExternalServiceLogConditionMixin):
                     dm_notify_client.get_reference(self.email_address + 'foo', self.template_id + 'bar')
                 }, "Cache should now start populating regardless of allow_resend flag"
 
-    def test_not_allow_resend(self, dm_notify_client):
+    def test_send_email_with_allow_resend_false(self, dm_notify_client):
         """Trigger identical emails and make sure only one is sent!"""
         with mock.patch(self.client_class_str + '.' + 'send_email_notification') as send_email_notification_mock:
             with mock.patch(self.client_class_str + '.' + 'get_all_notifications') as get_all_notifications_mock:
@@ -340,7 +342,7 @@ class TestDMNotifyClient(PatchExternalServiceLogConditionMixin):
                     email_reply_to_id=None
                 )
 
-    def test_behaviour_outside_flask_app_context(self):
+    def test_send_email_behaviour_outside_flask_app_context(self):
         """If logger is supplied then app context is not required"""
         dm_notify_client = DMNotifyClient(
             _test_api_key,
@@ -359,7 +361,7 @@ class TestDMNotifyClient(PatchExternalServiceLogConditionMixin):
                     email_reply_to_id=None
                 )
 
-    def test_replacement_address_allows_resend(self, app):
+    def test_send_email_allows_resend_to_replacement_addresses(self, app):
         """
             Test the replacement_email_address mechanism doesn't make calls to different addresses look like resends.
         """
@@ -434,7 +436,7 @@ class TestDMNotifyClient(PatchExternalServiceLogConditionMixin):
                     mock.ANY,
                 )
 
-    def test_can_use_templates_from_app_config(self, app):
+    def test_send_email_can_use_templates_from_app_config(self, app):
         app.config["NOTIFY_TEMPLATES"] = {"template_name": "template-id"}
 
         with app.app_context():

--- a/tests/email/test_dm_notify.py
+++ b/tests/email/test_dm_notify.py
@@ -322,6 +322,23 @@ class TestDMNotifyClient(PatchExternalServiceLogConditionMixin):
                     email_reply_to_id=None
                 )
 
+    def test_send_email_with_resend_false_without_using_cache(self, dm_notify_client):
+        """Checks the Notify API directly for the reference"""
+        with mock.patch(self.client_class_str + '.' + 'send_email_notification') as send_email_notification_mock:
+            with mock.patch(self.client_class_str + '.' + 'get_all_notifications') as get_all_notifications_mock:
+                get_all_notifications_mock.return_value = {
+                    "notifications": ["niC4qhMflcnl8MkY82N7Gqze2ZA7ed1pSBTGnxeDPj0="]
+                }
+
+                dm_notify_client.send_email(
+                    self.email_address, self.template_id, allow_resend=False, use_recent_cache=False
+                )
+
+                assert send_email_notification_mock.called is False
+                get_all_notifications_mock.assert_called_once_with(
+                    reference="niC4qhMflcnl8MkY82N7Gqze2ZA7ed1pSBTGnxeDPj0="
+                )
+
     def test_send_email_behaviour_outside_flask_app_context(self):
         """If logger is supplied then app context is not required"""
         dm_notify_client = DMNotifyClient(

--- a/tests/email/test_dm_notify.py
+++ b/tests/email/test_dm_notify.py
@@ -216,26 +216,6 @@ class TestDMNotifyClient(PatchExternalServiceLogConditionMixin):
                 email_reply_to_id=None
             )
 
-    def test_send_email_personalisation_passed_to_client(self, dm_notify_client, notify_send_email):
-        """Assert the expected existence of personalisation."""
-        personalisation = {u'f\u00a3oo': u'bar\u00a3'}
-        with mock.patch(self.client_class_str + '.' + 'send_email_notification') as email_mock:
-            notify_send_email.update(personalisation=personalisation)
-
-            dm_notify_client.send_email(
-                self.email_address,
-                self.template_id,
-                personalisation=personalisation
-            )
-
-            email_mock.assert_called_with(
-                self.email_address,
-                self.template_id,
-                personalisation=personalisation,
-                reference='CLkthp1ZgyeBSMCgQj-zf18netwEf3J9aJxLcm-FZ4s=',
-                email_reply_to_id=None
-            )
-
     def test_send_email_includes_personalisation_in_reference(self, dm_notify_client, notify_send_email):
         """Assert personalisation is added to the auto generated reference."""
         personalisation = {u'f\u00a3oo': u'bar\u00a3'}


### PR DESCRIPTION
https://trello.com/c/EnPFfpum/

After a recent failure in an email-sending job, we realised that the `allow_resend=False` option had some issues:
- the `DMNotifyClient` client instance first of all looks in its own cache, to get a list of sent email references. This cache is empty on initialisation, so for most email-sending scripts, each run on Jenkins have a new client instance and an empty cache.
- if the cache is empty, the client falls back to its `get_delivered_notifications()` (i.e., getting every recent delivered message, with a fresh API call), and looks for the reference in that list. Unfortunately, this list only contains the most recent 250 items! And that's across all scripts, jobs, apps, etc. Given most of our email sending scripts send thousands of emails each, if a job fails halfway then the majority of references won't be found.

To fix this I've added an optional flag to the `has_been_sent` and `send_email` methods, to allow a direct look up in the Notify  by reference. We should probably limit the usage to script retries only, for example if a `--resume-run-id` argument has been passed to the script. Otherwise there will be `O(n)` additional calls to Notify during any given script (as the cache is ignored and we need to check every individual email). However, 'expensive' is probably better than 'broken'...? As it stands, the `allow_resend=False` behaviour simply does not work outside the confines of a single script run.

Thoughts welcome!