### PR TITLE
draft

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '52.7.0'
+__version__ = '52.8.0'

--- a/dmutils/forms/helpers.py
+++ b/dmutils/forms/helpers.py
@@ -22,6 +22,23 @@ def remove_csrf_token(data):
 
 
 def govuk_option(option: typing.Dict) -> typing.Dict:
+    """Converts one digitalmarketplace-frontend-toolkit style option (of the radio and checkboxes elements)
+    into a format suitable for use with either digitalmarketplace-frontend-toolkit
+    templates/macros or govuk-frontend macros.
+
+    Example usage:
+
+    # app.py
+
+        @flask.route("/", methods=["GET", "POST"])
+        def view():
+            lot_question = {
+            option["value"]: option
+            for option in govuk_option(
+                ContentQuestion(content_loader.get_question(framework_slug, 'services', 'lot')).get('options')
+            )
+        }
+    """
     if option:
         # DMp's yml does not requires only labels, which is used as the value if none is provided
         item = {
@@ -36,4 +53,36 @@ def govuk_option(option: typing.Dict) -> typing.Dict:
 
 
 def govuk_options(options: typing.List[typing.Dict]) -> typing.List[typing.Dict]:
+    """Converts all digitalmarketplace-frontend-toolkit style options (of the radio and checkboxes elements)
+    into a format suitable for use with either digitalmarketplace-frontend-toolkit
+    templates/macros or govuk-frontend macros.
+
+    Example usage:
+
+    # app.py
+
+    @direct_award_public.route('/<string:framework_family>/choose-lot', methods=("GET", "POST"))
+    def choose_lot(framework_family):
+        all_frameworks = data_api_client.find_frameworks().get('frameworks')
+        framework = framework_helpers.get_latest_live_framework_or_404(all_frameworks, framework_family)
+
+        content_loader.load_messages(framework['slug'], ['advice', 'descriptions'])
+        gcloud_lot_messages = content_loader.get_message(framework['slug'], 'advice', 'lots')
+        gcloud_lot_messages = {x['slug']: x for x in gcloud_lot_messages}
+
+        lots = list()
+        for lot in framework['lots']:
+            lot_item = {
+                "value": lot['slug'],
+                "label": lot['name'],
+                "description": gcloud_lot_messages[lot['slug']]['body'],
+                "hint": gcloud_lot_messages[lot['slug']].get('advice'),
+            }
+
+            lots.append(lot_item)
+        return render_template('choose-lot.html',
+                            framework_family=framework_family,
+                            title="Choose a category",
+                            lots=govuk_options(lots))
+    """
     return [govuk_option(option) for option in options]

--- a/dmutils/forms/helpers.py
+++ b/dmutils/forms/helpers.py
@@ -2,6 +2,8 @@
 # allow importing from dmutils.forms.helpers for backwards compatibility
 from .errors import get_errors_from_wtform  # noqa: F401
 
+import typing
+
 
 def remove_csrf_token(data):
     """Flask-WTF==0.14.2 now includes `csrf_token` in `form.data`, whereas previously wtforms explicitly didn't do
@@ -17,3 +19,21 @@ def remove_csrf_token(data):
         del cleaned_data['csrf_token']
 
     return cleaned_data
+
+
+def govuk_option(option: typing.Dict) -> typing.Dict:
+    if option:
+        # DMp's yml does not requires only labels, which is used as the value if none is provided
+        item = {
+            "value": option.get('value', option['label']),
+            "text": option['label'],
+        }
+        if "description" in option:
+            item.update({"hint": {"text": option["description"]}})
+        return item
+    else:
+        return {}
+
+
+def govuk_options(options: typing.List[typing.Dict]) -> typing.List[typing.Dict]:
+    return [govuk_option(option) for option in options]

--- a/tests/forms/test_helpers.py
+++ b/tests/forms/test_helpers.py
@@ -1,0 +1,53 @@
+import pytest
+
+from dmutils.forms.helpers import govuk_options
+
+
+@pytest.mark.parametrize("dm_options,expected_output", (
+    ([], []),
+    (
+        [
+            {
+                "label": "text of the label",
+            },
+        ],
+        [
+            {
+                "value": "text of the label",
+                "text": "text of the label",
+            },
+        ],
+    ),
+    (
+        [
+            {
+                "label": "text of the label",
+                "value": "text of the value",
+            },
+        ],
+        [
+            {
+                "value": "text of the value",
+                "text": "text of the label",
+            },
+        ],
+    ),
+    (
+        [
+            {
+                "label": "text of the label",
+                "value": "text of the value",
+                "description": "text of the description",
+            },
+        ],
+        [
+            {
+                "value": "text of the value",
+                "text": "text of the label",
+                "hint": {"text": "text of the description"},
+            },
+        ],
+    ),
+))
+def test_govuk_options(dm_options, expected_output):
+    assert govuk_options(dm_options) == expected_output


### PR DESCRIPTION
trello: https://trello.com/c/3uVc3tgm/124-2-spike-replacing-radio-selection-buttons-with-govuk-frontend-radios-components-1-day

Function and tests in utils repo for converting the dictionaries content generates and are currently used to a list of dictionaries with input and label keys with the original values of radios and checkboxes.