### PR TITLE
Add to_link helper for creating <a> tag strings

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '52.7.0'
+__version__ = '52.8.0'

--- a/dmutils/html.py
+++ b/dmutils/html.py
@@ -1,0 +1,21 @@
+from jinja2 import Markup, escape
+
+
+def link_to(url, label='', **attrs):
+    """Create a hyperlink with the given text pointing to the URL"""
+
+    if url == '' or not isinstance(url, str):
+        raise ValueError('link_to expects URL to be a non-empty string')
+
+    if label == '' or label is None:
+        label = url
+
+    output = ['<a']
+    output.append(f' href="{escape(url)}"')
+    for key, value in attrs.items():
+        if isinstance(value, str):
+            output.append(' {}="{}"'.format(escape(key), escape(value)))
+    output.append('>')
+    output.append(escape(label))
+    output.append('</a>')
+    return Markup("".join(output))

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,0 +1,42 @@
+import pytest
+
+from dmutils.html import link_to
+import jinja2
+
+
+class TestToLink:
+    @pytest.mark.parametrize("label", (None, ''))
+    def test_to_link_sets_url_as_label_if_label_is_empty(self, label):
+        link = link_to('https://www.google.com', label)
+        assert link == '<a href="https://www.google.com">https://www.google.com</a>'
+
+    def test_to_link_wraps_label_with_a_tag(self):
+        link = link_to('https://www.google.com', 'Label')
+        assert link == '<a href="https://www.google.com">Label</a>'
+
+    def test_to_link_raises_error_if_url_is_not_string(self):
+        with pytest.raises(ValueError):
+            link_to(False, 'label')
+
+    def test_to_link_raises_error_if_url_is_empty(self):
+        with pytest.raises(ValueError):
+            link_to('', 'label')
+
+    def test_to_link_adds_attributes(self):
+        link = link_to('#', 'label', target='_blank')
+        assert link == '<a href="#" target="_blank">label</a>'
+
+    def test_to_link_ignores_non_text_attributes(self):
+        link = link_to('#', 'label', target=2)
+        assert link == '<a href="#">label</a>'
+
+    @pytest.mark.parametrize('autoescape', (True, False))
+    def test_to_link_returns_string_that_is_safe_for_jinja(self, autoescape):
+        link = link_to('<script>bad thing</script>')
+        env = jinja2.Environment(autoescape=autoescape)
+
+        template = env.from_string("{{ html }}")
+
+        expected = '<a href="&lt;script&gt;bad thing&lt;/script&gt;">&lt;script&gt;bad thing&lt;/script&gt;</a>'
+
+        assert template.render(html=link) == expected


### PR DESCRIPTION
While working on https://trello.com/c/EcbpN7V0/129-2-replace-summary-tables-on-saved-searches-page-with-tables I found myself really wishing I could just create a link without writing up a long string.

`to_link` takes a url string, an optional label string, and a set of key-value args for any other attributes, and outputs an HTML <a> tag string. Future iterations could accept numbers and other types and handle them.

`to_link('http://www.gov.uk', 'GOV.UK')` = `<a href="http://www.gov.uk">GOV.UK</a>"`

As I'm not a Python expert, I'd appreciate somebody picking this apart.