### PR TITLE
Add data argument to govuk_options

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '52.8.0'
+__version__ = '52.9.0'

--- a/dmutils/forms/helpers.py
+++ b/dmutils/forms/helpers.py
@@ -21,7 +21,9 @@ def remove_csrf_token(data):
     return cleaned_data
 
 
-def govuk_option(option: typing.Dict) -> typing.Dict:
+def govuk_option(
+    option: typing.Dict, data: typing.Optional[typing.Union[typing.List[str], str]] = None
+) -> typing.Dict:
     """Converts one digitalmarketplace-frontend-toolkit style option (of the radio and checkboxes elements)
     into a format suitable for use with either digitalmarketplace-frontend-toolkit
     templates/macros or govuk-frontend macros.
@@ -39,12 +41,25 @@ def govuk_option(option: typing.Dict) -> typing.Dict:
             )
         }
     """
+    _data: typing.List[str]
+    if data is None:
+        _data = []
+    elif isinstance(data, str):
+        _data = [data]
+    elif isinstance(data, list):
+        _data = data
+    else:
+        raise TypeError("`data` must be a string or a list of strings")
+
     if option:
         # DMp does not require a value for an option, fallback to label if not present
+        value = option.get("value", option["label"])
         item = {
-            "value": option.get('value', option['label']),
+            "value": value,
             "text": option['label'],
         }
+        if value in _data:
+            item["checked"] = True
         if "description" in option:
             item.update({"hint": {"text": option["description"]}})
         return item
@@ -52,7 +67,9 @@ def govuk_option(option: typing.Dict) -> typing.Dict:
         return {}
 
 
-def govuk_options(options: typing.List[typing.Dict]) -> typing.List[typing.Dict]:
+def govuk_options(
+    options: typing.List[typing.Dict], data: typing.Optional[typing.Union[typing.List[str], str]] = None
+) -> typing.List[typing.Dict]:
     """Converts all digitalmarketplace-frontend-toolkit style options (of the radio and checkboxes elements)
     into a format suitable for use with either digitalmarketplace-frontend-toolkit
     templates/macros or govuk-frontend macros.
@@ -85,4 +102,4 @@ def govuk_options(options: typing.List[typing.Dict]) -> typing.List[typing.Dict]
                             title="Choose a category",
                             lots=govuk_options(lots))
     """
-    return [govuk_option(option) for option in options]
+    return [govuk_option(option, data) for option in options]

--- a/dmutils/forms/helpers.py
+++ b/dmutils/forms/helpers.py
@@ -40,7 +40,7 @@ def govuk_option(option: typing.Dict) -> typing.Dict:
         }
     """
     if option:
-        # DMp's yml does not requires only labels, which is used as the value if none is provided
+        # DMp does not require a value for an option, fallback to label if not present
         item = {
             "value": option.get('value', option['label']),
             "text": option['label'],

--- a/tests/forms/test_helpers.py
+++ b/tests/forms/test_helpers.py
@@ -51,3 +51,58 @@ from dmutils.forms.helpers import govuk_options
 ))
 def test_govuk_options(dm_options, expected_output):
     assert govuk_options(dm_options) == expected_output
+
+
+def test_govuk_options_with_checked_item():
+    options = [
+        {"label": "Yes", "value": "yes"},
+        {"label": "No", "value": "no"},
+    ]
+
+    data = "yes"
+
+    items = govuk_options(options, data)
+
+    assert items == [
+        {"text": "Yes", "value": "yes", "checked": True},
+        {"text": "No", "value": "no"},
+    ]
+
+
+def test_govuk_options_with_multiple_checked_items():
+    options = [
+        {"label": "A", "value": "a"},
+        {"label": "B", "value": "b"},
+        {"label": "C", "value": "c"},
+    ]
+
+    data = ["a", "c"]
+
+    items = govuk_options(options, data)
+
+    assert items == [
+        {"text": "A", "value": "a", "checked": True},
+        {"text": "B", "value": "b"},
+        {"text": "C", "value": "c", "checked": True},
+    ]
+
+
+def test_govuk_options_with_invalid_data():
+    options = [
+        {"label": "a", "value": "a"},
+        {"label": "b", "value": "b"},
+        {"label": "c", "value": "c"},
+    ]
+
+    expected_options = [
+        {"text": "a", "value": "a"},
+        {"text": "b", "value": "b"},
+        {"text": "c", "value": "c"},
+    ]
+
+    assert govuk_options(options, "yes") == expected_options
+    assert govuk_options(options, "") == expected_options
+    assert govuk_options(options, None) == expected_options
+    assert govuk_options(options, []) == expected_options
+    with pytest.raises(TypeError):
+        govuk_options(options, {})


### PR DESCRIPTION
Ticket: https://trello.com/c/6xOXfwx7/123-2-use-radios-component-for-radios-questions-in-create-a-dos-opportunity-journey

We want to be able to check items in params for govukRadios or govukCheckboxes based on data submitted by users.

This commit adds the optional argument `data` to `govuk_options`, that takes the data submitted by a user for that form.