### PR TITLE
Add accessibility statement to external routes

### DIFF
--- a/dmutils/external.py
+++ b/dmutils/external.py
@@ -53,6 +53,11 @@ def privacy_notice():
     raise NotImplementedError()
 
 
+@external.route('/accessibility-statement')
+def accessibility_statement():
+    raise NotImplementedError()
+
+
 @external.route('/cookies')
 def cookies():
     raise NotImplementedError()


### PR DESCRIPTION
https://trello.com/c/rRLFjASj/240-publish-accessibility-statement-by-wednesday

This ensures all apps can link to the accessibility statement by enabling `url_for` for routes that aren't in the app we're using `url_for` in.