### PR TITLE
Add accessibility statement to external routes

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app, init_manager
 
 
-__version__ = '52.9.0'
+__version__ = '52.10.0'

--- a/dmutils/external.py
+++ b/dmutils/external.py
@@ -53,6 +53,11 @@ def privacy_notice():
     raise NotImplementedError()
 
 
+@external.route('/accessibility-statement')
+def accessibility_statement():
+    raise NotImplementedError()
+
+
 @external.route('/cookies')
 def cookies():
     raise NotImplementedError()

--- a/dmutils/external.py
+++ b/dmutils/external.py
@@ -53,11 +53,6 @@ def privacy_notice():
     raise NotImplementedError()
 
 
-@external.route('/accessibility-statement')
-def accessibility_statement():
-    raise NotImplementedError()
-
-
 @external.route('/cookies')
 def cookies():
     raise NotImplementedError()


### PR DESCRIPTION
https://trello.com/c/rRLFjASj/240-publish-accessibility-statement-by-wednesday

This ensures all apps can link to the accessibility statement by enabling url_for for routes that aren't in the app we're using url_for in.

This reverts the previous commit (#573) which didn't include a version bump so that the change and the bump are on the same merge.