### PR TITLE
Remove Flask-Script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Records breaking changes from major version bumps
 
+## 54.0.0
+
+You should now use `flask routes` in an app, instead of `python application.py
+list_routes` or `python application.py list_external_routes`.
+
+`flask routes` incldues the fully qualified name of the route method, so if you
+want to show only external routes you can use `flask routes | grep '^external'`.
+
 ## 53.0.0
 
 - You must change any uses of `dmutils.api_stubs` to use `dmtestutils.api_model_stubs` instead. The api stubs in this package have been removed.

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '53.0.0'
+__version__ = '54.0.0'

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -1,5 +1,5 @@
 from . import config, formats, logging, proxy_fix, request_id
-from .flask_init import init_app, init_manager
+from .flask_init import init_app
 
 
 __version__ = '53.0.0'

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -5,7 +5,6 @@ from types import MappingProxyType
 from dmutils import config, logging, proxy_fix, request_id, formats, filters, cookie_probe
 from dmutils.errors import api as api_errors, frontend as fe_errors
 from dmutils.urls import SafePurePathConverter
-from flask_script import Manager, Server
 from flask_wtf.csrf import CSRFError
 from werkzeug.exceptions import default_exceptions
 
@@ -113,37 +112,3 @@ def get_extra_files(paths):
                 filename = os.path.join(dirname, filename)
                 if os.path.isfile(filename):
                     yield filename
-
-
-def init_manager(application, port, extra_directories=()):
-
-    manager = Manager(application)
-
-    extra_files = list(get_extra_files(extra_directories))
-
-    logging.logger.debug("Watching {} extra files".format(len(extra_files)))
-
-    manager.add_command(
-        "runserver",
-        Server(port=port, extra_files=extra_files)
-    )
-
-    def print_route(rule):
-        print("{:10} {}".format(", ".join(rule.methods - set(['OPTIONS', 'HEAD'])), rule.rule))
-
-    @manager.command
-    def list_routes():
-        """List URLs of all application routes."""
-        for rule in sorted(manager.app.url_map.iter_rules(), key=lambda r: r.rule):
-            if rule.endpoint.startswith("external"):
-                continue
-            print_route(rule)
-
-    @manager.command
-    def list_external_routes():
-        """List URLs of all external routes."""
-        for rule in sorted(manager.app.url_map.iter_rules(), key=lambda r: r.rule):
-            if rule.endpoint.startswith("external"):
-                print_route(rule)
-
-    return manager

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-         'Flask-Script>=2.0.6',
          'Flask-WTF>=0.14.2',
          'Flask<1.1.0,>=1.0.2',
          'Flask-gzip>=0.2',


### PR DESCRIPTION
https://trello.com/c/kbhJdTm3/567-remove-flaskscript-from-dmutils

It is deprecated, we no longer need it, let's get rid of it! :fire:

This is a breaking change, but to install it into an app we simply need to delete most of the code in the apps' `./application.py` file :grin: