### PR TITLE
Block ')' from ending URLs

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '54.0.0'
+__version__ = '54.0.1'

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -27,7 +27,7 @@ def format_links(text, open_links_in_new_tab=None):
                                 (?:https?://|www\.)    # start with http:// or www.
                                 (?:[^\s<>"'/?#]+)      # domain doesn't have these characters
                                 (?:[^\s<>"']+)         # post-domain part of URL doesn't have these characters
-                                [^\s<>,"'\.]           # no dot at end
+                                [^\s<>,"'\.)]          # no dot or bracket at end
                                 )""", re.X)
     matched_urls = [type(text)(substr) for substr in url_match.findall(text)]
     if matched_urls:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -86,6 +86,18 @@ class TestFormatLinks:
         text = 'There are no Greek Γ Δ Ε Ζ Η Θ Ι Κ Λ links.'
         assert format_links(text) == text
 
+    def test_handles_url_in_brackets(self):
+        text = "(http://www.example.com)"
+        formatted_text = '(<a href="http://www.example.com" class="govuk-link" '\
+            'rel="external">http://www.example.com</a>)'
+        assert format_links(text) == formatted_text
+
+    def test_handles_url_in_angle_brackets(self):
+        text = "<http://www.example.com>"
+        formatted_text = '&lt;<a href="http://www.example.com" class="govuk-link" '\
+            'rel="external">http://www.example.com</a>&gt;'
+        assert format_links(text) == formatted_text
+
 
 class TestNbsp:
     def test_nbsp(self):


### PR DESCRIPTION
Trello: https://trello.com/c/U9O7zTCU/1437-fix-broken-urls-in-3-of-briefs

Previously, the URL-detection heuristic would see "something (like http://example.com) this" and detect "http://example.com)" as the URL. Whilst URLs can validly include ')', it is very rare. Indeed, of the 1000+ closed briefs we have, 49 have URLs that end in ')' where they should not. No closed brief has a URL that intentionally ends in ')'.

You can see an example of this problem in https://www.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/opportunities/13014, which was reported in x-gov Slack.

Thus, update our URL-detection heuristic to to forbid ')' as the last character of a URL. This will do the right thing for users in the vast majority of cases. I have not found any URLs that this change will break.

Add tests to confirm the new behaviour.