### PR TITLE
Support "hint" property in govuk_options

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '54.0.1'
+__version__ = '54.0.2'

--- a/dmutils/forms/helpers.py
+++ b/dmutils/forms/helpers.py
@@ -60,7 +60,9 @@ def govuk_option(
         }
         if value in _data:
             item["checked"] = True
-        if "description" in option:
+        if "hint" in option:
+            item.update({"hint": {"text": option["hint"]}})
+        elif "description" in option:
             item.update({"hint": {"text": option["description"]}})
         return item
     else:

--- a/tests/forms/test_helpers.py
+++ b/tests/forms/test_helpers.py
@@ -48,6 +48,22 @@ from dmutils.forms.helpers import govuk_options
             },
         ],
     ),
+    (
+        [
+            {
+                "label": "text of the label",
+                "value": "text of the value",
+                "hint": "text of the hint",
+            },
+        ],
+        [
+            {
+                "value": "text of the value",
+                "text": "text of the label",
+                "hint": {"text": "text of the hint"},
+            },
+        ],
+    ),
 ))
 def test_govuk_options(dm_options, expected_output):
     assert govuk_options(dm_options) == expected_output


### PR DESCRIPTION
Forms loaded via WTForms use the property "hint", but if it's present, its value is a string. We're expecting "hint" to be an object when outputted from this function.

We can support both content loader and WTForm options by checking for the "hint" property first, then the "description" property.