### PR TITLE
Add ability to override s3 endpoint URL for local development

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '54.0.2'
+__version__ = '54.1.0'


### PR DESCRIPTION
I want to run dmrunner with [localstack] instead of real AWS access. This PR changes the dmutils s3 client to use the url in the config variable in `S3_ENDPOINT_URL` as the endpoint URL for boto3, if (and only if) Flask is running in development mode.

[localstack]: https://github.com/localstack/localstack