### PR TITLE
Adds Redis session support behind env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 Records breaking changes from major version bumps
 
+## 55.0.0
+
+Adds support for Redis Flask session type. Note, this will only be used if `SESSION_TYPE= 'redis'` is set on the frontend apps.
+
 ## 54.0.0
 
 You should now use `flask routes` in an app, instead of `python application.py
 list_routes` or `python application.py list_external_routes`.
 
-`flask routes` incldues the fully qualified name of the route method, so if you
+`flask routes` includes the fully qualified name of the route method, so if you
 want to show only external routes you can use `flask routes | grep '^external'`.
 
 ## 53.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Records breaking changes from major version bumps
 
 ## 55.0.0
 
-Adds support for Redis Flask session type. Note, this will only be used if `SESSION_TYPE= 'redis'` is set on the frontend apps.
+Adds support for Redis Flask session type. Note, this will only be used if `DM_USE_REDIS_SESSION_TYPE` env var is set and `SESSION_TYPE= 'redis'` is set on the frontend apps.
 
 ## 54.0.0
 

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '54.1.1'
+__version__ = '55.0.0'

--- a/dmutils/cloudfoundry.py
+++ b/dmutils/cloudfoundry.py
@@ -1,0 +1,24 @@
+"""
+Support for running on a CloudFoundry platform such as GOV.UK PaaS.
+"""
+
+import json
+
+
+def get_vcap_services(app, default=None) -> dict:
+    if app.config.get("VCAP_SERVICES") is None:
+        return default
+
+    vcap_services = json.loads(app.config["VCAP_SERVICES"])
+
+    return vcap_services
+
+
+def get_service_by_name_from_vcap_services(vcap_services: dict, name: str) -> dict:
+    """Returns the first service from a VCAP_SERVICES json object that has name"""
+    for services in vcap_services.values():
+        for service in services:
+            if service["name"] == name:
+                return service
+
+    raise RuntimeError(f"Unable to find service with name {name} in VCAP_SERVICES")

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -63,7 +63,8 @@ def init_app(
     if login_manager:
         login_manager.init_app(application)
         import dmutils.session
-        dmutils.session.init_app(application)
+        if os.environ.get('DM_USE_REDIS_SESSION_TYPE'):
+            dmutils.session.init_app(application)
     if search_api_client:
         search_api_client.init_app(application)
 

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -62,8 +62,8 @@ def init_app(
         db.init_app(application)
     if login_manager:
         login_manager.init_app(application)
-        import dmutils.session
         if os.environ.get('DM_USE_REDIS_SESSION_TYPE'):
+            import dmutils.session
             dmutils.session.init_app(application)
     if search_api_client:
         search_api_client.init_app(application)

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -7,8 +7,6 @@ from dmutils.errors import api as api_errors, frontend as fe_errors
 from dmutils.urls import SafePurePathConverter
 from flask_wtf.csrf import CSRFError
 from werkzeug.exceptions import default_exceptions
-from flask_session import Session
-import redis
 
 
 frontend_error_handlers = MappingProxyType(OrderedDict((
@@ -48,9 +46,6 @@ def init_app(
         config_object.init_app(application)
 
     application.config.from_object(__name__)
-    application.config['SESSION_REDIS'] = redis.from_url('redis://127.0.0.1:6379')
-    sess = Session()
-    sess.init_app(application)
 
     # all belong to dmutils
     config.init_app(application)
@@ -67,6 +62,8 @@ def init_app(
         db.init_app(application)
     if login_manager:
         login_manager.init_app(application)
+        import dmutils.session
+        dmutils.session.init_app(application)
     if search_api_client:
         search_api_client.init_app(application)
 

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -7,6 +7,8 @@ from dmutils.errors import api as api_errors, frontend as fe_errors
 from dmutils.urls import SafePurePathConverter
 from flask_wtf.csrf import CSRFError
 from werkzeug.exceptions import default_exceptions
+from flask_session import Session
+import redis
 
 
 frontend_error_handlers = MappingProxyType(OrderedDict((
@@ -44,6 +46,11 @@ def init_app(
     application.config.from_object(config_object)
     if hasattr(config_object, 'init_app'):
         config_object.init_app(application)
+
+    application.config.from_object(__name__)
+    application.config['SESSION_REDIS'] = redis.from_url('redis://127.0.0.1:6379')
+    sess = Session()
+    sess.init_app(application)
 
     # all belong to dmutils
     config.init_app(application)

--- a/dmutils/session.py
+++ b/dmutils/session.py
@@ -1,0 +1,19 @@
+import flask_session
+import redis
+
+import dmutils.cloudfoundry as cf
+
+
+def init_app(app):
+    if not app.config.get("SESSION_REDIS"):
+        if app.config["DM_ENVIRONMENT"] == "development":
+            app.config["SESSION_REDIS"] = redis.Redis()
+        else:
+            vcap_services = cf.get_vcap_services(app)
+
+            redis_service_name = app.config["DM_REDIS_SERVICE_NAME"]
+            redis_service = cf.get_service_by_name_from_vcap_services(vcap_services, redis_service_name)
+
+            app.config["SESSION_REDIS"] = redis.from_url(redis_service["credentials"]["uri"])
+
+    flask_session.Session(app)

--- a/dmutils/session.py
+++ b/dmutils/session.py
@@ -7,7 +7,7 @@ import dmutils.cloudfoundry as cf
 
 def init_app(app):
     if not app.config.get("SESSION_REDIS"):
-        if app.config["DM_ENVIRONMENT"] == "development":
+        if app.config.get("DM_ENVIRONMENT") == "development":
             app.config["SESSION_REDIS"] = redis.Redis()
         else:
             vcap_services = cf.get_vcap_services(app)

--- a/dmutils/session.py
+++ b/dmutils/session.py
@@ -1,3 +1,4 @@
+
 import flask_session
 import redis
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
          'Flask<1.1.0,>=1.0.2',
          'Flask-gzip>=0.2',
          'Flask-Login>=0.2.11',
+         'Flask-Session>=0.3.2',
          'boto3<2,>=1.7.83',
          'contextlib2>=0.4.0',
          'cryptography>=3.2',
@@ -34,6 +35,7 @@ setup(
          'govuk-country-register>=0.3.0',
          'mailchimp3==3.0.6',
          'requests>=2.22.0,<3',
+         'redis>=3.5.2'
          'fleep<1.1,>=1.0.1',
          'notifications-python-client<6.0.0,>=5.0.1',
          'odfpy>=1.3.6',

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
          'govuk-country-register>=0.3.0',
          'mailchimp3==3.0.6',
          'requests>=2.22.0,<3',
-         'redis>=3.5.2'
+         'redis>=3.5.2',
          'fleep<1.1,>=1.0.1',
          'notifications-python-client<6.0.0,>=5.0.1',
          'odfpy>=1.3.6',

--- a/tests/test_cloudfoundry.py
+++ b/tests/test_cloudfoundry.py
@@ -1,0 +1,43 @@
+from dmutils import cloudfoundry
+import json
+
+
+def test_cloudfoundry_vcap_parser():
+    vcap_json = """
+    {
+        "gds-prometheus": [{
+            "binding_name": null,
+            "credentials": null,
+            "instance_name": "digitalmarketplace_prometheus",
+            "label": "gds-prometheus",
+            "name": "digitalmarketplace_prometheus",
+            "plan": "prometheus",
+            "provider": null,
+            "syslog_drain_url": null,
+            "tags": [],
+            "volume_mounts": []
+        }],
+        "redis": [{
+            "binding_name": null,
+            "credentials": null,
+            "instance_name": "digitalmarketplace_redis",
+            "label": "splunk",
+            "name": "digitalmarketplace_redis",
+            "plan": "unlimited",
+            "provider": null,
+            "tags": [],
+            "volume_mounts": []
+        }]
+    }
+            """
+    expected_dict = {'binding_name': None,
+                     'credentials': None,
+                     'instance_name': 'digitalmarketplace_redis',
+                     'label': 'splunk',
+                     'name': 'digitalmarketplace_redis',
+                     'plan': 'unlimited',
+                     'provider': None,
+                     'tags': [],
+                     'volume_mounts': []}
+    assert cloudfoundry.get_service_by_name_from_vcap_services(json.loads(vcap_json),
+                                                               'digitalmarketplace_redis') == expected_dict

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,40 @@
+import flask_session
+from flask import Flask
+from dmutils import session
+import mock
+
+
+class TestSession:
+
+    def setup(self):
+        self.application = Flask("mytestapp")
+
+    @mock.patch("flask_session.Session", autospec=True)
+    def test_session_initialises_flask_redis_session(self, _mock_session):
+        self.application.config['DM_ENVIRONMENT'] = 'development'
+        session.init_app(self.application)
+        flask_session.Session.assert_called_once()
+        assert type(self.application.config.get('SESSION_REDIS')).__name__ == 'Redis'
+
+    @mock.patch("flask_session.Session", autospec=True)
+    def test_session_initialises_flask_redis_session_with_credentials(self, _mock_session):
+        self.application.config['DM_REDIS_SERVICE_NAME'] = 'digitalmarketplace_redis'
+        self.application.config['VCAP_SERVICES'] = """
+    {
+        "redis": [{
+            "binding_name": null,
+            "credentials": {"uri": "redis://username:password@example.com:6379"},
+            "instance_name": "digitalmarketplace_redis",
+            "label": "splunk",
+            "name": "digitalmarketplace_redis",
+            "plan": "unlimited",
+            "provider": null,
+            "tags": [],
+            "volume_mounts": []
+        }]
+    }
+            """
+        session.init_app(self.application)
+        flask_session.Session.assert_called_once()
+        expected_dict = {'host': 'example.com', 'port': 6379, 'username': 'username', 'password': 'password', 'db': 0}
+        assert self.application.config["SESSION_REDIS"].connection_pool.connection_kwargs == expected_dict


### PR DESCRIPTION
https://trello.com/c/XXL04KtG/379-3-run-the-new-user-session-management-on-the-local-development-environment
This adds Redis session support behind an env var so that we can manage the rollout.
Code based largely on @lfdebrux's prior spike.