### PR TITLE
Set session type in utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Records breaking changes from major version bumps
 
 ## 55.0.0
 
-Adds support for Redis Flask session type. Note, this will only be used if `DM_USE_REDIS_SESSION_TYPE` env var is set and `SESSION_TYPE= 'redis'` is set on the frontend apps.
+Adds support for Redis Flask session type. Note, this will only be used if `DM_USE_REDIS_SESSION_TYPE` env var is set.
 
 ## 54.0.0
 

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '55.0.0'
+__version__ = '55.1.0'

--- a/dmutils/session.py
+++ b/dmutils/session.py
@@ -17,4 +17,6 @@ def init_app(app):
 
             app.config["SESSION_REDIS"] = redis.from_url(redis_service["credentials"]["uri"])
 
+    app.config["SESSION_USE_SIGNER"] = True
+    app.config["SESSION_TYPE"] = 'redis'
     flask_session.Session(app)

--- a/tests/test_flask_init.py
+++ b/tests/test_flask_init.py
@@ -111,3 +111,23 @@ class TestFlaskInit:
 
         assert os.getenv('DM_USE_REDIS_SESSION_TYPE') == 'true'
         dmutils.session.init_app.assert_called_once()
+
+    @mock.patch("dmutils.session", autospec=True)
+    def test_init_does_not_use_session_by_default(self, _mock_session):
+        bootstrap_mock = mock.Mock()
+        data_api_client_mock = mock.Mock()
+        db_mock = mock.Mock()
+        login_manager_mock = mock.Mock()
+        search_api_client_mock = mock.Mock()
+        dmutils.session = mock.Mock()
+        init_app(
+            self.application,
+            {},
+            bootstrap=bootstrap_mock,
+            data_api_client=data_api_client_mock,
+            db=db_mock,
+            login_manager=login_manager_mock,
+            search_api_client=search_api_client_mock
+        )
+
+        dmutils.session.init_app.assert_not_called()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -15,6 +15,8 @@ class TestSession:
         session.init_app(self.application)
         flask_session.Session.assert_called_once()
         assert type(self.application.config.get('SESSION_REDIS')).__name__ == 'Redis'
+        assert self.application.config.get('SESSION_TYPE') == 'redis'
+        assert self.application.config.get('SESSION_USE_SIGNER') is True
 
     @mock.patch("flask_session.Session", autospec=True)
     def test_session_initialises_flask_redis_session_with_credentials(self, _mock_session):


### PR DESCRIPTION
Follow-up to https://github.com/alphagov/digitalmarketplace-utils/pull/584. On reflection, it makes sense to set `SESSION_TYPE` directly in utils, rather than having to set it in each individual frontend app. 

N.B. This will not cause redis to be automatically used as it is still behind the `DM_USE_REDIS_SESSION_TYPE` env var.