### PR TITLE
get vcap_services directly from env

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '55.1.0'
+__version__ = '55.1.1'

--- a/dmutils/cloudfoundry.py
+++ b/dmutils/cloudfoundry.py
@@ -4,10 +4,9 @@ Support for running on a CloudFoundry platform such as GOV.UK PaaS.
 
 import json
 import os
-from typing import Union
 
 
-def get_vcap_services() -> Union[dict, KeyError]:
+def get_vcap_services() -> dict:
     return json.loads(os.environ["VCAP_SERVICES"])
 
 

--- a/dmutils/cloudfoundry.py
+++ b/dmutils/cloudfoundry.py
@@ -3,15 +3,12 @@ Support for running on a CloudFoundry platform such as GOV.UK PaaS.
 """
 
 import json
+import os
+from typing import Union
 
 
-def get_vcap_services(app, default=None) -> dict:
-    if app.config.get("VCAP_SERVICES") is None:
-        return default
-
-    vcap_services = json.loads(app.config["VCAP_SERVICES"])
-
-    return vcap_services
+def get_vcap_services() -> Union[dict, KeyError]:
+    return json.loads(os.environ["VCAP_SERVICES"])
 
 
 def get_service_by_name_from_vcap_services(vcap_services: dict, name: str) -> dict:

--- a/dmutils/session.py
+++ b/dmutils/session.py
@@ -10,7 +10,7 @@ def init_app(app):
         if app.config.get("DM_ENVIRONMENT") == "development":
             app.config["SESSION_REDIS"] = redis.Redis()
         else:
-            vcap_services = cf.get_vcap_services(app)
+            vcap_services = cf.get_vcap_services()
 
             redis_service_name = app.config["DM_REDIS_SERVICE_NAME"]
             redis_service = cf.get_service_by_name_from_vcap_services(vcap_services, redis_service_name)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,3 +1,5 @@
+import os
+
 import flask_session
 from flask import Flask
 from dmutils import session
@@ -19,9 +21,7 @@ class TestSession:
         assert self.application.config.get('SESSION_USE_SIGNER') is True
 
     @mock.patch("flask_session.Session", autospec=True)
-    def test_session_initialises_flask_redis_session_with_credentials(self, _mock_session):
-        self.application.config['DM_REDIS_SERVICE_NAME'] = 'digitalmarketplace_redis'
-        self.application.config['VCAP_SERVICES'] = """
+    @mock.patch.dict(os.environ, {"VCAP_SERVICES": """
     {
         "redis": [{
             "binding_name": null,
@@ -35,7 +35,9 @@ class TestSession:
             "volume_mounts": []
         }]
     }
-            """
+            """})
+    def test_session_initialises_flask_redis_session_with_credentials(self, _mock_session):
+        self.application.config['DM_REDIS_SERVICE_NAME'] = 'digitalmarketplace_redis'
         session.init_app(self.application)
         flask_session.Session.assert_called_once()
         expected_dict = {'host': 'example.com', 'port': 6379, 'username': 'username', 'password': 'password', 'db': 0}


### PR DESCRIPTION
https://trello.com/c/yS6OcI31/382-2-run-the-new-user-session-management-on-the-preview-environment-temporarily-for-testing
Previously we were erroneously attempting to read `VCAP_SERVICES` from app config which it is not included in.

This PR changes it to read `VCAP_SERVICES` directly from the env, I think this makes sense as it is not something we would want to modify in per-app config.