### PR TITLE
Add EmailTemplateError exception for DMNotifyClient

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '55.1.1'
+__version__ = '55.2.0'

--- a/dmutils/email/dm_notify.py
+++ b/dmutils/email/dm_notify.py
@@ -4,7 +4,7 @@ from flask import current_app
 from notifications_python_client import NotificationsAPIClient
 from notifications_python_client.errors import HTTPError
 
-from dmutils.email.exceptions import EmailError
+from dmutils.email.exceptions import EmailError, EmailTemplateError
 from dmutils.email.helpers import hash_string
 from dmutils.timing import logged_duration_for_external_request as log_external_request
 
@@ -185,6 +185,8 @@ class DMNotifyClient:
 
         except HTTPError as e:
             self._log_email_error_message(to_email_address, template_name_or_id, reference, e)
+            if any(msg["message"].startswith("Missing personalisation") for msg in e.message):
+                raise EmailTemplateError(str(e))
             raise EmailError(str(e))
 
         self._update_cache(reference)

--- a/dmutils/email/exceptions.py
+++ b/dmutils/email/exceptions.py
@@ -4,3 +4,7 @@
 
 class EmailError(Exception):
     pass
+
+
+class EmailTemplateError(Exception):
+    pass


### PR DESCRIPTION
This is part of a small mitigation for
https://trello.com/c/kwVKRjEm/1460-jenkins-job-notify-suppliers-of-framework-application-event-production-keeps-running-even-after-being-aborted;
if sending an email fails because there is an issue for the template, the script should fail instantly rather than continuing to try sending emails.

This PR adds a new exception EmailTemplateError as a subclass of EmailError, and depending on the JSON response from the Notify API we raise a different exception.

The example error for this is based on one we've seen in recent Jenkins jobs logs [1]

```
2020-11-13 15:56:28,uuu UTC dmapiclient.base INFO API GET request on https://api.digitalmarketplace.service.gov.uk/users?supplier_id=... finished in 0.10466979281045496
API POST request on https://api.notifications.service.gov.uk/v2/notifications/email failed with 400 '[{'error': 'BadRequestError', 'message': 'Missing personalisation: application_deadline'}]'
2020-11-13 15:56:28,uuu UTC script ERROR Error sending email: ['400 BadRequestError: Missing personalisation: application_deadline']
2020-11-13 15:56:28,uuu UTC script ERROR Failed sending to ...: 400 - [{'error': 'BadRequestError', 'message': 'Missing personalisation: application_deadline'}]
```

Unfortunately this error message doesn't seem to be documented in [the Notify docs][2], so I'm not sure whether it is stable.

[1]: https://ci.marketplace.team/job/notify-suppliers-of-framework-application-event-production/27/console
[2]: https://docs.notifications.service.gov.uk/rest-api.html#send-a-file-by-email-error-codes.