### PR TITLE
Remove redis env var check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Records breaking changes from major version bumps
 
+## 56.0.0
+
+Flask Redis session type is enabled by default.
+
 ## 55.0.0
 
 Adds support for Redis Flask session type. Note, this will only be used if `DM_USE_REDIS_SESSION_TYPE` env var is set.

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '55.2.1'
+__version__ = '56.0.0'

--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -5,6 +5,7 @@ from types import MappingProxyType
 from dmutils import config, logging, proxy_fix, request_id, formats, filters, cookie_probe
 from dmutils.errors import api as api_errors, frontend as fe_errors
 from dmutils.urls import SafePurePathConverter
+import dmutils.session
 from flask_wtf.csrf import CSRFError
 from werkzeug.exceptions import default_exceptions
 
@@ -62,9 +63,7 @@ def init_app(
         db.init_app(application)
     if login_manager:
         login_manager.init_app(application)
-        if os.environ.get('DM_USE_REDIS_SESSION_TYPE'):
-            import dmutils.session
-            dmutils.session.init_app(application)
+        dmutils.session.init_app(application)
     if search_api_client:
         search_api_client.init_app(application)
 

--- a/tests/test_flask_init.py
+++ b/tests/test_flask_init.py
@@ -4,7 +4,6 @@ from dmutils.flask_init import pluralize, init_app
 import dmutils.session
 import mock
 import pytest
-import os
 
 
 @pytest.mark.parametrize("count,singular,plural,output", [
@@ -90,9 +89,8 @@ class TestFlaskInit:
         assert login_manager_mock.init_app.call_args_list == [mock.call(self.application)]
         assert search_api_client_mock.init_app.call_args_list == [mock.call(self.application)]
 
-    @mock.patch.dict(os.environ, {"DM_USE_REDIS_SESSION_TYPE": "true"})
     @mock.patch("dmutils.session", autospec=True)
-    def test_init_uses_session_if_env_var_set(self, _mock_session):
+    def test_init_uses_session(self, _mock_session):
         bootstrap_mock = mock.Mock()
         data_api_client_mock = mock.Mock()
         db_mock = mock.Mock()
@@ -109,25 +107,4 @@ class TestFlaskInit:
             search_api_client=search_api_client_mock
         )
 
-        assert os.getenv('DM_USE_REDIS_SESSION_TYPE') == 'true'
         dmutils.session.init_app.assert_called_once()
-
-    @mock.patch("dmutils.session", autospec=True)
-    def test_init_does_not_use_session_by_default(self, _mock_session):
-        bootstrap_mock = mock.Mock()
-        data_api_client_mock = mock.Mock()
-        db_mock = mock.Mock()
-        login_manager_mock = mock.Mock()
-        search_api_client_mock = mock.Mock()
-        dmutils.session = mock.Mock()
-        init_app(
-            self.application,
-            {},
-            bootstrap=bootstrap_mock,
-            data_api_client=data_api_client_mock,
-            db=db_mock,
-            login_manager=login_manager_mock,
-            search_api_client=search_api_client_mock
-        )
-
-        dmutils.session.init_app.assert_not_called()


### PR DESCRIPTION
https://trello.com/c/VVsPUmkf/595-05-remove-toggle-post-redis-go-live
We no longer need this as we have finished the gradual Redis rollout.