### PR TITLE
Add date validator for date inputs

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '56.0.1'
+__version__ = '56.1.0'

--- a/dmutils/forms/fields.py
+++ b/dmutils/forms/fields.py
@@ -174,6 +174,20 @@ class DMDateField(DMFieldMixin, wtforms.fields.Field):
             return {}
 
     @property
+    def href(self):
+        if self._href:
+            return self._href
+
+        # first form field field with an error,
+        if self.form_field.errors:
+            for subfield in self.form_field:
+                if subfield.errors:
+                    return "input-" + subfield.name
+
+        # or just the first form field field
+        return super().href + "-day"
+
+    @property
     def day(self):
         return self.form_field.day
 

--- a/dmutils/forms/fields.py
+++ b/dmutils/forms/fields.py
@@ -239,3 +239,14 @@ class DMDateField(DMFieldMixin, wtforms.fields.Field):
             if not digits == 4:
                 self.data = None
                 self.process_errors.append(self.gettext('Not a valid date value'))
+
+    def post_validate(self, form, validation_stopped):
+        # Consumers of a data field might want to highlight individual inputs
+        # of the date input component, checking the values of {day, month,
+        # year}.errors.  In the case where the validator chain hasn't added
+        # errors to any of day month or year, we will add the errors to all the
+        # fields so that all inputs get highlighted.
+        if self.errors and not any((self.year.errors, self.month.errors, self.day.errors)):
+            self.year.errors = self.errors
+            self.month.errors = self.errors
+            self.day.errors = self.errors

--- a/dmutils/forms/fields.py
+++ b/dmutils/forms/fields.py
@@ -174,6 +174,18 @@ class DMDateField(DMFieldMixin, wtforms.fields.Field):
         else:
             return {}
 
+    @property
+    def day(self):
+        return self.form_field.day
+
+    @property
+    def month(self):
+        return self.form_field.month
+
+    @property
+    def year(self):
+        return self.form_field.year
+
     def process(self, formdata, data=unset_value):
         '''
         Process incoming data.

--- a/dmutils/forms/fields.py
+++ b/dmutils/forms/fields.py
@@ -46,11 +46,10 @@ __all__ = ['DMBooleanField', 'DMDecimalField', 'DMHiddenField', 'DMIntegerField'
 class DMBooleanField(DMFieldMixin, wtforms.fields.BooleanField):
     widget = DMCheckboxInput(hide_question=True)
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    @property
+    def href(self):
         # digitalmarketplace-frontend-toolkit suffixes the id with `-1`
-        if "id" not in kwargs:
-            self.href = self.href + "-1"
+        return self._href or super().href + "-1"
 
     @property
     def options(self):

--- a/dmutils/forms/mixins.py
+++ b/dmutils/forms/mixins.py
@@ -59,10 +59,7 @@ class DMFieldMixin:
     def __init__(self, label=None, validators=None, hint=None, question_advice=None, **kwargs):
         super().__init__(label=label, validators=validators, **kwargs)
 
-        if "id" in kwargs:
-            self.href = kwargs["id"]
-        else:
-            self.href = "input-" + self.id
+        self._href = kwargs.get("id")
 
         if hint:
             self.hint = hint
@@ -73,6 +70,10 @@ class DMFieldMixin:
         # if we want to specify it on a subclass
         # this line will bring it back
         self.type = getattr(self.__class__, 'type', self.type)
+
+    @property
+    def href(self):
+        return self._href or f"input-{self.id}"
 
     @property
     def question(self):
@@ -110,9 +111,6 @@ class DMSelectFieldMixin:
     '''
     def __init__(self, label=None, validators=None, coerce=text_type, options=None, **kwargs):
         super().__init__(label, validators=validators, coerce=coerce, **kwargs)
-        if "id" not in kwargs:
-            # This should be the id for the first option
-            self.href = self.href + "-1"
         if options:
             self.options = copy(options)
 
@@ -133,6 +131,11 @@ class DMSelectFieldMixin:
                         'value': value,
                     }
                 )
+
+    @property
+    def href(self):
+        # This should be the id for the first option
+        return self._href or super().href + "-1"
 
     @property
     def value(self):

--- a/dmutils/forms/validators.py
+++ b/dmutils/forms/validators.py
@@ -258,6 +258,10 @@ class DateValidator:
             # remove processing errors from field
             field.errors[:] = []
 
+            # add errors to specific form field fields
+            for form_field_field in error_fields:
+                getattr(field.form_field, form_field_field).errors = [error_message]
+
             validation_error = ValidationError(error_message)
             validation_error.fields = error_fields
             raise validation_error

--- a/dmutils/forms/validators.py
+++ b/dmutils/forms/validators.py
@@ -10,7 +10,7 @@ DateValidator -- Error messages for a date input
 import datetime
 from typing import Any, Dict, Optional
 
-from wtforms.validators import ValidationError
+from wtforms.validators import StopValidation, ValidationError
 
 from dmutils.email.helpers import validate_email_address
 
@@ -269,6 +269,6 @@ class DateValidator:
             for form_field_field in error_fields:
                 getattr(field.form_field, form_field_field).errors = [error_message]
 
-            validation_error = ValidationError(error_message)
+            validation_error = StopValidation(error_message)
             validation_error.fields = error_fields
             raise validation_error

--- a/dmutils/forms/validators.py
+++ b/dmutils/forms/validators.py
@@ -159,7 +159,14 @@ class DateValidator:
     def _error(self, error, fields, **kwargs):
         e = ValueError(self.format_error_message(error, **kwargs))
         e.error = error
-        e.fields = fields
+
+        # Design System guidance is that if more than one field has an error
+        # we should highlight all fields.
+        if len(fields) > 1:
+            e.fields = {"year", "month", "day"}
+        else:
+            e.fields = fields
+
         return e
 
     def format_error_message(self, error, **kwargs):

--- a/dmutils/forms/validators.py
+++ b/dmutils/forms/validators.py
@@ -1,10 +1,14 @@
-'''
+"""
 Validators for WTForms used in the Digital Marketplace frontend
 
 EmailValidator -- validate that a string is a valid email address
 GreaterThan -- compare the values of two fields
 FourDigitYear -- validate that a four digit year value is provided
-'''
+DateValidator -- Error messages for a date input
+"""
+
+import datetime
+from typing import Any, Dict, Optional
 
 from wtforms.validators import ValidationError
 
@@ -39,6 +43,7 @@ class GreaterThan:
     :param message:
         Error message to raise in case of a validation error.
     """
+
     def __init__(self, fieldname, message=None):
         self.fieldname = fieldname
         self.message = message
@@ -75,6 +80,7 @@ class FourDigitYear:
     :param message:
         Error message to raise in case of a validation error.
     """
+
     def __init__(self, message=None):
         self.message = message
 
@@ -90,3 +96,168 @@ class FourDigitYear:
                 message = field.gettext("Year must be YYYY.")
 
             raise ValidationError(message)
+
+
+class DateValidator:
+    """Error messages for a date input
+
+    Implements the guidance in [1].
+
+    Instead of taking a `message` DateValidator has two properties,
+    `whatever_it_is` and `Whatever_it_is`, which are stand-ins for whatever it
+    is the question is asking the user for. `whatever_it_is` is used in the
+    middle of a sentence, and should include a participle: for instance, if you
+    are asking for the date when a buyer needs a supplier to start work,
+    `whatever_it_is` should be `the start date`. `Whatever_it_is` (with a
+    capital 'W') is used at the beginning of the sentence, and should not
+    include a participle. If `Whatever_it_is` is not provided it will be
+    generated from `whatever_it_is` by dropping the first word and then
+    capitalising the first letter; in our previous example, for instance,
+    `Whatever_it_is` would be `Start date`.
+
+    Alternatively you can provide the error messages desired directly; there
+    are three different error messages that can be raised by this validator:
+
+    - nothing_is_entered_error_message
+    - date_is_incomplete_error_message
+    - date_entered_cant_be_correct_error_message
+
+    The string for `date_is_incomplete_error_message` also includes a
+    placeholder for `whatever_is_missing`, in format string syntax.
+
+    [1]:  https://design-system.service.gov.uk/components/date-input/#error-messages
+    """
+
+    def __init__(
+        self,
+        whatever_it_is,
+        Whatever_it_is=None,
+        *,
+        nothing_is_entered_error_message=None,
+        date_is_incomplete_error_message=None,
+        date_entered_cant_be_correct_error_message=None,
+    ):
+        self.whatever_it_is = whatever_it_is
+        if whatever_it_is and not Whatever_it_is:
+            _, rest = whatever_it_is.split(maxsplit=1)
+            self.Whatever_it_is = rest[0].upper() + rest[1:]
+        else:
+            self.Whatever_it_is = Whatever_it_is
+
+        self.nothing_is_entered_error_message = (
+            nothing_is_entered_error_message or "Enter {whatever_it_is}"
+        )
+        self.date_is_incomplete_error_message = (
+            date_is_incomplete_error_message
+            or "{Whatever_it_is} must include a {whatever_is_missing}"
+        )
+        self.date_entered_cant_be_correct_error_message = (
+            date_entered_cant_be_correct_error_message
+            or "{Whatever_it_is} must be a real date"
+        )
+
+    def _error(self, error, fields, **kwargs):
+        e = ValueError(self.format_error_message(error, **kwargs))
+        e.error = error
+        e.fields = fields
+        return e
+
+    def format_error_message(self, error, **kwargs):
+        return getattr(self, error + "_error_message").format(
+            whatever_it_is=self.whatever_it_is,
+            Whatever_it_is=self.Whatever_it_is,
+            **kwargs,
+        )
+
+    def validate_input(self, raw_data: Dict[str, Any]):
+        """Check that year month and day are in `raw_data` and are all integers
+
+        :raises ValueError:
+        """
+        if not any(raw_data.values()):
+            raise self._error(
+                "nothing_is_entered",
+                set(raw_data.keys()),
+            )
+        elif not all(raw_data.values()):
+            missing = list(sorted(
+                name
+                for name, value in raw_data.items()
+                if not value
+            ))
+            whatever_is_missing = " and ".join(missing)
+            raise self._error(
+                "date_is_incomplete",
+                set(missing),
+                whatever_is_missing=whatever_is_missing,
+            )
+
+        def int_or_none(s: Any) -> Optional[int]:
+            if not s:
+                return None
+            try:
+                return int(s)
+            except ValueError:
+                return None
+
+        data = {name: int_or_none(value) for name, value in raw_data.items()}
+
+        if not all(data.values()):
+            raise self._error(
+                "nothing_is_entered",
+                {k for k, v in data.items() if v is None},
+            )
+
+    def validate_data(self, data: Dict[str, int]):
+        """Check that year month and day in `data` make a valid date
+
+        :raises ValueError:
+        """
+        year, month, day = data["year"], data["month"], data["day"]
+
+        invalid = set()
+        if not (1 <= day and day <= 31):
+            invalid.add("day")
+        if not (1 <= month and month <= 12):
+            invalid.add("month")
+        if not (datetime.MINYEAR <= year and year <= datetime.MAXYEAR):
+            invalid.add("year")
+
+        if not invalid:
+            try:
+                datetime.date(year, month, day)
+            except ValueError:
+                # assume that since we've eliminated other possibilities
+                # above it must be that the day given is outside the number
+                # of days in the given month and year
+                # see https://docs.python.org/3.6/library/datetime.html#datetime.date
+                invalid.add("day")
+
+        if invalid:
+            raise self._error(
+                "date_entered_cant_be_correct",
+                invalid,
+            )
+
+    def validate_date(self, year, month, day):
+        self.validate_input({"year": year, "month": month, "day": day})
+        self.validate_data({"year": int(year), "month": int(month), "day": int(day)})
+
+    def __call__(self, form, field):
+        """WTForms date validator for DMDateField"""
+        try:
+            self.validate_date(
+                field.form_field.year.data,
+                field.form_field.month.data,
+                field.form_field.day.data,
+            )
+        except ValueError as e:
+            error_message = str(e)
+            error_fields = getattr(e, "fields", {"year", "month", "day"})
+
+            # remove processing errors from field
+            field.errors[:] = []
+
+            validation_error = ValidationError(error_message)
+            validation_error.fields = error_fields
+            raise validation_error

--- a/tests/forms/test_dmfields.py
+++ b/tests/forms/test_dmfields.py
@@ -1,5 +1,4 @@
 import pytest
-
 import wtforms
 
 import dmutils.forms.fields
@@ -83,6 +82,15 @@ def test_field_href_is_not_prefixed_with_input_prefix_if_specified(field_class):
     form = TestForm()
 
     assert form.field.href == "field"
+
+
+def test_date_field_href_is_suffixed_with_first_field_if_no_error():
+    class TestForm(wtforms.Form):
+        field = DMDateField()
+
+    form = TestForm()
+
+    assert form.field.href == "input-field-day"
 
 
 @pytest.mark.parametrize("field_class", (

--- a/tests/forms/test_dmfields.py
+++ b/tests/forms/test_dmfields.py
@@ -1,9 +1,9 @@
-
 import pytest
 
 import wtforms
 
 import dmutils.forms.fields
+from dmutils.forms.fields import DMDateField
 
 
 @pytest.fixture(params=dmutils.forms.fields.__all__)
@@ -107,3 +107,14 @@ def test_selection_field_href_is_not_suffixed_with_number_if_id_is_specified(fie
     form = TestForm()
 
     assert form.field.href == "field"
+
+
+def test_dm_date_field_proxies_access_to_form_field_fields():
+    class TestForm(wtforms.Form):
+        date = DMDateField("Date")
+
+    field = TestForm().date
+
+    assert field.day == field.form_field.day
+    assert field.month == field.form_field.month
+    assert field.year == field.form_field.year

--- a/tests/forms/test_dmfields.py
+++ b/tests/forms/test_dmfields.py
@@ -126,3 +126,20 @@ def test_dm_date_field_proxies_access_to_form_field_fields():
     assert field.day == field.form_field.day
     assert field.month == field.form_field.month
     assert field.year == field.form_field.year
+
+
+def test_dm_date_field_copies_errors_to_form_field_fields():
+    from wtforms.validators import ValidationError
+
+    def test_validator(form, field):
+        raise ValidationError("Validation error")
+
+    class TestForm(wtforms.Form):
+        date = DMDateField("Date", validators=[test_validator])
+
+    form = TestForm()
+    form.validate()
+
+    assert "Validation error" in form.date.day.errors
+    assert "Validation error" in form.date.month.errors
+    assert "Validation error" in form.date.year.errors

--- a/tests/forms/test_forms.py
+++ b/tests/forms/test_forms.py
@@ -1,5 +1,6 @@
-"""Test things in dmutils.forms working together"""
+"""Test tools in this module working together"""
 
+import pytest
 import wtforms
 from werkzeug.datastructures import MultiDict
 
@@ -31,3 +32,25 @@ def test_dm_date_field_with_date_validator_includes_error_on_specific_fields():
     assert form.validate() is False
     assert form.date.errors == ["Date must be a real date"]
     assert form.date.day.errors
+
+
+@pytest.mark.parametrize("data, error_field", (
+    ({"day": "01", "year": "2020"}, "month"),
+    ({"day": "01", "month": "13"}, "month"),
+    ({"day": "01", "month": "12"}, "year"),
+    ({"day": "2", "month": "2", "year": "-1"}, "day"),
+    ({"day": "30", "month": "2", "year": "2020"}, "day"),
+    ({"day": "31", "month": "13", "year": "2020"}, "month"),
+))
+def test_date_field_href_is_suffixed_with_first_field_with_error_when_using_date_validator(
+    data, error_field
+):
+    # this probably won't work with other validators
+
+    class TestForm(wtforms.Form):
+        field = DMDateField(validators=[DateValidator("a date")])
+
+    form = TestForm(MultiDict({"field-day": "01", "field-year": "2020"}))
+    form.validate()
+
+    assert form.field.href == "input-field-month"

--- a/tests/forms/test_forms.py
+++ b/tests/forms/test_forms.py
@@ -1,0 +1,33 @@
+"""Test things in dmutils.forms working together"""
+
+import wtforms
+from werkzeug.datastructures import MultiDict
+
+from dmutils.forms.fields import DMDateField
+from dmutils.forms.validators import DateValidator
+
+
+def test_dm_date_field_with_date_validator():
+    class TestForm(wtforms.Form):
+        date = DMDateField("Date", validators=[DateValidator("a date")])
+
+    form = TestForm()
+
+    assert form.validate() is False
+    assert form.date.errors == ["Enter a date"]
+
+    form = TestForm(MultiDict({"date-year": "2020", "date-month": "01", "date-day": "26"}))
+
+    assert form.validate() is True
+    assert not form.date.errors
+
+
+def test_dm_date_field_with_date_validator_includes_error_on_specific_fields():
+    class TestForm(wtforms.Form):
+        date = DMDateField("Date", validators=[DateValidator("a date")])
+
+    form = TestForm(MultiDict({"date-year": "2020", "date-month": "01", "date-day": "33"}))
+
+    assert form.validate() is False
+    assert form.date.errors == ["Date must be a real date"]
+    assert form.date.day.errors

--- a/tests/forms/test_validators.py
+++ b/tests/forms/test_validators.py
@@ -8,6 +8,7 @@ from wtforms.validators import ValidationError
 import dmutils.forms.validators
 from dmutils.forms.validators import (
     GreaterThan,
+    DateValidator,
 )
 
 
@@ -110,3 +111,96 @@ class TestGreaterThan:
         form.other.data = b
 
         assert validator(form, form.field) is None
+
+
+class TestDateValidator:
+    @pytest.fixture
+    def validate_date(self):
+        return DateValidator("a date").validate_date
+
+    @pytest.fixture
+    def validator(self):
+        return DateValidator("a date")
+
+    def test_date_error_message_returns_none_for_valid_date(self, validate_date):
+        assert validate_date(2020, 11, 27) is None
+        assert validate_date(2004, 2, 29) is None
+
+    @pytest.mark.parametrize("date", (
+        ("2020", 1, 26),
+        (2020, "1", 26),
+        (2020, 1, "26"),
+        ("2020", "1", "26"),
+        ("2020", "01", "26"),
+        ("2020", "01", "06"),
+    ))
+    def test_date_error_message_can_handle_strings(self, validate_date, date):
+        assert validate_date(*date) is None
+
+    @pytest.mark.parametrize("data, invalid_fields", (
+        ((None, None, None), {"year", "month", "day"}),
+        (("", "", ""), {"year", "month", "day"}),
+        (("foo", "bar", "baz"), {"year", "month", "day"}),
+        (("1.0", "1.0", "1.0"), {"year", "month", "day"}),
+        (("2020", "1", "baz"), {"day"}),
+        (("2020", "1", "1.0"), {"day"}),
+    ))
+    def test_date_error_message_raises_nothing_is_entered_message_if_data_is_empty_or_not_int(
+        self, validate_date, data, invalid_fields
+    ):
+        with pytest.raises(ValueError) as e:
+            validate_date(*data)
+
+        assert str(e.value) == "Enter a date"
+        assert e.value.error == "nothing_is_entered"
+        assert e.value.fields == invalid_fields
+
+    @pytest.mark.parametrize("data, invalid_fields, error_message", (
+        ((2020, "", ""), {"month", "day"}, "Date must include a day and month"),
+        ((2020, 1, ""), {"day"}, "Date must include a day"),
+        (("", 1, ""), {"day", "year"}, "Date must include a day and year"),
+    ))
+    def test_date_error_message_raises_date_is_incomplete_message_for_missing_data(
+        self, validate_date, data, invalid_fields, error_message
+    ):
+        with pytest.raises(ValueError) as e:
+            validate_date(*data)
+
+        assert str(e.value) == error_message
+        assert e.value.error == "date_is_incomplete"
+        assert e.value.fields == invalid_fields
+
+    @pytest.mark.parametrize("data, invalid_fields", (
+        ((2020, 13, 1), {"month"}),
+        ((1999, 1, 310), {"day"}),
+        ((-19, 1, 310), {"year", "day"}),
+        ((2001, 2, 29), {"day"}),
+    ))
+    def test_data_error_message_raises_date_entered_cant_be_correct_message_for_invalid_date(
+        self, validate_date, data, invalid_fields
+    ):
+        with pytest.raises(ValueError) as e:
+            validate_date(*data)
+
+        assert str(e.value) == "Date must be a real date"
+        assert e.value.error == "date_entered_cant_be_correct"
+        assert e.value.fields == invalid_fields
+
+    def test_raises_validation_error_for_invalid_data(self, form, field, validator):
+        field.form_field.year.data = None
+        field.form_field.month.data = None
+        field.form_field.day.data = None
+        field.errors = []
+
+        with pytest.raises(ValidationError) as e:
+            validator(form, field)
+
+        assert str(e.value) == "Enter a date"
+        assert e.value.fields == {"year", "month", "day"}
+
+    def test_does_not_raise_validation_error_for_valid_data(self, form, field, validator):
+        field.form_field.year.data = 2020
+        field.form_field.month.data = 1
+        field.form_field.day.data = 26
+
+        validator(form, field)

--- a/tests/forms/test_validators.py
+++ b/tests/forms/test_validators.py
@@ -156,9 +156,14 @@ class TestDateValidator:
         assert e.value.fields == invalid_fields
 
     @pytest.mark.parametrize("data, invalid_fields, error_message", (
-        ((2020, "", ""), {"month", "day"}, "Date must include a day and month"),
+        # 'Highlight the day, month or year field where the information is missing'.
         ((2020, 1, ""), {"day"}, "Date must include a day"),
-        (("", 1, ""), {"day", "year"}, "Date must include a day and year"),
+        ((2020, "", 1), {"month"}, "Date must include a month"),
+        (("", 1, 1), {"year"}, "Date must include a year"),
+        # 'If more than one field is missing information, highlight the date input as a whole'.
+        ((2020, "", ""), {"day", "month", "year"}, "Date must include a day and month"),
+        (("", 1, ""), {"day", "month", "year"}, "Date must include a day and year"),
+        (("", "", 1), {"day", "month", "year"}, "Date must include a month and year"),
     ))
     def test_date_error_message_raises_date_is_incomplete_message_for_missing_data(
         self, validate_date, data, invalid_fields, error_message
@@ -171,10 +176,13 @@ class TestDateValidator:
         assert e.value.fields == invalid_fields
 
     @pytest.mark.parametrize("data, invalid_fields", (
+        # 'Highlight the day, month or year field with the incorrect information'.
         ((2020, 13, 1), {"month"}),
         ((1999, 1, 310), {"day"}),
-        ((-19, 1, 310), {"year", "day"}),
         ((2001, 2, 29), {"day"}),
+        # 'Or highlight the date as a whole if there’s incorrect information in
+        # more than one field, or it’s not clear which field is incorrect'.
+        ((-19, 1, 310), {"day", "month", "year"}),
     ))
     def test_data_error_message_raises_date_entered_cant_be_correct_message_for_invalid_date(
         self, validate_date, data, invalid_fields

--- a/tests/forms/test_validators.py
+++ b/tests/forms/test_validators.py
@@ -3,7 +3,7 @@ from datetime import date
 import pytest
 import mock
 
-from wtforms.validators import ValidationError
+from wtforms.validators import StopValidation, ValidationError
 
 import dmutils.forms.validators
 from dmutils.forms.validators import (
@@ -200,7 +200,7 @@ class TestDateValidator:
         field.form_field.day.data = None
         field.errors = []
 
-        with pytest.raises(ValidationError) as e:
+        with pytest.raises(StopValidation) as e:
             validator(form, field)
 
         assert str(e.value) == "Enter a date"


### PR DESCRIPTION
https://trello.com/c/Ex9qw68e/184-3-more-granular-date-error-messages

Add `DateValidator` class to validate date input submissions from user. This should (hopefully) be usable with both WTForms DMDateFields and content loader date questions.