### PR TITLE
Fix bugs in GreaterThan validator

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '56.0.0'
+__version__ = '56.0.1'

--- a/dmutils/forms/validators.py
+++ b/dmutils/forms/validators.py
@@ -47,17 +47,25 @@ class GreaterThan:
         try:
             other = form[self.fieldname]
         except KeyError:
-            raise ValidationError(field.gettext("Invalid field name '%s'." % self.fieldname))
-        if other.data and not field.data > other.data:
-            d = {
-                'other_label': hasattr(other, 'label') and other.label.text or self.fieldname,
-                'other_name': self.fieldname
-            }
-            message = self.message
-            if message is None:
-                message = field.gettext('Field must be greater than %(other_name)s.')
+            raise ValidationError(
+                field.gettext("Invalid field name '%s'." % self.fieldname)
+            )
+        if field.data is None or other.data is None:
+            return
+        elif field.data > other.data:
+            return
 
-            raise ValidationError(message % d)
+        d = {
+            "other_label": hasattr(other, "label")
+            and other.label.text
+            or self.fieldname,
+            "other_name": self.fieldname,
+        }
+        message = self.message
+        if message is None:
+            message = field.gettext("Field must be greater than %(other_name)s.")
+
+        raise ValidationError(message % d)
 
 
 class FourDigitYear:


### PR DESCRIPTION
While working on another ticket I found some bugs in the GreaterThan 
validator:

- it will raise an exception if there is no data for field
- it will not compare itself to 0

This commit adds some tests and fixes the bugs.

Now the GreaterThan validator will not compare itself if has no input
(same as we were doing if other had no input), and will do the comparison
 if other is 0.