### PR TITLE
Replace make with invoke

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,3 +11,4 @@ max-complexity = 12
 max-line-length = 120
 per-file-ignores =
     **/__init__.py : F401
+    tasks.py: F401

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,11 @@ jobs:
           path: venv
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
 
+      - name: Install developer tools
+        run: make bootstrap
+
       - name: Install dependencies
-        run: make requirements-dev
+        run: invoke requirements-dev
 
       - name: Run tests
-        run: make test
+        run: invoke test

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,20 @@
-SHELL := /bin/bash
-VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
 
-.PHONY: virtualenv
-virtualenv:
-	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true
+.DEFAULT_GOAL := bootstrap
 
-.PHONY: requirements-dev
-requirements-dev: virtualenv requirements-dev.txt
-	${VIRTUALENV_ROOT}/bin/pip install -Ur requirements-dev.txt
+%:
+	@[ -z $$TERM ] || tput setaf 1  # red
+	@echo 2>1 warning: calling '`make`' is being deprecated in this repo, you should use '`invoke` (https://pyinvoke.org)' instead.
+	@[ -z $$TERM ] || tput setaf 9  # default
+	@# pass goals to '`invoke`'
+	invoke $(or $(MAKECMDGOALS), $@)
 
-.PHONY: test
-test: show-environment test-flake8 test-mypy test-python
+help:
+	invoke --list
 
-.PHONY: test-flake8
-test-flake8: virtualenv
-	${VIRTUALENV_ROOT}/bin/flake8 .
-
-.PHONY: test-mypy
-test-mypy: virtualenv requirements-dev
-	${VIRTUALENV_ROOT}/bin/mypy dmutils/
-
-.PHONY: test-python
-test-python: virtualenv requirements-dev
-	${VIRTUALENV_ROOT}/bin/py.test ${PYTEST_ARGS}
-
-.PHONY: show-environment
-show-environment:
-	@echo "Environment variables in use:"
-	@env | grep DM_ || true
-
+.PHONY: bootstrap
+bootstrap:
+	pip install digitalmarketplace-developer-tools
+	@echo done
+	@[ -z $$TERM ] || tput setaf 2  # green
+	@echo 2>1 dmdevtools has been installed globally, run developer tasks with '`invoke`'
+	@[ -z $$TERM ] || tput setaf 9  # default

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,1 @@
+from dmdevtools.invoke_tasks import library_tasks as ns

--- a/tasks.py
+++ b/tasks.py
@@ -1,1 +1,12 @@
+from invoke import task
+
 from dmdevtools.invoke_tasks import library_tasks as ns
+
+
+@task(ns["virtualenv"], ns["requirements_dev"])
+def test_mypy(c):
+    c.run("mypy dmutils/")
+
+
+ns.add_task(test_mypy)
+ns["test"].pre.insert(-1, test_mypy)


### PR DESCRIPTION
Ticket: https://trello.com/c/hCCo28Bc/1329-add-makefiles-to-digitalmarketplace-utils-and-reduce-duplication-across-apps

We want to be able to reduce duplication of code across our repos; one of the places we have a lot of duplicated code is in our Makefiles; all of our repos have very similar Makefiles with small historical differences.

This pull request replaces Make with invoke, using the tasks from alphagov/digitalmarketplace-dev-tools.

See alphagov/digitalmarketplace-developer-tools#1 for more details.

---

Note: the tests won't pass until alphagov/digitalmarketplace-developer-tools#1 is merged, as they now depend on invoke