### PR TITLE
Log Direct Plus API errors

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '56.1.0'
+__version__ = '56.1.1'

--- a/dmutils/direct_plus_client.py
+++ b/dmutils/direct_plus_client.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Optional
+
 import requests
 from requests import HTTPError
 
@@ -76,9 +78,14 @@ class DirectPlusClient(object):
             )
         return response
 
-    def get_organization_by_duns_number(self, duns_number):
+    def get_organization_by_duns_number(self, duns_number) -> Optional[dict]:
         """
         Request a supplier by duns number from the Direct Plus API
+
+        :return the organisation corresponding to the DUNS number; or `None` if the number is invalid or no
+                corresponding organisation exists.
+        :raises KeyError on unexpected failure if the response body is JSON.
+        :raises ValueError on unexpected failure if the response body is not valid JSON.
         """
         response = self._direct_plus_request(
             f'data/duns/{duns_number}', payload={'productId': 'cmpelk', 'versionId': 'v2'}


### PR DESCRIPTION
Trello: https://trello.com/c/bZ4XlASA

We had a recent incident involving the Direct Plus API. We were getting 400 responses for valid DUNS numbers. This was a problem because no API errors were logged, which made debugging very difficult. So add logging for unexpected errors.

Also, understanding what the APi client did was difficult, so add some documentation.

Also, start following the documented API more closely, and only treat the errors as expected when we also get the error codes we expect. This is taken from the API documentation: https://directplus.documentation.dnb.com/errorsAndInformationMessages.html.