### PR TITLE
Handle all errors from Notify client

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-08-28T14:21:12Z",
+  "generated_at": "2021-02-10T17:15:51Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -144,49 +144,49 @@
         "hashed_secret": "e8248cbe79a288ffec75d7300ad2e07172f487f6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 21,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "0039db059f44eaa2cce38116b03c23aeec7a1794",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 102,
+        "line_number": 105,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "fbec469b46275944228db1877d7bbeccf214e2d6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 235,
+        "line_number": 238,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "7082c8ba4d4386fab8014c5da63e73d14fc47632",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 339,
+        "line_number": 342,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "9f4fe05d5a7d2bd83f960d3d218ba5a82e84f5ea",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 386,
+        "line_number": 389,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "739fa541b48d94623cdd58b308ef03b93fe9bdfb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 393,
+        "line_number": 396,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "e3760ae7b3ffbeb801c999220d09646c4f69b0dc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 423,
+        "line_number": 426,
         "type": "Secret Keyword"
       }
     ],

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '56.1.1'
+__version__ = '56.1.2'

--- a/tests/email/test_dm_notify.py
+++ b/tests/email/test_dm_notify.py
@@ -490,7 +490,16 @@ class TestDMNotifyClient(PatchExternalServiceLogConditionMixin):
             assert dm_notify_client.has_been_sent('reference_123', use_recent_cache=False) == has_been_sent
             get_all_notifications_mock.assert_called_once_with(reference='reference_123')
 
-    def test_raises_email_error(self, dm_notify_client, notify_example_http_error):
+    def test_raises_email_error_for_string_error(self, dm_notify_client, notify_example_http_error):
+        notify_example_http_error._message = "An error"
+
+        with mock.patch(self.client_class_str + '.' + 'send_email_notification') as email_mock:
+            email_mock.side_effect = notify_example_http_error
+
+            with pytest.raises(EmailError):
+                dm_notify_client.send_email(self.email_address, self.template_id)
+
+    def test_raises_email_error_for_api_error(self, dm_notify_client, notify_example_http_error):
         with mock.patch(self.client_class_str + '.' + 'send_email_notification') as email_mock:
             email_mock.side_effect = notify_example_http_error
 


### PR DESCRIPTION
Trello: https://trello.com/c/ct6lxcle

Most of the time, Notify error messages are of type `List[Dict]`. However, sometimes, they are a string - see https://github.com/alphagov/notifications-python-client/pull/189.

Handle both properly. This will fix the errors we see when we get unexpected errors from Notify (for example, 503s).