### PR TITLE
Mark this package as having type hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Records breaking changes from major version bumps
 
+## 58.0.0
+
+### Breaking changes
+
+Mark this package as PEP 561 compatible. If you have dmutils as a dependency and run type checking, the type checker
+will now check that you're using dmutils correctly. This might break your application's type checking if you're using 
+dmutils incorrectly. 
+
 ## 57.0.0
 
 ### Breaking changes

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '57.0.0'
+__version__ = '58.0.0'

--- a/dmutils/filters.py
+++ b/dmutils/filters.py
@@ -1,11 +1,14 @@
 from __future__ import unicode_literals
 
+from typing import Iterable, Any
+
 import govuk_country_register
 import re
 from jinja2 import evalcontextfilter, Markup, escape
+from jinja2.nodes import EvalContext
 
 
-def smartjoin(input):
+def smartjoin(input: Iterable) -> str:
     list_to_join = list(input)
     if len(list_to_join) > 1:
         return '{} and {}'.format(', '.join(list_to_join[:-1]), list_to_join[-1])
@@ -15,7 +18,7 @@ def smartjoin(input):
         return ''
 
 
-def format_links(text, open_links_in_new_tab=None):
+def format_links(text: str, open_links_in_new_tab: bool = False) -> str:
     """
     Filter that searches a given string (or other string-like object) for any URIs
     and wraps them with either an anchor link or a span, depending on whether the link contains a valid protocol.
@@ -53,7 +56,7 @@ def format_links(text, open_links_in_new_tab=None):
         return text
 
 
-def nbsp(text):
+def nbsp(text: str) -> str:
     """Replace spaces with nbsp.
 
     If you want to use html with this filter you need to pass it in as marksafe
@@ -63,7 +66,7 @@ def nbsp(text):
     return text.replace(' ', Markup('&nbsp;'))
 
 
-def capitalize_first(maybe_text):
+def capitalize_first(maybe_text: Any) -> Any:
     """If it's a string capitalise the first character, unless it looks like a URL
 
     :param maybe_text: Could be anything
@@ -84,7 +87,7 @@ _multiple_newlines_re = re.compile(r'(\r\n[ \t\f\v]*){2,}')
 _single_newline_re = re.compile(r'(\r\n)')
 
 
-def replace_newlines_with_breaks(value):
+def replace_newlines_with_breaks(value: str) -> str:
     """Replace newlines in a string with HTML <br> elements"""
 
     # `escape()` returns Markdown objects in python2
@@ -100,7 +103,7 @@ def replace_newlines_with_breaks(value):
 
 
 @evalcontextfilter
-def preserve_line_breaks(eval_ctx, value):
+def preserve_line_breaks(eval_ctx: EvalContext, value: str) -> str:
     result = replace_newlines_with_breaks(value)
 
     if eval_ctx.autoescape:
@@ -109,7 +112,7 @@ def preserve_line_breaks(eval_ctx, value):
     return result
 
 
-def sub_country_codes(text):
+def sub_country_codes(text: str) -> str:
     """Replace country codes with country common name
 
     :param text:    text containing country codes in the form 'country:AA'

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     description='Common utils for Digital Marketplace apps.',
     long_description=__doc__,
     packages=find_packages(),
+    package_data={'dmutils': ['py.typed']},
     include_package_data=True,
     install_requires=[
          'Flask-WTF>=0.14.2',


### PR DESCRIPTION
Trello: https://trello.com/c/DZ28pqhm/90-try-to-add-type-hints-to-content-loader

As per [PEP 561](https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages), we need to let type checkers know that this package has type hints. We do this by adding an empty `py.typed` file, and adding it to `setup.py`.

mypy will now recognise that this package is typed. So it will check the types when type checking things that depend on dmutils.

Also add type hints to the filters module.