### PR TITLE
Ensure that the tests are run at least weekly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Run tests
-on: [pull_request]
+on: 
+  pull_request:
+  schedule:
+    - cron: "0 0 * * SUN"
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We make changes to this repo infrequently. So there can be long gaps between test runs. Add weekly tests on a Sunday to ensure that we notice in a timely manner if the tests break.