### PR TITLE
Add dependabot to this repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "03:00"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
We've pinned some dependencies in [`setup.py`](https://github.com/alphagov/digitalmarketplace-utils/blob/main/setup.py). We should add dependabot to make sure that they're kept up to date

We should probably be reducing the amount of pinning anyway, but this is probably still a good first step.