### PR TITLE
Disable Hypothesis deadlines in spreadsheet tests

### DIFF
--- a/tests/test_ods.py
+++ b/tests/test_ods.py
@@ -3,7 +3,7 @@ import functools
 
 import dmutils.ods as ods
 
-from hypothesis import strategies as st
+from hypothesis import strategies as st, settings
 from hypothesis import given, example
 
 po = functools.partial(mock.patch.object, autospec=True)
@@ -155,6 +155,7 @@ class TestSpreadSheet(object):
         assert instance._sheets == {}
 
     @given(st.text())
+    @settings(deadline=None)
     def test_sheet(self, name):
         instance = ods.SpreadSheet()
         instance._document = mock.MagicMock(spec_set=instance._document)
@@ -174,6 +175,7 @@ class TestSpreadSheet(object):
 
     @given(st.text(), st.text(), st.integers(min_value=0, max_value=10),
            st.dictionaries(st.text(), st.text()))
+    @settings(deadline=None)
     def test_add_style(self, name, family, count, kwargs):
         styles = [mock.Mock() for v in range(count)]
 


### PR DESCRIPTION
By default, Hypothesis imposes a 0.2s deadline on tests and treats them as failing if they exceed this (https://hypothesis.readthedocs.io/en/latest/settings.html).

However, these spreadsheet tests can be slow - they're manipulating spreadsheets after all! So the tests sometimes fail because they slightly exceed the deadline. For example, https://github.com/alphagov/digitalmarketplace-utils/runs/1880009563?check_suite_focus=true and https://github.com/alphagov/digitalmarketplace-utils/runs/2467835277?check_suite_focus=true.

Disable the deadline for these tests so that they stop being flaky.

Fixes failure seen in https://github.com/alphagov/digitalmarketplace-utils/pull/610