### PR TITLE
Specify Python 3.6 version

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,2 @@
+# TODO: remove this file when using Python 3.7
+3.6.13


### PR DESCRIPTION
We need to tell Dependabot which version of Python it should use. Otherwise, it tries to run using Python 3.8, which causes us problems similar to https://github.com/dependabot/feedback/issues/794

We should be able to delete this file once we've upgraded to Python 3.7

Should unblock all the broken Dependabot PRs, e.g. https://github.com/alphagov/digitalmarketplace-utils/pull/620