### PR TITLE
Remove comment from Python version specifier

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,2 +1,1 @@
-# TODO: remove this file when using Python 3.7
 3.6.13


### PR DESCRIPTION
I think Dependabot doesn't know how to handle the comment - it seems to implement its own parser for this file. So we need to remove the comment for Dependabot to be able to parse this file.

If we're lucky, this will fix the problem of Dependabot losing important 3.6-specific dependencies.

Follow-on from https://github.com/alphagov/digitalmarketplace-utils/pull/623