### PR TITLE
Bump minor version

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '58.0.0'
+__version__ = '58.1.0'


### PR DESCRIPTION
So downstream users can take [the updated version of mailchimp](https://github.com/alphagov/digitalmarketplace-utils/pull/613). I don't think there are any breaking changes.