### PR TITLE
Stop using the mock library for tests

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -3,7 +3,6 @@
 flake8
 freezegun
 hypothesis
-mock
 moto
 mypy
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,8 +14,8 @@ blinker==1.4
     # via gds-metrics
 boto3==1.17.71
     # via
+    #   digitalmarketplace-utils
     #   moto
-    #   sanitized-package
 botocore==1.20.71
     # via
     #   boto3
@@ -32,11 +32,11 @@ chardet==4.0.0
 click==7.1.2
     # via flask
 contextlib2==0.6.0.post1
-    # via sanitized-package
+    # via digitalmarketplace-utils
 cryptography==3.4.7
     # via
+    #   digitalmarketplace-utils
     #   moto
-    #   sanitized-package
 defusedxml==0.7.1
     # via odfpy
 digitalmarketplace-test-utils==2.8.2
@@ -46,31 +46,31 @@ docopt==0.6.2
 flake8==3.9.2
     # via -r requirements-dev.in
 flask-gzip==0.2
-    # via sanitized-package
+    # via digitalmarketplace-utils
 flask-login==0.5.0
-    # via sanitized-package
+    # via digitalmarketplace-utils
 flask-session==0.3.2
-    # via sanitized-package
+    # via digitalmarketplace-utils
 flask-wtf==0.14.3
-    # via sanitized-package
+    # via digitalmarketplace-utils
 flask==1.0.4
     # via
+    #   digitalmarketplace-utils
     #   flask-gzip
     #   flask-login
     #   flask-session
     #   flask-wtf
     #   gds-metrics
-    #   sanitized-package
 fleep==1.0.1
-    # via sanitized-package
+    # via digitalmarketplace-utils
 freezegun==1.1.0
     # via -r requirements-dev.in
 future==0.18.2
     # via notifications-python-client
 gds-metrics==0.2.4
-    # via sanitized-package
+    # via digitalmarketplace-utils
 govuk-country-register==0.5.0
-    # via sanitized-package
+    # via digitalmarketplace-utils
 hypothesis==6.12.0
     # via -r requirements-dev.in
 idna==2.8
@@ -95,7 +95,7 @@ jmespath==0.10.0
     #   boto3
     #   botocore
 mailchimp3==3.0.14
-    # via sanitized-package
+    # via digitalmarketplace-utils
 markupsafe==1.1.1
     # via
     #   jinja2
@@ -103,8 +103,6 @@ markupsafe==1.1.1
     #   wtforms
 mccabe==0.6.1
     # via flake8
-mock==3.0.5
-    # via -r requirements-dev.in
 monotonic==1.6
     # via notifications-python-client
 more-itertools==8.7.0
@@ -116,9 +114,9 @@ mypy-extensions==0.4.3
 mypy==0.812
     # via -r requirements-dev.in
 notifications-python-client==5.7.1
-    # via sanitized-package
+    # via digitalmarketplace-utils
 odfpy==1.4.1
-    # via sanitized-package
+    # via digitalmarketplace-utils
 packaging==20.9
     # via pytest
 pluggy==0.13.1
@@ -145,30 +143,29 @@ python-dateutil==2.8.1
     #   freezegun
     #   moto
 python-json-logger==0.1.11
-    # via sanitized-package
+    # via digitalmarketplace-utils
 pytz==2021.1
     # via
+    #   digitalmarketplace-utils
     #   moto
-    #   sanitized-package
 redis==3.5.3
-    # via sanitized-package
+    # via digitalmarketplace-utils
 requests-mock==1.9.2
     # via -r requirements-dev.in
 requests==2.25.1
     # via
+    #   digitalmarketplace-utils
     #   mailchimp3
     #   moto
     #   notifications-python-client
     #   requests-mock
     #   responses
-    #   sanitized-package
 responses==0.13.3
     # via moto
 s3transfer==0.4.2
     # via boto3
 six==1.15.0
     # via
-    #   mock
     #   moto
     #   python-dateutil
     #   requests-mock
@@ -186,7 +183,7 @@ typing-extensions==3.7.4.3
     #   importlib-metadata
     #   mypy
 unicodecsv==0.14.1
-    # via sanitized-package
+    # via digitalmarketplace-utils
 urllib3==1.26.4
     # via
     #   botocore
@@ -194,11 +191,11 @@ urllib3==1.26.4
     #   responses
 werkzeug==1.0.1
     # via
+    #   digitalmarketplace-utils
     #   flask
     #   moto
-    #   sanitized-package
 workdays==1.4
-    # via sanitized-package
+    # via digitalmarketplace-utils
 wtforms==2.3.3
     # via flask-wtf
 xmltodict==0.12.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
-import mock
 import pytest
 
 from flask import Flask
 from io import StringIO
 from logging import Logger, StreamHandler
+from unittest import mock
 
 from dmutils.logging import init_app as logging_init_app
 

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 """Tests for the Digital Marketplace MailChimp integration."""
 import logging
-import mock
 import pytest
 import types
 
 from json.decoder import JSONDecodeError
 from requests import RequestException
 from requests.exceptions import HTTPError, ConnectTimeout
+from unittest import mock
 
 from dmutils.email.dm_mailchimp import DMMailChimpClient, get_response_from_exception
 from mailchimp3.mailchimpclient import MailChimpError

--- a/tests/email/test_dm_notify.py
+++ b/tests/email/test_dm_notify.py
@@ -2,10 +2,10 @@
 """Tests for the Digital Marketplace Notify client."""
 import json
 
-import mock
 import os
 from collections import OrderedDict
 from itertools import product
+from unittest import mock
 
 import pytest
 from notifications_python_client.errors import HTTPError

--- a/tests/email/test_tokens.py
+++ b/tests/email/test_tokens.py
@@ -2,10 +2,10 @@
 import base64
 from datetime import datetime
 
-import mock
 import pytest
 from cryptography import fernet
 from freezegun import freeze_time
+from unittest import mock
 
 from dmutils.config import init_app
 from dmutils.email.tokens import (

--- a/tests/email/test_user_account_email.py
+++ b/tests/email/test_user_account_email.py
@@ -1,6 +1,6 @@
-import mock
 import pytest
 from flask import session, current_app
+from unittest import mock
 
 from dmutils.config import init_app
 from dmutils.email import send_user_account_email, EmailError

--- a/tests/forms/test_dmwidgets.py
+++ b/tests/forms/test_dmwidgets.py
@@ -1,6 +1,5 @@
-
-import mock
 import pytest
+from unittest import mock
 
 import dmutils.forms.fields
 import dmutils.forms.mixins

--- a/tests/forms/test_validators.py
+++ b/tests/forms/test_validators.py
@@ -1,7 +1,7 @@
 from datetime import date
 
 import pytest
-import mock
+from unittest import mock
 
 from wtforms.validators import StopValidation, ValidationError
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,8 +1,8 @@
 from contextlib import contextmanager
 from datetime import datetime
 from io import BytesIO
+from unittest import mock
 
-import mock
 from testfixtures import logcapture
 from dmtestutils.comparisons import AnyStringMatching
 

--- a/tests/test_asset_fingerprint.py
+++ b/tests/test_asset_fingerprint.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-import mock
+from unittest import mock
 
 from dmutils.asset_fingerprint import AssetFingerprinter
 

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 import datetime
-import mock
+from unittest import mock
 
 import dmutils.dates as dates_package
 

--- a/tests/test_direct_plus_client.py
+++ b/tests/test_direct_plus_client.py
@@ -1,6 +1,6 @@
-import mock
 import pytest
 import requests_mock
+from unittest import mock
 
 from dmutils.direct_plus_client import (
     DirectPlusClient,

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,9 +1,9 @@
 # coding: utf-8
-import mock
 import pytest
 
 from botocore.exceptions import ClientError
 from freezegun import freeze_time
+from unittest import mock
 
 from dmutils.documents import (
     generate_file_name, get_extension,

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,5 +1,4 @@
 import json
-import mock
 import pytest
 
 from flask import session
@@ -9,6 +8,7 @@ from werkzeug.exceptions import (
 )
 from werkzeug.http import dump_cookie
 from jinja2.exceptions import TemplateNotFound
+from unittest import mock
 
 from dmutils.authentication import UnauthorizedWWWAuthenticate
 from dmutils.errors.frontend import csrf_handler, redirect_to_login, render_error_page

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import mock
 import pytest
 
 from flask import Markup
+from unittest import mock
 
 from dmutils.filters import (
     capitalize_first, format_links, nbsp, smartjoin, preserve_line_breaks, sub_country_codes

--- a/tests/test_flask_init.py
+++ b/tests/test_flask_init.py
@@ -2,8 +2,8 @@ from flask import Flask
 
 from dmutils.flask_init import pluralize, init_app
 import dmutils.session
-import mock
 import pytest
+from unittest import mock
 
 
 @pytest.mark.parametrize("count,singular,plural,output", [

--- a/tests/test_jinja_environment.py
+++ b/tests/test_jinja_environment.py
@@ -1,5 +1,5 @@
-import mock
 from dmutils.jinja2_environment import DMSandboxedEnvironment
+from unittest import mock
 
 
 def test_custom_filters_added():

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -5,10 +5,9 @@ import os.path
 import tempfile
 import time
 
-import mock
-
 from flask import request
 import pytest
+from unittest import mock
 
 from dmtestutils.comparisons import AnyStringMatching, AnySupersetOf, RestrictedAny
 

--- a/tests/test_ods.py
+++ b/tests/test_ods.py
@@ -1,5 +1,5 @@
-import mock
 import functools
+from unittest import mock
 
 import dmutils.ods as ods
 

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -1,7 +1,7 @@
 from flask import request
 from itertools import chain, product
-import mock
 import pytest
+from unittest import mock
 
 from dmtestutils.mocking import assert_args_and_return
 from dmtestutils.comparisons import AnySupersetOf

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3,7 +3,7 @@ import os
 import flask_session
 from flask import Flask
 from dmutils import session
-import mock
+from unittest import mock
 
 
 class TestSession:

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,8 +1,8 @@
 from collections import namedtuple
 
 import json
-import mock
 import pytest
+from unittest import mock
 
 from dmutils.status import get_disk_space_status, get_app_status, StatusError
 

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -6,12 +6,12 @@ from contextlib import contextmanager
 from itertools import chain, product
 import json
 import logging
-import mock
 from numbers import Number
 import random
 import re
 import sys
 import time
+from unittest import mock
 
 from flask import request
 import pytest

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,5 +1,5 @@
-import mock
 import pytest
+from unittest import mock
 from dmutils.user import user_has_role, User
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,8 +1,8 @@
 from flask import Response
 from werkzeug.exceptions import BadRequest
 
-import mock
 import pytest
+from unittest import mock
 
 from dmutils.views import DownloadFileView, SimpleDownloadFileView
 


### PR DESCRIPTION
mock is now part of the Python standard library, available as unittest.mock in Python 3.3 onwards. We only support Python 3.6+. Switch across to use the standard library version to reduce our maintenance burden.

https://mock.readthedocs.io/en/latest/