### PR TITLE
Update to latest v1 Flask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Digital marketplace utils changelog
 
-Records breaking changes from major version bumps
+Records breaking changes from major version bumps.
+
+## 59.0.0
+
+### Breaking changes
+
+Upgrade to Flask 1.1. This has some known
+[breaking changes](https://flask.palletsprojects.com/en/2.0.x/changes/#version-1-1-0).
 
 ## 58.0.0
 

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '58.1.0'
+__version__ = '58.2.0'

--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '58.2.0'
+__version__ = '59.0.0'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,8 +14,8 @@ blinker==1.4
     # via gds-metrics
 boto3==1.17.78
     # via
+    #   digitalmarketplace-utils
     #   moto
-    #   sanitized-package
 botocore==1.20.78
     # via
     #   boto3
@@ -32,11 +32,11 @@ chardet==4.0.0
 click==7.1.2
     # via flask
 contextlib2==0.6.0.post1
-    # via sanitized-package
+    # via digitalmarketplace-utils
 cryptography==3.4.7
     # via
+    #   digitalmarketplace-utils
     #   moto
-    #   sanitized-package
 defusedxml==0.7.1
     # via odfpy
 digitalmarketplace-test-utils==2.8.2
@@ -46,31 +46,31 @@ docopt==0.6.2
 flake8==3.9.2
     # via -r requirements-dev.in
 flask-gzip==0.2
-    # via sanitized-package
+    # via digitalmarketplace-utils
 flask-login==0.5.0
-    # via sanitized-package
+    # via digitalmarketplace-utils
 flask-session==0.3.2
-    # via sanitized-package
+    # via digitalmarketplace-utils
 flask-wtf==0.14.3
-    # via sanitized-package
-flask==1.0.4
+    # via digitalmarketplace-utils
+flask==1.1.4
     # via
+    #   digitalmarketplace-utils
     #   flask-gzip
     #   flask-login
     #   flask-session
     #   flask-wtf
     #   gds-metrics
-    #   sanitized-package
 fleep==1.0.1
-    # via sanitized-package
+    # via digitalmarketplace-utils
 freezegun==1.1.0
     # via -r requirements-dev.in
 future==0.18.2
     # via notifications-python-client
 gds-metrics==0.2.4
-    # via sanitized-package
+    # via digitalmarketplace-utils
 govuk-country-register==0.5.0
-    # via sanitized-package
+    # via digitalmarketplace-utils
 hypothesis==6.13.4
     # via -r requirements-dev.in
 idna==2.8
@@ -95,7 +95,7 @@ jmespath==0.10.0
     #   boto3
     #   botocore
 mailchimp3==3.0.14
-    # via sanitized-package
+    # via digitalmarketplace-utils
 markupsafe==1.1.1
     # via
     #   jinja2
@@ -116,9 +116,9 @@ mypy-extensions==0.4.3
 mypy==0.812
     # via -r requirements-dev.in
 notifications-python-client==5.7.1
-    # via sanitized-package
+    # via digitalmarketplace-utils
 odfpy==1.4.1
-    # via sanitized-package
+    # via digitalmarketplace-utils
 packaging==20.9
     # via pytest
 pluggy==0.13.1
@@ -145,23 +145,23 @@ python-dateutil==2.8.1
     #   freezegun
     #   moto
 python-json-logger==0.1.11
-    # via sanitized-package
+    # via digitalmarketplace-utils
 pytz==2021.1
     # via
+    #   digitalmarketplace-utils
     #   moto
-    #   sanitized-package
 redis==3.5.3
-    # via sanitized-package
+    # via digitalmarketplace-utils
 requests-mock==1.9.2
     # via -r requirements-dev.in
 requests==2.25.1
     # via
+    #   digitalmarketplace-utils
     #   mailchimp3
     #   moto
     #   notifications-python-client
     #   requests-mock
     #   responses
-    #   sanitized-package
 responses==0.13.3
     # via moto
 s3transfer==0.4.2
@@ -186,7 +186,7 @@ typing-extensions==3.7.4.3
     #   importlib-metadata
     #   mypy
 unicodecsv==0.14.1
-    # via sanitized-package
+    # via digitalmarketplace-utils
 urllib3==1.26.4
     # via
     #   botocore
@@ -196,9 +196,8 @@ werkzeug==1.0.1
     # via
     #   flask
     #   moto
-    #   sanitized-package
 workdays==1.4
-    # via sanitized-package
+    # via digitalmarketplace-utils
 wtforms==2.3.3
     # via flask-wtf
 xmltodict==0.12.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     include_package_data=True,
     install_requires=[
          'Flask-WTF>=0.14.2',
-         'Flask<1.1.0,>=1.0.2',
+         'Flask~=1.0',
          'Flask-gzip>=0.2',
          'Flask-Login>=0.2.11',
          'Flask-Session>=0.3.2',
@@ -43,7 +43,6 @@ setup(
          'python-json-logger>=0.1.11,<3.0.0',
          'pytz',
          'unicodecsv>=0.14.1',
-         'Werkzeug>=0.16,<1.1.0',
          'workdays>=1.4',
     ],
     python_requires="~=3.6",

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -120,7 +120,7 @@ def test_init_app_only_adds_handlers_to_defined_loggers(app):
         and isinstance(v.handlers[0], logging.StreamHandler)
     }
 
-    assert loggers == {'flask.app', 'dmutils', 'dmapiclient', 'flask_wtf.csrf', 'urllib3.util.retry'}
+    assert loggers == {'conftest', 'dmutils', 'dmapiclient', 'flask_wtf.csrf', 'urllib3.util.retry'}
 
 
 def test_urllib3_retry_logger_not_configured_for_search_api(app):

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -109,8 +109,8 @@ _messages_expected = OrderedDict((
                 'error': "{name}: {street} - {duration_process}s",
             },
             {
-                'success': AnyStringMatching(r"flask\.app\.foobar: (\{.*\}|eccles) - [0-9eE.-]+s"),
-                'error': AnyStringMatching(r"flask\.app\.foobar: (\{.*\}|eccles) - [0-9eE.-]+s"),
+                'success': AnyStringMatching(r"conftest\.foobar: (\{.*\}|eccles) - [0-9eE.-]+s"),
+                'error': AnyStringMatching(r"conftest\.foobar: (\{.*\}|eccles) - [0-9eE.-]+s"),
             },
         ),
     ),
@@ -375,7 +375,7 @@ def test_logged_duration_mock_logger(
                         if ("street" in str(message) and "street" not in (inject_context or {})) else ()
                     ),
                     AnySupersetOf({
-                        "name": "flask.app.foobar",
+                        "name": "conftest.foobar",
                         "levelname": logging.getLevelName(log_level),
                         "message": _messages_expected[message][1].get('error' if raise_exception else 'success'),
                         "duration_real": RestrictedAny(
@@ -445,7 +445,7 @@ def test_logged_duration_mock_logger(
                     "key": "D#",
                     "duration_real": RestrictedAny(lambda value: 0.48 < value < 0.6),
                     "duration_process": RestrictedAny(lambda value: isinstance(value, Number)),
-                    "name": "flask.app.foobar",
+                    "name": "conftest.foobar",
                 }),),
             ),
             (
@@ -483,7 +483,7 @@ def test_logged_duration_mock_logger(
                         ),
                         "duration_real": RestrictedAny(lambda value: 0.18 < value < 0.35),
                         "duration_process": RestrictedAny(lambda value: isinstance(value, Number)),
-                        "name": "flask.app.foobar",
+                        "name": "conftest.foobar",
                     }),
                 ),
             ),


### PR DESCRIPTION
https://trello.com/c/obh5gpQp/2250-update-to-flask-114

Stop pinning to v1.0.x, since v1.1.x was recently released. We're not ready to move to v2, but do want to be on the most recent v1.

Flask now controls the version of wekzeug, so we no longer need to pin wekzeug ourselves.