### PR TITLE
Replace mock with stdlib unittest.mock

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -3,7 +3,6 @@
 flake8
 freezegun
 hypothesis
-mock
 moto
 mypy
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,8 +14,8 @@ blinker==1.4
     # via gds-metrics
 boto3==1.17.78
     # via
+    #   digitalmarketplace-utils
     #   moto
-    #   sanitized-package
 botocore==1.20.78
     # via
     #   boto3
@@ -32,11 +32,11 @@ chardet==4.0.0
 click==7.1.2
     # via flask
 contextlib2==0.6.0.post1
-    # via sanitized-package
+    # via digitalmarketplace-utils
 cryptography==3.4.7
     # via
+    #   digitalmarketplace-utils
     #   moto
-    #   sanitized-package
 defusedxml==0.7.1
     # via odfpy
 digitalmarketplace-test-utils==2.8.2
@@ -46,31 +46,31 @@ docopt==0.6.2
 flake8==3.9.2
     # via -r requirements-dev.in
 flask-gzip==0.2
-    # via sanitized-package
+    # via digitalmarketplace-utils
 flask-login==0.5.0
-    # via sanitized-package
+    # via digitalmarketplace-utils
 flask-session==0.3.2
-    # via sanitized-package
+    # via digitalmarketplace-utils
 flask-wtf==0.14.3
-    # via sanitized-package
+    # via digitalmarketplace-utils
 flask==1.1.4
     # via
+    #   digitalmarketplace-utils
     #   flask-gzip
     #   flask-login
     #   flask-session
     #   flask-wtf
     #   gds-metrics
-    #   sanitized-package
 fleep==1.0.1
-    # via sanitized-package
+    # via digitalmarketplace-utils
 freezegun==1.1.0
     # via -r requirements-dev.in
 future==0.18.2
     # via notifications-python-client
 gds-metrics==0.2.4
-    # via sanitized-package
+    # via digitalmarketplace-utils
 govuk-country-register==0.5.0
-    # via sanitized-package
+    # via digitalmarketplace-utils
 hypothesis==6.13.4
     # via -r requirements-dev.in
 idna==2.8
@@ -95,7 +95,7 @@ jmespath==0.10.0
     #   boto3
     #   botocore
 mailchimp3==3.0.14
-    # via sanitized-package
+    # via digitalmarketplace-utils
 markupsafe==1.1.1
     # via
     #   jinja2
@@ -103,8 +103,6 @@ markupsafe==1.1.1
     #   wtforms
 mccabe==0.6.1
     # via flake8
-mock==3.0.5
-    # via -r requirements-dev.in
 monotonic==1.6
     # via notifications-python-client
 more-itertools==8.7.0
@@ -116,9 +114,9 @@ mypy-extensions==0.4.3
 mypy==0.812
     # via -r requirements-dev.in
 notifications-python-client==5.7.1
-    # via sanitized-package
+    # via digitalmarketplace-utils
 odfpy==1.4.1
-    # via sanitized-package
+    # via digitalmarketplace-utils
 packaging==20.9
     # via pytest
 pluggy==0.13.1
@@ -145,30 +143,29 @@ python-dateutil==2.8.1
     #   freezegun
     #   moto
 python-json-logger==0.1.11
-    # via sanitized-package
+    # via digitalmarketplace-utils
 pytz==2021.1
     # via
+    #   digitalmarketplace-utils
     #   moto
-    #   sanitized-package
 redis==3.5.3
-    # via sanitized-package
+    # via digitalmarketplace-utils
 requests-mock==1.9.2
     # via -r requirements-dev.in
 requests==2.25.1
     # via
+    #   digitalmarketplace-utils
     #   mailchimp3
     #   moto
     #   notifications-python-client
     #   requests-mock
     #   responses
-    #   sanitized-package
 responses==0.13.3
     # via moto
 s3transfer==0.4.2
     # via boto3
 six==1.15.0
     # via
-    #   mock
     #   moto
     #   python-dateutil
     #   requests-mock
@@ -186,7 +183,7 @@ typing-extensions==3.7.4.3
     #   importlib-metadata
     #   mypy
 unicodecsv==0.14.1
-    # via sanitized-package
+    # via digitalmarketplace-utils
 urllib3==1.26.5
     # via
     #   botocore
@@ -197,7 +194,7 @@ werkzeug==1.0.1
     #   flask
     #   moto
 workdays==1.4
-    # via sanitized-package
+    # via digitalmarketplace-utils
 wtforms==2.3.3
     # via flask-wtf
 xmltodict==0.12.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from flask import Flask

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tests for the Digital Marketplace MailChimp integration."""
 import logging
-import mock
+from unittest import mock
 import pytest
 import types
 

--- a/tests/email/test_dm_notify.py
+++ b/tests/email/test_dm_notify.py
@@ -2,7 +2,7 @@
 """Tests for the Digital Marketplace Notify client."""
 import json
 
-import mock
+from unittest import mock
 import os
 from collections import OrderedDict
 from itertools import product

--- a/tests/email/test_tokens.py
+++ b/tests/email/test_tokens.py
@@ -2,7 +2,7 @@
 import base64
 from datetime import datetime
 
-import mock
+from unittest import mock
 import pytest
 from cryptography import fernet
 from freezegun import freeze_time

--- a/tests/email/test_user_account_email.py
+++ b/tests/email/test_user_account_email.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from flask import session, current_app
 

--- a/tests/forms/test_dmwidgets.py
+++ b/tests/forms/test_dmwidgets.py
@@ -1,5 +1,5 @@
 
-import mock
+from unittest import mock
 import pytest
 
 import dmutils.forms.fields

--- a/tests/forms/test_validators.py
+++ b/tests/forms/test_validators.py
@@ -1,7 +1,7 @@
 from datetime import date
 
 import pytest
-import mock
+from unittest import mock
 
 from wtforms.validators import StopValidation, ValidationError
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from io import BytesIO
 
-import mock
+from unittest import mock
 from testfixtures import logcapture
 from dmtestutils.comparisons import AnyStringMatching
 

--- a/tests/test_asset_fingerprint.py
+++ b/tests/test_asset_fingerprint.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-import mock
+from unittest import mock
 
 from dmutils.asset_fingerprint import AssetFingerprinter
 

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 import datetime
-import mock
+from unittest import mock
 
 import dmutils.dates as dates_package
 

--- a/tests/test_direct_plus_client.py
+++ b/tests/test_direct_plus_client.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 import requests_mock
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-import mock
+from unittest import mock
 import pytest
 
 from botocore.exceptions import ClientError

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -18,21 +18,17 @@ from dmutils.external import external as external_blueprint
 
 @pytest.mark.parametrize('cookie_probe_expect_present', (True, False))
 @pytest.mark.parametrize('user_session', (True, False))
-@mock.patch('dmutils.errors.frontend.current_app')
-def test_csrf_handler_redirects_to_login(current_app, user_session, app, cookie_probe_expect_present):
-    current_app.config = {
-        "DM_COOKIE_PROBE_COOKIE_NAME": "foo",
-        "DM_COOKIE_PROBE_COOKIE_VALUE": "bar",
-        "DM_COOKIE_PROBE_EXPECT_PRESENT": cookie_probe_expect_present,
-    }
-
+def test_csrf_handler_redirects_to_login(user_session, app, cookie_probe_expect_present):
     with app.test_request_context('/', environ_base={
-        "HTTP_COOKIE": dump_cookie(
-            current_app.config["DM_COOKIE_PROBE_COOKIE_NAME"],
-            current_app.config["DM_COOKIE_PROBE_COOKIE_VALUE"],
-        ),
+        "HTTP_COOKIE": dump_cookie("foo", "bar"),
     }):
-        app.config['WTF_CSRF_ENABLED'] = True
+        app.logger = mock.MagicMock()
+        app.config.update({
+            "DM_COOKIE_PROBE_COOKIE_NAME": "foo",
+            "DM_COOKIE_PROBE_COOKIE_VALUE": "bar",
+            "DM_COOKIE_PROBE_EXPECT_PRESENT": cookie_probe_expect_present,
+            "WTF_CSRF_ENABLED": True,
+        })
         app.register_blueprint(external_blueprint)
 
         if user_session:
@@ -45,11 +41,11 @@ def test_csrf_handler_redirects_to_login(current_app, user_session, app, cookie_
         assert response.location == '/user/login?next=%2F'
 
         if user_session:
-            assert current_app.logger.info.call_args_list == [
+            assert app.logger.info.call_args_list == [
                 mock.call('csrf.invalid_token: Aborting request, user_id: {user_id}', extra={'user_id': 1234})
             ]
         else:
-            assert current_app.logger.info.call_args_list == [
+            assert app.logger.info.call_args_list == [
                 mock.call('csrf.session_expired: Redirecting user to log in page')
             ]
 
@@ -59,20 +55,19 @@ def test_csrf_handler_redirects_to_login(current_app, user_session, app, cookie_
     ("foo", "blah",),
     None,
 ))
-@mock.patch('dmutils.cookie_probe.current_app')
 @mock.patch('dmutils.errors.frontend.render_template')
-def test_cookie_probe_incorrect(render_template, current_app, app, cookie_kv):
-    current_app.config = {
-        "DM_COOKIE_PROBE_COOKIE_NAME": "foo",
-        "DM_COOKIE_PROBE_COOKIE_VALUE": "bar",
-        "DM_COOKIE_PROBE_EXPECT_PRESENT": True,
-    }
+def test_cookie_probe_incorrect(render_template, app, cookie_kv):
     render_template.return_value = "<html>Oh dear</html>"
 
     with app.test_request_context('/', environ_base=cookie_kv and {
         "HTTP_COOKIE": dump_cookie(*cookie_kv),
     }):
-        app.config['WTF_CSRF_ENABLED'] = True
+        app.config.update({
+            "DM_COOKIE_PROBE_COOKIE_NAME": "foo",
+            "DM_COOKIE_PROBE_COOKIE_VALUE": "bar",
+            "DM_COOKIE_PROBE_EXPECT_PRESENT": True,
+            "WTF_CSRF_ENABLED": True,
+        })
         app.register_blueprint(external_blueprint)
 
         response, status_code = csrf_handler(CSRFError())

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,5 +1,5 @@
 import json
-import mock
+from unittest import mock
 import pytest
 
 from flask import session

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
 import pytest
 
 from flask import Markup

--- a/tests/test_flask_init.py
+++ b/tests/test_flask_init.py
@@ -2,7 +2,7 @@ from flask import Flask
 
 from dmutils.flask_init import pluralize, init_app
 import dmutils.session
-import mock
+from unittest import mock
 import pytest
 
 

--- a/tests/test_jinja_environment.py
+++ b/tests/test_jinja_environment.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from dmutils.jinja2_environment import DMSandboxedEnvironment
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -5,7 +5,7 @@ import os.path
 import tempfile
 import time
 
-import mock
+from unittest import mock
 
 from flask import request
 import pytest

--- a/tests/test_ods.py
+++ b/tests/test_ods.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import functools
 
 import dmutils.ods as ods

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -1,6 +1,6 @@
 from flask import request
 from itertools import chain, product
-import mock
+from unittest import mock
 import pytest
 
 from dmtestutils.mocking import assert_args_and_return

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3,7 +3,7 @@ import os
 import flask_session
 from flask import Flask
 from dmutils import session
-import mock
+from unittest import mock
 
 
 class TestSession:

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 
 import json
-import mock
+from unittest import mock
 import pytest
 
 from dmutils.status import get_disk_space_status, get_app_status, StatusError

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from itertools import chain, product
 import json
 import logging
-import mock
+from unittest import mock
 from numbers import Number
 import random
 import re

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from dmutils.user import user_has_role, User
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,7 @@
 from flask import Response
 from werkzeug.exceptions import BadRequest
 
-import mock
+from unittest import mock
 import pytest
 
 from dmutils.views import DownloadFileView, SimpleDownloadFileView


### PR DESCRIPTION
https://trello.com/c/TIWfCbjY/2232-upgrade-mock-in-digitalmarketplace-utils

Mock is now part of the standard library. Start using the version in the standard library. One fewer dependency for us to manage.

Also stop mocking `current_app` so that it still works with the version of mock in Python 3.8. This is because mock now tries to probe for asynchronicity, which causes errors because there is no application context at that time: testing-cabal/mock@ad2b38d

Fixes the errors we encountered when trying to upgrade mock: https://github.com/alphagov/digitalmarketplace-utils/pull/621#issuecomment-840494969