### PR TITLE
Add helper method to support assets rewrite performed by multiple apps

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '59.0.0'
+__version__ = '59.1.0'

--- a/dmutils/urls.py
+++ b/dmutils/urls.py
@@ -4,6 +4,21 @@ import re
 from werkzeug.routing import BaseConverter, ValidationError
 
 
+def rewrite_supplier_asset_path(url, assets_url):
+    """
+    Supplier frontend has an authenticated endpoint for declaration documents: frameworks.download_declaration_document
+
+    Sometimes other apps need to be able to show declaration documents to users who are not the supplier who uploaded
+    the document. This function allows them to convert the supplier frontend URL into an assets URL.
+
+    You must ensure that you are only exposing this document to authorised users.
+    """
+    parts = url.split('/suppliers/assets')
+    if len(parts) == 2:
+        return assets_url + parts[1]
+    return url
+
+
 class SafePurePathConverter(BaseConverter):
     """
         Like the default :class:`PathConverter`, but it converts

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -3,7 +3,7 @@ from pathlib import PurePath
 from flask import url_for
 import pytest
 
-from dmutils.urls import SafePurePathConverter
+from dmutils.urls import SafePurePathConverter, rewrite_supplier_asset_path
 
 
 @pytest.mark.parametrize("route_pattern,request_path", tuple(
@@ -84,3 +84,17 @@ def test_safepurepath_url_reversing(app, arg_value, expected_url):
 
     with app.app_context():
         assert url_for("some_view", some_path=arg_value) == expected_url
+
+
+@pytest.mark.parametrize("input_url,expected_url", [
+    (
+        'https://gov.uk/suppliers/assets/digital-outcomes-and-specialists-5/documents/modern-slavery-statement.pdf',
+        'https://assets.gov.uk/digital-outcomes-and-specialists-5/documents/modern-slavery-statement.pdf'
+    ),
+    (
+        'https://assets.gov.uk/digital-outcomes-and-specialists-5/documents/modern-slavery-statement.pdf',
+        'https://assets.gov.uk/digital-outcomes-and-specialists-5/documents/modern-slavery-statement.pdf'
+    ),
+])
+def test_rewrite_supplier_asset_path(input_url, expected_url):
+    assert rewrite_supplier_asset_path(input_url, 'https://assets.gov.uk') == expected_url


### PR DESCRIPTION
https://trello.com/c/5E22SHaQ/988-ccs-sourcing-admins-cant-view-suppliers-modern-slavery-statements

Supplier frontend has an authenticated endpoint for declaration documents: frameworks.download_declaration_document

Sometimes other apps need to be able to show declaration documents to users who are not the supplier who uploaded
the document. This function allows them to convert the supplier frontend URL into an assets URL.

You must ensure that you are only exposing this document to authorised users.

We're going to use this to give admins access. We can then update buyer frontend to use this (instead of hard-coding URLs)