### PR TITLE
Stop using dependabot for development dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
     interval: weekly
     time: "03:00"
   open-pull-requests-limit: 10
+  allow:
+    - dependency-type: production


### PR DESCRIPTION
This matches how we use dependabot for the frontend apps. Currently, the bulk of dependabot PRs for this repo are for development dependencies (https://github.com/alphagov/digitalmarketplace-utils/pulls). I don't think keeping up to date with every patch version increment is a good use of our time and effort.