### PR TITLE
Remove Python 2 back-compatibility

### DIFF
--- a/dmutils/config.py
+++ b/dmutils/config.py
@@ -1,7 +1,5 @@
 import os
 
-from flask._compat import string_types
-
 
 def init_app(app):
     for key, value in app.config.items():
@@ -45,7 +43,7 @@ def convert_to_boolean(value):
     >>> for value in ['falsey', 'other', True, 0]:
     ...   assert convert_to_boolean(value) == value
     """
-    if isinstance(value, string_types):
+    if isinstance(value, str):
         if value.lower() in ['t', 'true', 'on', 'yes', '1']:
             return True
         elif value.lower() in ['f', 'false', 'off', 'no', '0']:


### PR DESCRIPTION
We no longer support Python 2, and it will cause problems for the Flask v2 upgrade.